### PR TITLE
Fix config test default

### DIFF
--- a/middleware/config.py
+++ b/middleware/config.py
@@ -225,7 +225,13 @@ class Config:
     CHROME_PROFILE_DIR = os.getenv("CHROME_PROFILE_DIR", "")
     
     # Application settings
-    APP_ENV = os.getenv("APP_ENV", "development")
+    # Default APP_ENV to "test" when running under pytest to avoid failing
+    # configuration validation during imports. This allows the modules to be
+    # imported without a populated .env when running the unit tests.
+    APP_ENV = os.getenv(
+        "APP_ENV",
+        "test" if "pytest" in sys.argv[0] or "PYTEST_CURRENT_TEST" in os.environ else "development",
+    )
     DEBUG = os.getenv("DEBUG", "False").lower() == "true"
     TOKEN_EXPIRY_DAYS = int(os.getenv("TOKEN_EXPIRY_DAYS", 30))
     CHURCH_EXCEL_FILE = DATA_DIR / os.getenv("CHURCH_EXCEL_FILE", "Church Application Form.xlsx")


### PR DESCRIPTION
## Summary
- avoid failing config validation when running tests by defaulting APP_ENV

## Testing
- `PYTHONPATH=middleware pytest middleware/tests/test_chmeetings_connector.py::test_chm_connector_init -q`
- `PYTHONPATH=middleware pytest -q` *(fails: test_get_person and others)*

------
https://chatgpt.com/codex/tasks/task_e_6842595551fc83308d4140c6aaaa0b9c