### PR TITLE
Fix README documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,14 +81,14 @@ python main.py export-church-teams
 python main.py export-church-teams --church-code ABC
 ```
 
-For detailed setup and usage instructions, see the [Installation Guide](INSTALLATION.md) and [Usage Guide](USAGE.md).
+For detailed setup and usage instructions, see the [Installation Guide](docs/INSTALLATION.md) and [Usage Guide](docs/USAGE.md).
 
 ## Documentation
 
-- [Installation Guide](INSTALLATION.md)
+- [Installation Guide](docs/INSTALLATION.md)
 - [Architecture Overview](ARCHITECTURE.md)
-- [Usage Guide](USAGE.md)
-- [Troubleshooting](TROUBLESHOOTING.md)
+- [Usage Guide](docs/USAGE.md)
+- [Troubleshooting](docs/TROUBLESHOOTING.md)
 - [Contributing](CONTRIBUTING.md)
 
 ## Project Status


### PR DESCRIPTION
## Summary
- fix README.md links to docs directory

## Testing
- `pip install -r middleware/requirements.txt`
- `pytest -q` *(fails: ModuleNotFoundError and configuration errors)*

------
https://chatgpt.com/codex/tasks/task_e_68425a3190048330a55786170f64b8fe