### PR TITLE
Fix person lookup in connector test

### DIFF
--- a/middleware/tests/test_chmeetings_connector.py
+++ b/middleware/tests/test_chmeetings_connector.py
@@ -70,7 +70,8 @@ def test_get_people(chm_connector, mocker, mock_chm_people_data):
 
 def test_get_person(chm_connector, mocker, mock_chm_people_data):
     live_test = os.getenv("LIVE_TEST", "false").strip().lower() == "true"
-    person_id = "3471242"  # Kobe Bryant - Keep as string
+    # Use an ID that exists in mock_chm_people_data.json
+    person_id = "3505203"  # Jerry Phan - Keep as string
 ## NEW CODE:
     if live_test:
         start = time.time()
@@ -105,7 +106,9 @@ def test_get_person(chm_connector, mocker, mock_chm_people_data):
         with pytest.MonkeyPatch.context() as mp:
             mock_response = mocker.Mock()
             mock_response.status_code = 200
-            person_data = next(p for p in mock_chm_people_data if str(p["id"]) == person_id)
+            # Use next with a default value to avoid StopIteration if the ID is missing
+            person_data = next((p for p in mock_chm_people_data if str(p["id"]) == person_id), None)
+            assert person_data is not None, "Mock data should contain the person"
             mock_response.json.return_value = person_data
             mp.setattr("requests.Session.get", lambda *args, **kwargs: mock_response)
             person = chm_connector.get_person(person_id)


### PR DESCRIPTION
## Summary
- update the mocked person id in `test_get_person`
- use `next` with default value to avoid `StopIteration`

## Testing
- `PYTHONPATH=middleware pytest middleware/tests/test_chmeetings_connector.py::test_get_person -q`
- `PYTHONPATH=middleware pytest -q` *(fails: summer_2025.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6842efbe95e88330b696956fdde807c3