### PR TITLE
Session: venue estimator, orphan audit, sports registered, gender fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## Unreleased
 
 ### New Features
+- Added `Sports Registered` column to the `Contacts-Status` tab in church-team Excel exports — closes [#82](https://github.com/i12know/vaysf/issues/82)
+  - Appears immediately before `Athlete Fee`
+  - Lists all sports/events for each participant as a comma-separated, sorted string (e.g. `Badminton Women Doubles, Basketball`)
+  - Matched by `Participant ID (WP)` with `ChMeetings ID` as fallback; blank when the person has no roster entries
+  - Duplicates within the same participant are suppressed
 - Added `python main.py inspect-person --chm-id <ID>` for read-only ChMeetings person inspection with WordPress fallback context
   - Prints the raw ChMeetings record when the person still exists
   - Reports cleanly when ChMeetings returns `404 Not Found`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,17 @@
   - Audit summary line now includes a `Removed: N/M` count when removal is active
   - Run without the flag first to review `data/team_group_orphan_audit.xlsx`, then re-run with `--remove-orphans` to clean up
   - Combines cleanly with `--church-code` to target a single church: `python main.py audit-team-groups --church-code GAC --remove-orphans`
-- Added `Venue-Capacity` tab to the consolidated ALL church-team Excel export — closes [#83](https://github.com/i12know/vaysf/issues/83)
-  - Estimates court-time needed for Basketball, Volleyball Men, and Volleyball Women using current roster data
-  - Counts each church as one "Estimating Team" when its roster meets the minimum team size; approval-agnostic
-  - Minimum team sizes are sourced from the `summer_2026.json` validation rules (with `COURT_ESTIMATE_MIN_TEAM_SIZE` as fallback)
-  - Per-event slot math: `pool_slots = ceil(teams * pool_games_per_team / 2)`, `playoff_slots = max(playoff_teams - 1, 0)`, plus optional third-place game
-  - Tunable via `COURT_ESTIMATE_*` constants in `middleware/config.py` (default 2 pool games per team, 60 min/game, third-place off)
-  - Tab appears only in the consolidated ALL export; per-church exports omit it (Sports Fest staff use this for diocese-wide planning)
-  - Snapshot disclaimer in row 1 makes it clear that team counts move with each export run
+- Expanded `Venue-Capacity` tab to cover all Sports Fest events — closes [#83](https://github.com/i12know/vaysf/issues/83)
+  - **Team sports** (Basketball, Volleyball Men/Women, Soccer, Bible Challenge): one row per event; a church counts as an "Estimating" team when its roster meets the minimum team size; "Potential" = estimating + partial (all churches with ≥ 1 entry)
+  - **Racquet sports** (Badminton, Pickleball, Pickleball 35+, Table Tennis, Table Tennis 35+, Tennis): one row per sport; "Estimating" = complete pairs `floor(doubles / 2)` + singles; "Potential" = all individual registrations including unpaired
+  - Added `SPORT_TYPE["SOCCER"] = "Soccer - Coed Exhibition"` and added Soccer to `SPORT_BY_CATEGORY["TEAM"]`
+  - Added `COURT_ESTIMATE_RACQUET_EVENTS` list in `config.py`
+  - Per-sport minutes constants in `config.py` (`COURT_ESTIMATE_MINUTES_BASKETBALL = 60`, `_VOLLEYBALL = 60`, `_SOCCER = 60`, `_BIBLE_CHALLENGE = 45`, `_BADMINTON = 25`, `_PICKLEBALL = 20`, `_PICKLEBALL_35 = 20`, `_TABLE_TENNIS = 20`, `_TABLE_TENNIS_35 = 20`, `_TENNIS = 30`) — tune these in `config.py` before each season
+  - `COURT_ESTIMATE_MINUTES_PER_GAME` lookup dict maps every sport label to its constant
+  - `_compute_court_slots` now accepts a `minutes_per_game` parameter; per-sport minutes used automatically
+  - Column headers renamed to `Potential Teams/Entries` and `Estimating Teams/Entries` to cover both team and racquet semantics
+  - Minimum team sizes are sourced from the `summer_2026.json` validation rules (with `COURT_ESTIMATE_MIN_TEAM_SIZE` as fallback); Soccer=4, Bible Challenge=3 added as fallbacks
+  - Tab appears only in the consolidated ALL export; per-church exports omit it
 - Fixed case-sensitive bug in `sync/participants.py` that caused team-sport `sport_gender` to always be written as `Mixed` (e.g. `Basketball Mixed Team` instead of `Basketball Men Team`)
   - Comparisons like `GENDER["MEN"] in param.upper()` were checking `"Men" in "MEN TEAM"` and silently failing because `in` is case-sensitive
   - Roster sync now compares case-insensitively in both the full-label branch and a new bare-name lookup branch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### New Features
 - Added `--remove-orphans` flag to `python main.py audit-team-groups`
   - After identifying each orphaned Team-group membership (person_id returns 404 from ChMeetings), the membership is deleted from the group via `DELETE /api/v1/groups/{group_id}/memberships/{person_id}`
-  - Audit summary line now includes a `Removed: N/M` count when removal is active
+  - Audit summary line now includes a `Removed: N/M (stuck/API-undeleteable: K)` count when removal is active; "stuck" records are ones where DELETE also returns 404 due to a ChMeetings platform bug (filed as ChMeetings support ticket **#20188** — follow up if stuck count remains non-zero after resolution)
   - Run without the flag first to review `data/team_group_orphan_audit.xlsx`, then re-run with `--remove-orphans` to clean up
   - Combines cleanly with `--church-code` to target a single church: `python main.py audit-team-groups --church-code GAC --remove-orphans`
 - Expanded `Venue-Capacity` tab to cover all Sports Fest events — closes [#83](https://github.com/i12know/vaysf/issues/83)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@
 ## Unreleased
 
 ### New Features
+- Added `Venue-Capacity` tab to the consolidated ALL church-team Excel export — closes [#83](https://github.com/i12know/vaysf/issues/83)
+  - Estimates court-time needed for Basketball, Volleyball Men, and Volleyball Women using current roster data
+  - Counts each church as one "Estimating Team" when its roster meets the minimum team size; approval-agnostic
+  - Minimum team sizes are sourced from the `summer_2026.json` validation rules (with `COURT_ESTIMATE_MIN_TEAM_SIZE` as fallback)
+  - Per-event slot math: `pool_slots = ceil(teams * pool_games_per_team / 2)`, `playoff_slots = max(playoff_teams - 1, 0)`, plus optional third-place game
+  - Tunable via `COURT_ESTIMATE_*` constants in `middleware/config.py` (default 2 pool games per team, 60 min/game, third-place off)
+  - Tab appears only in the consolidated ALL export; per-church exports omit it (Sports Fest staff use this for diocese-wide planning)
+  - Snapshot disclaimer in row 1 makes it clear that team counts move with each export run
+- Fixed case-sensitive bug in `sync/participants.py` that caused team-sport `sport_gender` to always be written as `Mixed` (e.g. `Basketball Mixed Team` instead of `Basketball Men Team`)
+  - Comparisons like `GENDER["MEN"] in param.upper()` were checking `"Men" in "MEN TEAM"` and silently failing because `in` is case-sensitive
+  - Roster sync now compares case-insensitively in both the full-label branch and a new bare-name lookup branch
+  - Added a bare-name fallback that recovers gender/format by looking up the canonical `SPORT_TYPE` entry, so older registrations stored as `"Basketball"` (without the `- Men Team` suffix) heal on the next sync without manual DB edits
+  - Format heuristic flipped from "contains Team" to "not contains Singles" so `"Coed Exhibition"` and other non-standard suffixes still map to Team
 - Added `Sports Registered` column to the `Contacts-Status` tab in church-team Excel exports — closes [#82](https://github.com/i12know/vaysf/issues/82)
   - Appears immediately before `Athlete Fee`
   - Lists all sports/events for each participant as a comma-separated, sorted string (e.g. `Badminton Women Doubles, Basketball`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## Unreleased
 
 ### New Features
+- Added `--remove-orphans` flag to `python main.py audit-team-groups`
+  - After identifying each orphaned Team-group membership (person_id returns 404 from ChMeetings), the membership is deleted from the group via `DELETE /api/v1/groups/{group_id}/memberships/{person_id}`
+  - Audit summary line now includes a `Removed: N/M` count when removal is active
+  - Run without the flag first to review `data/team_group_orphan_audit.xlsx`, then re-run with `--remove-orphans` to clean up
+  - Combines cleanly with `--church-code` to target a single church: `python main.py audit-team-groups --church-code GAC --remove-orphans`
 - Added `Venue-Capacity` tab to the consolidated ALL church-team Excel export — closes [#83](https://github.com/i12know/vaysf/issues/83)
   - Estimates court-time needed for Basketball, Volleyball Men, and Volleyball Women using current roster data
   - Counts each church as one "Estimating Team" when its roster meets the minimum team size; approval-agnostic

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -536,9 +536,9 @@ python main.py sync --type approvals
 
 ### Auditing Team Groups for Orphaned Members
 
-Over time, ChMeetings group memberships can contain person IDs that no longer resolve to a live person record (deleted or merged accounts). The `audit-team-groups` command identifies these orphaned IDs so you can clean them up directly in ChMeetings.
+Over time, ChMeetings group memberships can contain person IDs that no longer resolve to a live person record (deleted or merged accounts). The `audit-team-groups` command identifies these orphaned IDs so you can clean them up.
 
-**Audit all Team groups:**
+**Audit all Team groups (review only — no changes):**
 
 ```bash
 python main.py audit-team-groups
@@ -550,9 +550,23 @@ python main.py audit-team-groups
 python main.py audit-team-groups --church-code GAC
 ```
 
-The command writes an audit workbook to `data/team_group_orphan_audit.xlsx` listing every orphaned ID, the group it was found in, and the church code.
+The command writes an audit workbook to `data/team_group_orphan_audit.xlsx` listing every orphaned ID, the group it was found in, and lookup status.
 
-> During `export-church-teams`, orphaned IDs are silently skipped and a summary warning is logged per church (e.g., `Team GAC: skipped 10 orphaned member IDs — [...]`). Run `audit-team-groups` after seeing those warnings to get the full list and clean up.
+**Remove orphaned memberships from ChMeetings:**
+
+```bash
+python main.py audit-team-groups --remove-orphans
+```
+
+Run the plain audit first to review the workbook, then re-run with `--remove-orphans` to delete the stale memberships. The flag combines with `--church-code` for targeted cleanup:
+
+```bash
+python main.py audit-team-groups --church-code GAC --remove-orphans
+```
+
+The summary log will confirm how many were removed (e.g., `Removed: 21/21 orphaned membership(s).`). After cleanup, future `export-church-teams` runs will no longer log 404 warnings for those IDs.
+
+> During `export-church-teams`, orphaned IDs are silently skipped and a summary warning is logged per church (e.g., `Team GAC: skipped 10 orphaned member IDs — [...]`). Run `audit-team-groups` after seeing those warnings to get the full list, then use `--remove-orphans` to clean up.
 
 ### Inspecting a Single Person
 

--- a/middleware/church_teams_export.py
+++ b/middleware/church_teams_export.py
@@ -20,9 +20,18 @@ from config import (
     ATHLETE_FEE_OTHER_EVENTS_ONLY,
     ATHLETE_FEE_LATE,
     REGISTRATION_DEADLINE,
+    SPORT_TYPE,
+    COURT_ESTIMATE_EVENTS,
+    COURT_ESTIMATE_DEFAULT_POOL_GAMES_PER_TEAM,
+    COURT_ESTIMATE_DEFAULT_MINUTES_PER_GAME,
+    COURT_ESTIMATE_INCLUDE_THIRD_PLACE_GAME,
+    COURT_ESTIMATE_MIN_TEAM_SIZE,
+    COURT_ESTIMATE_PLAYOFF_RULES,
 )
 from chmeetings.backend_connector import ChMeetingsConnector
 from wordpress.frontend_connector import WordPressConnector
+from validation.models import RulesManager
+from math import ceil
 
 class ChurchTeamsExporter: # MODIFIED CLASS NAME
     """
@@ -968,10 +977,11 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
             
             all_filename = f"Church_Team_Status_ALL_{datetime.now().strftime('%Y-%m-%d')}.xlsx"
             self._write_excel_report(output_dir / all_filename,
-                                     summary_data_list, 
-                                     all_contacts_data, 
+                                     summary_data_list,
+                                     all_contacts_data,
                                      all_rosters_data,
-                                     all_validation_data)   
+                                     all_validation_data,
+                                     include_venue_capacity=True)
 
         # Handle force resend options
         if force_resend_pending or force_resend_validated1 or force_resend_validated2:
@@ -984,11 +994,122 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
         logger.info("Report generation process finished.")
         return True
 
+    @staticmethod
+    def _decompose_event_name(event_name: str) -> Tuple[str, str, str]:
+        """Split a canonical event name like 'Basketball - Men Team' into
+        (sport_type, sport_gender, sport_format) using the same casing the
+        roster rows store after sync."""
+        parts = event_name.split(" - ", 1)
+        sport_type = parts[0].strip()
+        if len(parts) < 2:
+            return sport_type, "", "Team"
+        suffix = parts[1].upper()
+        if "WOMEN" in suffix:
+            gender = "Women"
+        elif "MEN" in suffix:
+            gender = "Men"
+        elif "MIXED" in suffix or "COED" in suffix:
+            gender = "Mixed"
+        else:
+            gender = ""
+        sport_format = "Singles" if "SINGLES" in suffix else "Team"
+        return sport_type, gender, sport_format
+
+    def _get_min_team_size(self, event_name: str) -> int:
+        """Look up minimum team size from the validation ruleset; fall back
+        to COURT_ESTIMATE_MIN_TEAM_SIZE if the JSON rule is absent."""
+        if not hasattr(self, "_rules_manager_cache"):
+            try:
+                self._rules_manager_cache = RulesManager(collection="SUMMER_2026")
+            except Exception as e:
+                logger.warning(f"Could not load validation rules for venue estimate: {e}")
+                self._rules_manager_cache = None
+        if self._rules_manager_cache is not None:
+            for rule in self._rules_manager_cache.get_rules_for_sport(event_name):
+                if rule.get("rule_type") == "team_size" and rule.get("category") == "min":
+                    try:
+                        return int(rule.get("value"))
+                    except (TypeError, ValueError):
+                        pass
+        return int(COURT_ESTIMATE_MIN_TEAM_SIZE.get(event_name, 0))
+
+    def _count_estimating_teams(self, roster_rows: List[Dict[str, Any]],
+                                 event_name: str, min_team_size: int) -> int:
+        """Count churches with at least min_team_size roster entries for this event.
+        Approval-agnostic — every roster entry counts."""
+        if min_team_size <= 0:
+            return 0
+        target_type, target_gender, _ = self._decompose_event_name(event_name)
+        counts_by_church: Dict[str, int] = {}
+        for r in roster_rows:
+            r_type = str(r.get("sport_type") or "").strip()
+            r_gender = str(r.get("sport_gender") or "").strip()
+            if r_type.casefold() != target_type.casefold():
+                continue
+            if target_gender and r_gender.casefold() != target_gender.casefold():
+                continue
+            church = str(r.get("Church Team") or "").strip()
+            if not church:
+                continue
+            counts_by_church[church] = counts_by_church.get(church, 0) + 1
+        return sum(1 for n in counts_by_church.values() if n >= min_team_size)
+
+    @staticmethod
+    def _get_playoff_teams(n_teams: int) -> int:
+        for rule in COURT_ESTIMATE_PLAYOFF_RULES:
+            if rule["min_teams"] <= n_teams <= rule["max_teams"]:
+                return int(rule["playoff_teams"])
+        return 0
+
+    def _compute_court_slots(self, n_teams: int) -> Dict[str, Any]:
+        pool_games_per_team = COURT_ESTIMATE_DEFAULT_POOL_GAMES_PER_TEAM
+        minutes_per_game = COURT_ESTIMATE_DEFAULT_MINUTES_PER_GAME
+        include_third = COURT_ESTIMATE_INCLUDE_THIRD_PLACE_GAME
+
+        pool_slots = ceil((n_teams * pool_games_per_team) / 2) if n_teams > 0 else 0
+        playoff_teams = self._get_playoff_teams(n_teams)
+        playoff_slots = max(playoff_teams - 1, 0)
+        third_place_slots = 1 if include_third and playoff_teams >= 4 else 0
+        total_slots = pool_slots + playoff_slots + third_place_slots
+        return {
+            "pool_games_per_team": pool_games_per_team,
+            "minutes_per_game": minutes_per_game,
+            "pool_slots": pool_slots,
+            "playoff_teams": playoff_teams,
+            "playoff_slots": playoff_slots,
+            "include_third_place": include_third,
+            "third_place_slots": third_place_slots,
+            "total_slots": total_slots,
+            "court_hours": round(total_slots * minutes_per_game / 60, 2),
+        }
+
+    def _build_venue_capacity_rows(self, roster_rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        rows = []
+        for event_name in COURT_ESTIMATE_EVENTS:
+            min_team_size = self._get_min_team_size(event_name)
+            n_teams = self._count_estimating_teams(roster_rows, event_name, min_team_size)
+            s = self._compute_court_slots(n_teams)
+            rows.append({
+                "Event": event_name,
+                "Estimating Teams": n_teams,
+                "Pool Games Per Team": s["pool_games_per_team"],
+                "Minutes Per Game": s["minutes_per_game"],
+                "Pool Slots": s["pool_slots"],
+                "Playoff Teams": s["playoff_teams"],
+                "Playoff Slots": s["playoff_slots"],
+                "Third Place?": "Yes" if s["include_third_place"] else "No",
+                "Third Place Slots": s["third_place_slots"],
+                "Total Court Slots": s["total_slots"],
+                "Estimated Court Hours": s["court_hours"],
+            })
+        return rows
+
     def _write_excel_report(self, filepath: Path,
                             summary_rows: List[Dict[str, Any]],
                             contacts_rows: List[Dict[str, Any]],
                             roster_rows: List[Dict[str, Any]],
-                            validation_rows: List[Dict[str, Any]]):
+                            validation_rows: List[Dict[str, Any]],
+                            include_venue_capacity: bool = False):
         """Writes the collected data to an Excel file with specified tabs and formatting."""
         logger.info(f"Writing Excel report to: {filepath}")
         try:
@@ -1118,6 +1239,27 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
                     )
                 df_validation.to_excel(writer, sheet_name="Validation-Issues", index=False)
                 logger.debug(f"Validation-Issues tab: {len(df_validation)} rows.")
+
+                # Venue-Capacity Tab (only on the consolidated ALL export — see Issue #83)
+                if include_venue_capacity:
+                    venue_rows = self._build_venue_capacity_rows(roster_rows)
+                    venue_cols = [
+                        "Event", "Estimating Teams", "Pool Games Per Team",
+                        "Minutes Per Game", "Pool Slots", "Playoff Teams",
+                        "Playoff Slots", "Third Place?", "Third Place Slots",
+                        "Total Court Slots", "Estimated Court Hours",
+                    ]
+                    df_venue = pd.DataFrame(venue_rows, columns=venue_cols)
+                    snapshot_note = (
+                        f"Roster snapshot as of {datetime.now().strftime('%Y-%m-%d')} — "
+                        "Estimating Teams counts every roster entry regardless of approval status; "
+                        "updates with each export run."
+                    )
+                    # Reserve row 1 for the snapshot disclaimer; data starts on row 2.
+                    df_venue.to_excel(writer, sheet_name="Venue-Capacity", index=False, startrow=1)
+                    venue_ws = writer.sheets["Venue-Capacity"]
+                    venue_ws.cell(row=1, column=1, value=snapshot_note)
+                    logger.debug(f"Venue-Capacity tab: {len(df_venue)} rows.")
 
                 # Add yellow note to Photo column in Roster sheet
                 if not df_roster.empty:

--- a/middleware/church_teams_export.py
+++ b/middleware/church_teams_export.py
@@ -1054,7 +1054,10 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
         for r in roster_rows:
             r_type = str(r.get("sport_type") or "").strip()
             r_gender = str(r.get("sport_gender") or "").strip()
-            if r_type.casefold() != target_type.casefold():
+            # Match either the base name ("Soccer") or the full Other-Events label
+            # ("Soccer - Coed Exhibition"), since other_events are stored verbatim.
+            if (r_type.casefold() != target_type.casefold() and
+                    r_type.casefold() != event_name.casefold()):
                 continue
             if target_gender and r_gender.casefold() != target_gender.casefold():
                 continue

--- a/middleware/church_teams_export.py
+++ b/middleware/church_teams_export.py
@@ -1034,11 +1034,18 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
         return int(COURT_ESTIMATE_MIN_TEAM_SIZE.get(event_name, 0))
 
     def _count_estimating_teams(self, roster_rows: List[Dict[str, Any]],
-                                 event_name: str, min_team_size: int) -> int:
-        """Count churches with at least min_team_size roster entries for this event.
-        Approval-agnostic — every roster entry counts."""
+                                 event_name: str, min_team_size: int) -> Dict[str, Any]:
+        """Return estimating/potential team counts and the qualifying church codes.
+
+        Approval-agnostic — every roster entry counts.
+
+        Returns a dict with:
+          n_estimating  – churches with >= min_team_size entries (ready to compete)
+          n_potential   – churches with >= 1 but < min_team_size entries (still forming)
+          team_codes    – sorted, comma-separated list of estimating church codes
+        """
         if min_team_size <= 0:
-            return 0
+            return {"n_estimating": 0, "n_potential": 0, "team_codes": ""}
         target_type, target_gender, _ = self._decompose_event_name(event_name)
         counts_by_church: Dict[str, int] = {}
         for r in roster_rows:
@@ -1052,7 +1059,13 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
             if not church:
                 continue
             counts_by_church[church] = counts_by_church.get(church, 0) + 1
-        return sum(1 for n in counts_by_church.values() if n >= min_team_size)
+        estimating = sorted(c for c, n in counts_by_church.items() if n >= min_team_size)
+        potential = [c for c, n in counts_by_church.items() if 0 < n < min_team_size]
+        return {
+            "n_estimating": len(estimating),
+            "n_potential": len(potential),
+            "team_codes": ", ".join(estimating),
+        }
 
     @staticmethod
     def _get_playoff_teams(n_teams: int) -> int:
@@ -1087,11 +1100,13 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
         rows = []
         for event_name in COURT_ESTIMATE_EVENTS:
             min_team_size = self._get_min_team_size(event_name)
-            n_teams = self._count_estimating_teams(roster_rows, event_name, min_team_size)
-            s = self._compute_court_slots(n_teams)
+            counts = self._count_estimating_teams(roster_rows, event_name, min_team_size)
+            s = self._compute_court_slots(counts["n_estimating"])
             rows.append({
                 "Event": event_name,
-                "Estimating Teams": n_teams,
+                "Potential Teams": counts["n_potential"],
+                "Estimating Teams": counts["n_estimating"],
+                "Teams": counts["team_codes"],
                 "Pool Games Per Team": s["pool_games_per_team"],
                 "Minutes Per Game": s["minutes_per_game"],
                 "Pool Slots": s["pool_slots"],
@@ -1244,10 +1259,10 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
                 if include_venue_capacity:
                     venue_rows = self._build_venue_capacity_rows(roster_rows)
                     venue_cols = [
-                        "Event", "Estimating Teams", "Pool Games Per Team",
-                        "Minutes Per Game", "Pool Slots", "Playoff Teams",
-                        "Playoff Slots", "Third Place?", "Third Place Slots",
-                        "Total Court Slots", "Estimated Court Hours",
+                        "Event", "Potential Teams", "Estimating Teams", "Teams",
+                        "Pool Games Per Team", "Minutes Per Game", "Pool Slots",
+                        "Playoff Teams", "Playoff Slots", "Third Place?",
+                        "Third Place Slots", "Total Court Slots", "Estimated Court Hours",
                     ]
                     df_venue = pd.DataFrame(venue_rows, columns=venue_cols)
                     snapshot_note = (

--- a/middleware/church_teams_export.py
+++ b/middleware/church_teams_export.py
@@ -1015,6 +1015,39 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
                 logger.debug(f"Summary tab: {len(df_summary)} rows.")
 
                 # Contacts-Status Tab
+                # Build sports-registered lookup keyed by Participant ID (WP) and ChMeetings ID
+                sports_by_wp_id: Dict[str, list] = {}
+                sports_by_chm_id: Dict[str, list] = {}
+                for rrow in roster_rows:
+                    label_parts = [
+                        str(rrow.get("sport_type") or "").strip(),
+                        str(rrow.get("sport_gender") or "").strip(),
+                        str(rrow.get("sport_format") or "").strip(),
+                    ]
+                    label = " ".join(p for p in label_parts if p)
+                    if not label:
+                        continue
+                    wp_pid = str(rrow.get("Participant ID (WP)") or "").strip()
+                    chm_pid = str(rrow.get("ChMeetings ID") or "").strip()
+                    if wp_pid and wp_pid not in ("0", ""):
+                        sports_by_wp_id.setdefault(wp_pid, [])
+                        if label not in sports_by_wp_id[wp_pid]:
+                            sports_by_wp_id[wp_pid].append(label)
+                    if chm_pid and chm_pid not in ("0", ""):
+                        sports_by_chm_id.setdefault(chm_pid, [])
+                        if label not in sports_by_chm_id[chm_pid]:
+                            sports_by_chm_id[chm_pid].append(label)
+
+                for crow in contacts_rows:
+                    wp_pid = str(crow.get("Participant ID (WP)") or "").strip()
+                    chm_pid = str(crow.get("ChMeetings ID") or "").strip()
+                    sports = (
+                        sports_by_wp_id.get(wp_pid)
+                        or sports_by_chm_id.get(chm_pid)
+                        or []
+                    )
+                    crow["Sports Registered"] = ", ".join(sorted(sports)) if sports else ""
+
                 df_contacts = pd.DataFrame(contacts_rows)
                 if not df_contacts.empty:
 
@@ -1022,8 +1055,8 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
                     if photo_url_col_name in df_contacts.columns:
                         # Create the hyperlink formula if the URL is not "N/A" and looks like a URL
                         df_contacts[photo_url_col_name] = df_contacts[photo_url_col_name].apply(
-                            lambda url: f'=HYPERLINK("{url}", "{url}")' 
-                            if isinstance(url, str) and url != "N/A" and (url.startswith("http://") or url.startswith("https://")) 
+                            lambda url: f'=HYPERLINK("{url}", "{url}")'
+                            if isinstance(url, str) and url != "N/A" and (url.startswith("http://") or url.startswith("https://"))
                             else url # Keep "N/A" or other non-URL values as is
                         )
 
@@ -1031,7 +1064,8 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
                         "Church Team", "ChMeetings ID", "First Name", "Last Name", "Is_Participant",
                         "Is_Member_ChM", "Participant ID (WP)", "Approval_Status (WP)",
                         "Total_Open_ERRORs (WP)", "Gender", "Birthdate", "Age (at Event)",
-                        "Mobile Phone", "Email", "Registration Date (WP)", "Athlete Fee", "First_Open_ERROR_Desc (WP)",
+                        "Mobile Phone", "Email", "Registration Date (WP)", "Sports Registered", "Athlete Fee",
+                        "First_Open_ERROR_Desc (WP)",
                         "Box 1", "Box 2", "Box 3", "Box 4", "Box 5", "Box 6",
                         photo_url_col_name, "Update_on_ChM"
                     ]

--- a/middleware/church_teams_export.py
+++ b/middleware/church_teams_export.py
@@ -1313,7 +1313,7 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
                 df_validation.to_excel(writer, sheet_name="Validation-Issues", index=False)
                 logger.debug(f"Validation-Issues tab: {len(df_validation)} rows.")
 
-                # Venue-Capacity Tab (only on the consolidated ALL export — see Issue #83)
+                # Venue-Estimator Tab (only on the consolidated ALL export — see Issue #83)
                 if include_venue_capacity:
                     venue_rows = self._build_venue_capacity_rows(roster_rows)
                     venue_cols = [
@@ -1328,11 +1328,12 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
                         "Estimating = complete entries; Potential = all registrations including partial. "
                         "Approval-agnostic. Updates with each export run."
                     )
-                    # Reserve row 1 for the snapshot disclaimer; data starts on row 2.
-                    df_venue.to_excel(writer, sheet_name="Venue-Capacity", index=False, startrow=1)
-                    venue_ws = writer.sheets["Venue-Capacity"]
-                    venue_ws.cell(row=1, column=1, value=snapshot_note)
-                    logger.debug(f"Venue-Capacity tab: {len(df_venue)} rows.")
+                    # Data first, then a blank row, then the snapshot disclaimer at the bottom.
+                    df_venue.to_excel(writer, sheet_name="Venue-Estimator", index=False, startrow=0)
+                    venue_ws = writer.sheets["Venue-Estimator"]
+                    note_row = len(df_venue) + 3  # header + data rows + blank row
+                    venue_ws.cell(row=note_row, column=1, value=snapshot_note)
+                    logger.debug(f"Venue-Estimator tab: {len(df_venue)} rows.")
 
                 # Add yellow note to Photo column in Roster sheet
                 if not df_roster.empty:

--- a/middleware/church_teams_export.py
+++ b/middleware/church_teams_export.py
@@ -21,11 +21,14 @@ from config import (
     ATHLETE_FEE_LATE,
     REGISTRATION_DEADLINE,
     SPORT_TYPE,
+    is_racquet_sport,
     COURT_ESTIMATE_EVENTS,
+    COURT_ESTIMATE_RACQUET_EVENTS,
     COURT_ESTIMATE_DEFAULT_POOL_GAMES_PER_TEAM,
     COURT_ESTIMATE_DEFAULT_MINUTES_PER_GAME,
     COURT_ESTIMATE_INCLUDE_THIRD_PLACE_GAME,
     COURT_ESTIMATE_MIN_TEAM_SIZE,
+    COURT_ESTIMATE_MINUTES_PER_GAME,
     COURT_ESTIMATE_PLAYOFF_RULES,
 )
 from chmeetings.backend_connector import ChMeetingsConnector
@@ -1060,10 +1063,10 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
                 continue
             counts_by_church[church] = counts_by_church.get(church, 0) + 1
         estimating = sorted(c for c, n in counts_by_church.items() if n >= min_team_size)
-        potential = [c for c, n in counts_by_church.items() if 0 < n < min_team_size]
+        partial = [c for c, n in counts_by_church.items() if 0 < n < min_team_size]
         return {
             "n_estimating": len(estimating),
-            "n_potential": len(potential),
+            "n_potential": len(estimating) + len(partial),  # all churches with >= 1 entry
             "team_codes": ", ".join(estimating),
         }
 
@@ -1074,9 +1077,9 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
                 return int(rule["playoff_teams"])
         return 0
 
-    def _compute_court_slots(self, n_teams: int) -> Dict[str, Any]:
+    def _compute_court_slots(self, n_teams: int,
+                              minutes_per_game: int = COURT_ESTIMATE_DEFAULT_MINUTES_PER_GAME) -> Dict[str, Any]:
         pool_games_per_team = COURT_ESTIMATE_DEFAULT_POOL_GAMES_PER_TEAM
-        minutes_per_game = COURT_ESTIMATE_DEFAULT_MINUTES_PER_GAME
         include_third = COURT_ESTIMATE_INCLUDE_THIRD_PLACE_GAME
 
         pool_slots = ceil((n_teams * pool_games_per_team) / 2) if n_teams > 0 else 0
@@ -1096,16 +1099,45 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
             "court_hours": round(total_slots * minutes_per_game / 60, 2),
         }
 
+    def _count_racquet_entries(self, roster_rows: List[Dict[str, Any]],
+                               sport_name: str) -> Dict[str, Any]:
+        """Count racquet sport entries for the venue estimator.
+
+        Estimating Entries = complete pairs floor(n_doubles / 2) + n_singles.
+        Potential Entries  = total individual registrations (one person may be
+                             waiting for a partner to sign up).
+        """
+        n_singles = 0
+        n_doubles = 0
+        for r in roster_rows:
+            if str(r.get("sport_type") or "").strip().casefold() != sport_name.casefold():
+                continue
+            fmt = str(r.get("sport_format") or "").strip().casefold()
+            if "singles" in fmt:
+                n_singles += 1
+            else:
+                n_doubles += 1
+        n_estimating = n_singles + (n_doubles // 2)
+        n_potential = n_singles + n_doubles
+        return {
+            "n_estimating": n_estimating,
+            "n_potential": n_potential,
+            "team_codes": "",
+        }
+
     def _build_venue_capacity_rows(self, roster_rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         rows = []
+
+        # Team sports — count churches with a complete roster
         for event_name in COURT_ESTIMATE_EVENTS:
             min_team_size = self._get_min_team_size(event_name)
             counts = self._count_estimating_teams(roster_rows, event_name, min_team_size)
-            s = self._compute_court_slots(counts["n_estimating"])
+            mpg = COURT_ESTIMATE_MINUTES_PER_GAME.get(event_name, COURT_ESTIMATE_DEFAULT_MINUTES_PER_GAME)
+            s = self._compute_court_slots(counts["n_estimating"], minutes_per_game=mpg)
             rows.append({
                 "Event": event_name,
-                "Potential Teams": counts["n_potential"],
-                "Estimating Teams": counts["n_estimating"],
+                "Potential Teams/Entries": counts["n_potential"],
+                "Estimating Teams/Entries": counts["n_estimating"],
                 "Teams": counts["team_codes"],
                 "Pool Games Per Team": s["pool_games_per_team"],
                 "Minutes Per Game": s["minutes_per_game"],
@@ -1117,6 +1149,28 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
                 "Total Court Slots": s["total_slots"],
                 "Estimated Court Hours": s["court_hours"],
             })
+
+        # Racquet sports — count complete pairs + singles
+        for sport_name in COURT_ESTIMATE_RACQUET_EVENTS:
+            counts = self._count_racquet_entries(roster_rows, sport_name)
+            mpg = COURT_ESTIMATE_MINUTES_PER_GAME.get(sport_name, COURT_ESTIMATE_DEFAULT_MINUTES_PER_GAME)
+            s = self._compute_court_slots(counts["n_estimating"], minutes_per_game=mpg)
+            rows.append({
+                "Event": sport_name,
+                "Potential Teams/Entries": counts["n_potential"],
+                "Estimating Teams/Entries": counts["n_estimating"],
+                "Teams": counts["team_codes"],
+                "Pool Games Per Team": s["pool_games_per_team"],
+                "Minutes Per Game": s["minutes_per_game"],
+                "Pool Slots": s["pool_slots"],
+                "Playoff Teams": s["playoff_teams"],
+                "Playoff Slots": s["playoff_slots"],
+                "Third Place?": "Yes" if s["include_third_place"] else "No",
+                "Third Place Slots": s["third_place_slots"],
+                "Total Court Slots": s["total_slots"],
+                "Estimated Court Hours": s["court_hours"],
+            })
+
         return rows
 
     def _write_excel_report(self, filepath: Path,
@@ -1259,7 +1313,7 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
                 if include_venue_capacity:
                     venue_rows = self._build_venue_capacity_rows(roster_rows)
                     venue_cols = [
-                        "Event", "Potential Teams", "Estimating Teams", "Teams",
+                        "Event", "Potential Teams/Entries", "Estimating Teams/Entries", "Teams",
                         "Pool Games Per Team", "Minutes Per Game", "Pool Slots",
                         "Playoff Teams", "Playoff Slots", "Third Place?",
                         "Third Place Slots", "Total Court Slots", "Estimated Court Hours",
@@ -1267,8 +1321,8 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
                     df_venue = pd.DataFrame(venue_rows, columns=venue_cols)
                     snapshot_note = (
                         f"Roster snapshot as of {datetime.now().strftime('%Y-%m-%d')} — "
-                        "Estimating Teams counts every roster entry regardless of approval status; "
-                        "updates with each export run."
+                        "Estimating = complete entries; Potential = all registrations including partial. "
+                        "Approval-agnostic. Updates with each export run."
                     )
                     # Reserve row 1 for the snapshot disclaimer; data starts on row 2.
                     df_venue.to_excel(writer, sheet_name="Venue-Capacity", index=False, startrow=1)

--- a/middleware/church_teams_export.py
+++ b/middleware/church_teams_export.py
@@ -1054,8 +1054,9 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
         for r in roster_rows:
             r_type = str(r.get("sport_type") or "").strip()
             r_gender = str(r.get("sport_gender") or "").strip()
-            # Match either the base name ("Soccer") or the full Other-Events label
-            # ("Soccer - Coed Exhibition"), since other_events are stored verbatim.
+            # Primary/secondary sports are stored as the base name (e.g. "Basketball");
+            # Other-Events sports are stored as the full SPORT_TYPE value verbatim.
+            # Accept either so both paths match.
             if (r_type.casefold() != target_type.casefold() and
                     r_type.casefold() != event_name.casefold()):
                 continue

--- a/middleware/config.py
+++ b/middleware/config.py
@@ -87,7 +87,8 @@ SPORT_TYPE = {
     "VOLLEYBALL_MEN": "Volleyball - Men Team",
     "VOLLEYBALL_WOMEN": "Volleyball - Women Team",
     "BIBLE_CHALLENGE": "Bible Challenge - Mixed Team",
-    
+    "SOCCER": "Soccer - Coed Exhibition",
+
     # Racquet sports
     "BADMINTON": "Badminton",
     "PICKLEBALL": "Pickleball",
@@ -95,7 +96,7 @@ SPORT_TYPE = {
     "TABLE_TENNIS": "Table Tennis",
     "TABLE_TENNIS_35": "Table Tennis 35+",
     "TENNIS": "Tennis",
-    
+
     # Other events
     "TRACK_FIELD": "Track & Field",
     "TUG_OF_WAR": "Tug-of-war",
@@ -119,7 +120,8 @@ SPORT_BY_CATEGORY = {
         SPORT_TYPE["BASKETBALL"],
         SPORT_TYPE["VOLLEYBALL_MEN"],
         SPORT_TYPE["VOLLEYBALL_WOMEN"],
-        SPORT_TYPE["BIBLE_CHALLENGE"]
+        SPORT_TYPE["BIBLE_CHALLENGE"],
+        SPORT_TYPE["SOCCER"],
     ],
     SPORT_CATEGORY["RACQUET"]: [
         SPORT_TYPE["BADMINTON"],
@@ -402,12 +404,27 @@ def is_racquet_sport(sport: str) -> bool:
     return sport in RACQUET_SPORTS
 
 # Venue capacity estimation defaults (Issue #83)
-# Used by church_teams_export.py to produce a quick court-time estimate
-# for the major team-sport events. Constants only — no UI tuning yet.
+# Used by church_teams_export.py to produce a quick court-time estimate.
+# Team sports: one row per event, counting churches with a complete roster.
+# Racquet sports: one row per sport, counting complete pairs/individuals.
+
+# Team sports included in the estimator (roster-based, min-size threshold).
 COURT_ESTIMATE_EVENTS = [
     SPORT_TYPE["BASKETBALL"],
     SPORT_TYPE["VOLLEYBALL_MEN"],
     SPORT_TYPE["VOLLEYBALL_WOMEN"],
+    SPORT_TYPE["SOCCER"],
+    SPORT_TYPE["BIBLE_CHALLENGE"],
+]
+
+# Racquet sports included in the estimator (entry-based, doubles counted as pairs).
+COURT_ESTIMATE_RACQUET_EVENTS = [
+    SPORT_TYPE["BADMINTON"],
+    SPORT_TYPE["PICKLEBALL"],
+    SPORT_TYPE["PICKLEBALL_35"],
+    SPORT_TYPE["TABLE_TENNIS"],
+    SPORT_TYPE["TABLE_TENNIS_35"],
+    SPORT_TYPE["TENNIS"],
 ]
 
 # Pool games per team. Kept low (2) to surface the *minimum* venue need.
@@ -416,13 +433,42 @@ COURT_ESTIMATE_DEFAULT_POOL_GAMES_PER_TEAM = 2
 COURT_ESTIMATE_DEFAULT_MINUTES_PER_GAME = 60
 COURT_ESTIMATE_INCLUDE_THIRD_PLACE_GAME = False
 
+# Per-sport minutes per game — tune these once venues are confirmed.
+COURT_ESTIMATE_MINUTES_BASKETBALL = 60
+COURT_ESTIMATE_MINUTES_VOLLEYBALL = 60
+COURT_ESTIMATE_MINUTES_SOCCER = 60
+COURT_ESTIMATE_MINUTES_BIBLE_CHALLENGE = 45
+COURT_ESTIMATE_MINUTES_BADMINTON = 25
+COURT_ESTIMATE_MINUTES_PICKLEBALL = 20
+COURT_ESTIMATE_MINUTES_PICKLEBALL_35 = 20
+COURT_ESTIMATE_MINUTES_TABLE_TENNIS = 20
+COURT_ESTIMATE_MINUTES_TABLE_TENNIS_35 = 20
+COURT_ESTIMATE_MINUTES_TENNIS = 30
+
+# Lookup by sport_type label — used by _compute_court_slots.
+COURT_ESTIMATE_MINUTES_PER_GAME = {
+    SPORT_TYPE["BASKETBALL"]:       COURT_ESTIMATE_MINUTES_BASKETBALL,
+    SPORT_TYPE["VOLLEYBALL_MEN"]:   COURT_ESTIMATE_MINUTES_VOLLEYBALL,
+    SPORT_TYPE["VOLLEYBALL_WOMEN"]: COURT_ESTIMATE_MINUTES_VOLLEYBALL,
+    SPORT_TYPE["SOCCER"]:           COURT_ESTIMATE_MINUTES_SOCCER,
+    SPORT_TYPE["BIBLE_CHALLENGE"]:  COURT_ESTIMATE_MINUTES_BIBLE_CHALLENGE,
+    SPORT_TYPE["BADMINTON"]:        COURT_ESTIMATE_MINUTES_BADMINTON,
+    SPORT_TYPE["PICKLEBALL"]:       COURT_ESTIMATE_MINUTES_PICKLEBALL,
+    SPORT_TYPE["PICKLEBALL_35"]:    COURT_ESTIMATE_MINUTES_PICKLEBALL_35,
+    SPORT_TYPE["TABLE_TENNIS"]:     COURT_ESTIMATE_MINUTES_TABLE_TENNIS,
+    SPORT_TYPE["TABLE_TENNIS_35"]:  COURT_ESTIMATE_MINUTES_TABLE_TENNIS_35,
+    SPORT_TYPE["TENNIS"]:           COURT_ESTIMATE_MINUTES_TENNIS,
+}
+
 # Fallback only — the JSON-driven MIN_TEAM_SIZE_* rules in
 # validation/summer_2026.json are the source of truth. Used if a rule
 # is missing for an event in COURT_ESTIMATE_EVENTS.
 COURT_ESTIMATE_MIN_TEAM_SIZE = {
-    SPORT_TYPE["BASKETBALL"]: 5,
-    SPORT_TYPE["VOLLEYBALL_MEN"]: 6,
+    SPORT_TYPE["BASKETBALL"]:       5,
+    SPORT_TYPE["VOLLEYBALL_MEN"]:   6,
     SPORT_TYPE["VOLLEYBALL_WOMEN"]: 6,
+    SPORT_TYPE["SOCCER"]:           4,
+    SPORT_TYPE["BIBLE_CHALLENGE"]:  3,
 }
 
 COURT_ESTIMATE_PLAYOFF_RULES = [

--- a/middleware/config.py
+++ b/middleware/config.py
@@ -401,6 +401,36 @@ def is_racquet_sport(sport: str) -> bool:
     """
     return sport in RACQUET_SPORTS
 
+# Venue capacity estimation defaults (Issue #83)
+# Used by church_teams_export.py to produce a quick court-time estimate
+# for the major team-sport events. Constants only — no UI tuning yet.
+COURT_ESTIMATE_EVENTS = [
+    SPORT_TYPE["BASKETBALL"],
+    SPORT_TYPE["VOLLEYBALL_MEN"],
+    SPORT_TYPE["VOLLEYBALL_WOMEN"],
+]
+
+# Pool games per team. Kept low (2) to surface the *minimum* venue need.
+# Tune upward once a venue is confirmed.
+COURT_ESTIMATE_DEFAULT_POOL_GAMES_PER_TEAM = 2
+COURT_ESTIMATE_DEFAULT_MINUTES_PER_GAME = 60
+COURT_ESTIMATE_INCLUDE_THIRD_PLACE_GAME = False
+
+# Fallback only — the JSON-driven MIN_TEAM_SIZE_* rules in
+# validation/summer_2026.json are the source of truth. Used if a rule
+# is missing for an event in COURT_ESTIMATE_EVENTS.
+COURT_ESTIMATE_MIN_TEAM_SIZE = {
+    SPORT_TYPE["BASKETBALL"]: 5,
+    SPORT_TYPE["VOLLEYBALL_MEN"]: 6,
+    SPORT_TYPE["VOLLEYBALL_WOMEN"]: 6,
+}
+
+COURT_ESTIMATE_PLAYOFF_RULES = [
+    {"min_teams": 1, "max_teams": 3, "playoff_teams": 0},
+    {"min_teams": 4, "max_teams": 7, "playoff_teams": 4},
+    {"min_teams": 8, "max_teams": 999, "playoff_teams": 8},
+]
+
 # Configuration class
 class Config:
     """Configuration settings for VAYSF middleware."""

--- a/middleware/group_assignment.py
+++ b/middleware/group_assignment.py
@@ -510,8 +510,8 @@ def audit_team_groups(church_code: Optional[str] = None,
                             logger.warning(
                                 f"Cannot remove orphaned membership: person_id={person_id} from "
                                 f"{group_name} — ChMeetings DELETE also returned 404. "
-                                f"This record is permanently stuck and must be resolved by "
-                                f"ChMeetings support."
+                                f"This record is permanently stuck (ChMeetings bug ticket #20188) "
+                                f"and must be resolved by ChMeetings support."
                             )
                         else:
                             lookup_status = "orphan_remove_failed"

--- a/middleware/group_assignment.py
+++ b/middleware/group_assignment.py
@@ -390,17 +390,28 @@ def clear_team_groups(
         return failed == 0
 
 
-def audit_team_groups(church_code: Optional[str] = None) -> bool:
+def audit_team_groups(church_code: Optional[str] = None,
+                      remove_orphans: bool = False) -> bool:
     """
     Audit Team XXX groups for orphaned ChMeetings memberships.
 
     A membership is considered orphaned when it appears in a Team group but
     GET /people/{id} returns 404 Not Found.
+
+    If remove_orphans=True, each orphaned membership is deleted from ChMeetings
+    immediately after identification. This is irreversible — run without the flag
+    first to review the audit file before committing to removal.
     """
     normalized_code = church_code.strip().upper() if church_code else None
     logger.info(
-        f"Starting team-group orphan audit (church_code={normalized_code or 'ALL'})..."
+        f"Starting team-group orphan audit (church_code={normalized_code or 'ALL'}, "
+        f"remove_orphans={remove_orphans})..."
     )
+    if remove_orphans:
+        logger.warning(
+            "REMOVE MODE: orphaned memberships will be deleted from ChMeetings. "
+            "This action is irreversible."
+        )
 
     with ChMeetingsConnector() as chm_connector, WordPressConnector() as wp_connector:
         if not chm_connector.authenticate():
@@ -421,6 +432,7 @@ def audit_team_groups(church_code: Optional[str] = None) -> bool:
         groups_processed = 0
         memberships_found = 0
         orphans_found = 0
+        orphans_removed = 0
         resolved_found = 0
         failed_lookups = 0
         audit_rows: List[Dict[str, str]] = []
@@ -478,6 +490,20 @@ def audit_team_groups(church_code: Optional[str] = None) -> bool:
                         f"Orphaned Team-group membership found: {group_name} has person_id={person_id}, "
                         f"but ChMeetings GET /people/{person_id} returned 404."
                     )
+                    if remove_orphans:
+                        removed = chm_connector.remove_person_from_group(
+                            group_id, person_id, not_found_ok=True
+                        )
+                        if removed:
+                            orphans_removed += 1
+                            logger.info(
+                                f"Removed orphaned membership: person_id={person_id} from {group_name}."
+                            )
+                        else:
+                            logger.error(
+                                f"Failed to remove orphaned membership: person_id={person_id} from {group_name}."
+                            )
+                        lookup_status = "orphan_removed" if removed else "orphan_remove_failed"
                 else:
                     failed_lookups += 1
                     logger.warning(
@@ -511,11 +537,14 @@ def audit_team_groups(church_code: Optional[str] = None) -> bool:
                 })
 
         _write_audit_file("team_group_orphan_audit.xlsx", audit_rows)
-        logger.info(
+        summary = (
             f"Team-group orphan audit complete: {groups_processed} group(s), "
             f"{memberships_found} membership(s), {orphans_found} orphan(s), "
             f"{resolved_found} resolved lookup(s), {failed_lookups} failed lookup(s)."
         )
+        if remove_orphans:
+            summary += f" Removed: {orphans_removed}/{orphans_found} orphaned membership(s)."
+        logger.info(summary)
 
         return True
 

--- a/middleware/group_assignment.py
+++ b/middleware/group_assignment.py
@@ -433,6 +433,7 @@ def audit_team_groups(church_code: Optional[str] = None,
         memberships_found = 0
         orphans_found = 0
         orphans_removed = 0
+        orphans_stuck = 0
         resolved_found = 0
         failed_lookups = 0
         audit_rows: List[Dict[str, str]] = []
@@ -494,16 +495,29 @@ def audit_team_groups(church_code: Optional[str] = None,
                         removed = chm_connector.remove_person_from_group(
                             group_id, person_id, not_found_ok=True
                         )
-                        if removed:
+                        delete_status = getattr(
+                            chm_connector, "last_group_membership_delete_status", "failed"
+                        )
+                        if removed and delete_status == "removed":
                             orphans_removed += 1
+                            lookup_status = "orphan_removed"
                             logger.info(
                                 f"Removed orphaned membership: person_id={person_id} from {group_name}."
                             )
+                        elif removed and delete_status == "already_absent":
+                            orphans_stuck += 1
+                            lookup_status = "orphan_stuck"
+                            logger.warning(
+                                f"Cannot remove orphaned membership: person_id={person_id} from "
+                                f"{group_name} — ChMeetings DELETE also returned 404. "
+                                f"This record is permanently stuck and must be resolved by "
+                                f"ChMeetings support."
+                            )
                         else:
+                            lookup_status = "orphan_remove_failed"
                             logger.error(
                                 f"Failed to remove orphaned membership: person_id={person_id} from {group_name}."
                             )
-                        lookup_status = "orphan_removed" if removed else "orphan_remove_failed"
                 else:
                     failed_lookups += 1
                     logger.warning(
@@ -543,7 +557,10 @@ def audit_team_groups(church_code: Optional[str] = None,
             f"{resolved_found} resolved lookup(s), {failed_lookups} failed lookup(s)."
         )
         if remove_orphans:
-            summary += f" Removed: {orphans_removed}/{orphans_found} orphaned membership(s)."
+            summary += (
+                f" Removed: {orphans_removed}/{orphans_found} orphaned membership(s)"
+                f" (stuck/API-undeleteable: {orphans_stuck})."
+            )
         logger.info(summary)
 
         return True

--- a/middleware/main.py
+++ b/middleware/main.py
@@ -89,6 +89,11 @@ def parse_args() -> argparse.Namespace:
         "--church-code",
         help="Limit the audit to a single team group such as Team GAC",
     )
+    audit_team_groups_parser.add_argument(
+        "--remove-orphans",
+        action="store_true",
+        help="Remove orphaned memberships from ChMeetings after identifying them (irreversible)",
+    )
 
     # Export command
     export_parser = subparsers.add_parser("export-church-teams", help="Export church team status reports")
@@ -622,7 +627,8 @@ def main() -> None:
                 logger.info("Team-group clearing complete. Check data/team_group_clearing_audit.xlsx for the audit log.")
     elif args.command == "audit-team-groups":
         from group_assignment import audit_team_groups
-        success = audit_team_groups(church_code=args.church_code)
+        success = audit_team_groups(church_code=args.church_code,
+                                    remove_orphans=args.remove_orphans)
         if success:
             logger.info("Team-group audit complete. Check data/team_group_orphan_audit.xlsx for the audit log.")
     elif args.command == "export-church-teams":

--- a/middleware/sync/participants.py
+++ b/middleware/sync/participants.py
@@ -709,17 +709,41 @@ class ParticipantSyncer:
                         sport_format = SPORT_FORMAT["TEAM"]
                     elif len(sport_parts) > 1:
                         param = sport_parts[1]
-                        if GENDER["MEN"] in param.upper():
+                        param_upper = param.upper()
+                        if GENDER["MEN"].upper() in param_upper:
                             sport_gender = GENDER["MEN"]
-                        elif GENDER["WOMEN"] in param.upper():
+                        elif GENDER["WOMEN"].upper() in param_upper:
                             sport_gender = GENDER["WOMEN"]
-                        elif GENDER["MIXED"] in param.upper():
+                        elif GENDER["MIXED"].upper() in param_upper or "COED" in param_upper:
                             sport_gender = GENDER["MIXED"]
                         else:
                             sport_gender = GENDER["MIXED"]
-                        sport_format = SPORT_FORMAT["TEAM"] if SPORT_FORMAT["TEAM"] in param else SPORT_FORMAT["SINGLES"]
+                        sport_format = SPORT_FORMAT["SINGLES"] if SPORT_FORMAT["SINGLES"].upper() in param_upper else SPORT_FORMAT["TEAM"]
                     else:
-                        sport_format, sport_gender = parse_format(format_value)
+                        # Bare name with no " - " separator (e.g., "Basketball" stored without
+                        # the "- Men Team" suffix by older registrations). Look up the canonical
+                        # SPORT_TYPE entry to recover the correct gender/format before falling
+                        # back to parse_format().
+                        canonical = next(
+                            (v for v in SPORT_TYPE.values()
+                             if v.split(" - ")[0].strip() == sport_type),
+                            None,
+                        )
+                        canonical_parts = canonical.split(" - ", 1) if canonical else []
+                        if len(canonical_parts) > 1:
+                            param = canonical_parts[1]
+                            param_upper = param.upper()
+                            if GENDER["MEN"].upper() in param_upper:
+                                sport_gender = GENDER["MEN"]
+                            elif GENDER["WOMEN"].upper() in param_upper:
+                                sport_gender = GENDER["WOMEN"]
+                            elif GENDER["MIXED"].upper() in param_upper or "COED" in param_upper:
+                                sport_gender = GENDER["MIXED"]
+                            else:
+                                sport_gender = GENDER["MIXED"]
+                            sport_format = SPORT_FORMAT["SINGLES"] if SPORT_FORMAT["SINGLES"].upper() in param_upper else SPORT_FORMAT["TEAM"]
+                        else:
+                            sport_format, sport_gender = parse_format(format_value)
 
                 roster_data = {
                     "church_code": participant["church_code"],

--- a/middleware/tests/test_church_teams_export.py
+++ b/middleware/tests/test_church_teams_export.py
@@ -759,3 +759,129 @@ def test_contacts_status_tab_includes_sports_registered_column(mock_connectors, 
 
     carol_row = contacts_df[contacts_df["First Name"] == "Carol"].iloc[0]
     assert carol_row["Sports Registered"] == "" or pd.isna(carol_row["Sports Registered"])
+
+
+def test_venue_capacity_court_slot_math(mock_connectors):
+    """Pool/playoff/total slot math (Issue #83)."""
+    exporter = ChurchTeamsExporter()
+
+    # 0 teams → all zeros
+    s0 = exporter._compute_court_slots(0)
+    assert s0["pool_slots"] == 0
+    assert s0["playoff_teams"] == 0
+    assert s0["playoff_slots"] == 0
+    assert s0["total_slots"] == 0
+    assert s0["court_hours"] == 0.0
+
+    # 6 teams, 2 pool games each → ceil(6*2/2) = 6 pool, 4-team playoff = 3 playoff games
+    s6 = exporter._compute_court_slots(6)
+    assert s6["pool_slots"] == 6
+    assert s6["playoff_teams"] == 4
+    assert s6["playoff_slots"] == 3
+    assert s6["third_place_slots"] == 0  # default off
+    assert s6["total_slots"] == 9
+    assert s6["court_hours"] == 9.0  # 60 min/game
+
+    # 8 teams → ceil(8*2/2)=8 pool, 8-team playoff = 7 playoff games
+    s8 = exporter._compute_court_slots(8)
+    assert s8["pool_slots"] == 8
+    assert s8["playoff_teams"] == 8
+    assert s8["playoff_slots"] == 7
+    assert s8["total_slots"] == 15
+
+    # 3 teams → only pool play, no playoff
+    s3 = exporter._compute_court_slots(3)
+    assert s3["pool_slots"] == 3
+    assert s3["playoff_teams"] == 0
+    assert s3["playoff_slots"] == 0
+    assert s3["total_slots"] == 3
+
+
+def test_count_estimating_teams_uses_min_team_size(mock_connectors):
+    """A church only counts when its roster meets the min team size (Issue #83)."""
+    exporter = ChurchTeamsExporter()
+
+    # RPC has 5 basketball players (meets min=5), TLC has 4 (does not)
+    roster_rows = [
+        {"Church Team": "RPC", "sport_type": "Basketball", "sport_gender": "Men"} for _ in range(5)
+    ] + [
+        {"Church Team": "TLC", "sport_type": "Basketball", "sport_gender": "Men"} for _ in range(4)
+    ]
+
+    n = exporter._count_estimating_teams(roster_rows, "Basketball - Men Team", min_team_size=5)
+    assert n == 1  # only RPC qualifies
+
+
+def test_count_estimating_teams_separates_volleyball_men_and_women(mock_connectors):
+    """Volleyball Men and Women are distinct events (Issue #83)."""
+    exporter = ChurchTeamsExporter()
+
+    roster_rows = (
+        [{"Church Team": "RPC", "sport_type": "Volleyball", "sport_gender": "Men"} for _ in range(6)]
+        + [{"Church Team": "RPC", "sport_type": "Volleyball", "sport_gender": "Women"} for _ in range(6)]
+        + [{"Church Team": "TLC", "sport_type": "Volleyball", "sport_gender": "Women"} for _ in range(6)]
+    )
+
+    assert exporter._count_estimating_teams(roster_rows, "Volleyball - Men Team", 6) == 1
+    assert exporter._count_estimating_teams(roster_rows, "Volleyball - Women Team", 6) == 2
+
+
+def test_venue_capacity_tab_only_in_consolidated_export(mock_connectors, tmp_path):
+    """Venue-Capacity tab appears only when include_venue_capacity=True (Issue #83)."""
+    exporter = ChurchTeamsExporter()
+
+    summary_rows = [{
+        "Church Code": "RPC",
+        "Total Members (ChM Team Group)": 6, "Total Participants (in WP)": 6,
+        "Total Approved (WP)": 0, "Total Pending Approval (WP)": 6, "Total Denied (WP)": 0,
+        "Total Participants w/ Open ERRORs (WP)": 0,
+        "Total Open Individual ERRORs (WP)": 0, "Total Open TEAM ERRORs (WP)": 0,
+        "Total Open WARNINGs (WP)": 0, "Total Sports w/ Open TEAM Issues (WP)": 0,
+        "Latest ChM Record Update for Team": "2026-05-13",
+    }]
+    contacts_rows = [{
+        "Church Team": "RPC", "ChMeetings ID": str(100 + i), "First Name": f"P{i}",
+        "Last Name": "X", "Is_Participant": "Yes", "Is_Member_ChM": "Yes",
+        "Participant ID (WP)": i, "Approval_Status (WP)": "pending",
+        "Total_Open_ERRORs (WP)": 0, "Gender": "Male", "Birthdate": "2000-01-01",
+        "Age (at Event)": 26, "Mobile Phone": "", "Email": "",
+        "Registration Date (WP)": "2026-03-01", "Athlete Fee": 30,
+        "First_Open_ERROR_Desc (WP)": "",
+        "Box 1": "", "Box 2": "", "Box 3": "", "Box 4": "", "Box 5": "", "Box 6": "",
+        "Photo URL (WP)": "N/A", "Update_on_ChM": "",
+    } for i in range(6)]
+    roster_rows = [{
+        "Church Team": "RPC", "ChMeetings ID": str(100 + i), "Participant ID (WP)": i,
+        "sport_type": "Basketball", "sport_gender": "Men", "sport_format": "Team",
+    } for i in range(6)]
+
+    # Single-church export: no Venue-Capacity tab
+    single_path = tmp_path / "single.xlsx"
+    exporter._write_excel_report(single_path, summary_rows, contacts_rows, roster_rows, [])
+    assert "Venue-Capacity" not in pd.ExcelFile(single_path).sheet_names
+
+    # Consolidated ALL export: tab present, three rows, snapshot note in row 1
+    all_path = tmp_path / "all.xlsx"
+    exporter._write_excel_report(all_path, summary_rows, contacts_rows, roster_rows, [],
+                                 include_venue_capacity=True)
+    sheets = pd.ExcelFile(all_path).sheet_names
+    assert "Venue-Capacity" in sheets
+
+    venue_df = pd.read_excel(all_path, sheet_name="Venue-Capacity", header=1)
+    assert list(venue_df.columns)[0] == "Event"
+    assert "Estimated Court Hours" in venue_df.columns
+    assert len(venue_df) == 3  # Basketball, Volleyball Men, Volleyball Women
+
+    bball = venue_df[venue_df["Event"] == "Basketball - Men Team"].iloc[0]
+    assert int(bball["Estimating Teams"]) == 1  # RPC's 6 basketball players
+    assert int(bball["Pool Slots"]) == 1  # ceil(1*2/2) = 1
+    # 1 team → no playoff per default rules
+    assert int(bball["Playoff Teams"]) == 0
+    assert int(bball["Total Court Slots"]) == 1
+
+    vb_men = venue_df[venue_df["Event"] == "Volleyball - Men Team"].iloc[0]
+    assert int(vb_men["Estimating Teams"]) == 0  # no volleyball rosters
+
+    # Snapshot disclaimer is in row 1 (above the header row)
+    raw = pd.read_excel(all_path, sheet_name="Venue-Capacity", header=None)
+    assert "Roster snapshot as of" in str(raw.iloc[0, 0])

--- a/middleware/tests/test_church_teams_export.py
+++ b/middleware/tests/test_church_teams_export.py
@@ -878,7 +878,7 @@ def test_count_racquet_entries(mock_connectors):
 
 
 def test_venue_capacity_tab_only_in_consolidated_export(mock_connectors, tmp_path):
-    """Venue-Capacity tab appears only when include_venue_capacity=True (Issue #83)."""
+    """Venue-Estimator tab appears only when include_venue_capacity=True (Issue #83)."""
     exporter = ChurchTeamsExporter()
 
     summary_rows = [{
@@ -906,26 +906,26 @@ def test_venue_capacity_tab_only_in_consolidated_export(mock_connectors, tmp_pat
         "sport_type": "Basketball", "sport_gender": "Men", "sport_format": "Team",
     } for i in range(6)]
 
-    # Single-church export: no Venue-Capacity tab
+    # Single-church export: no Venue-Estimator tab
     single_path = tmp_path / "single.xlsx"
     exporter._write_excel_report(single_path, summary_rows, contacts_rows, roster_rows, [])
-    assert "Venue-Capacity" not in pd.ExcelFile(single_path).sheet_names
+    assert "Venue-Estimator" not in pd.ExcelFile(single_path).sheet_names
 
-    # Consolidated ALL export: tab present, three rows, snapshot note in row 1
+    # Consolidated ALL export: tab present, snapshot note appended after data
     all_path = tmp_path / "all.xlsx"
     exporter._write_excel_report(all_path, summary_rows, contacts_rows, roster_rows, [],
                                  include_venue_capacity=True)
     sheets = pd.ExcelFile(all_path).sheet_names
-    assert "Venue-Capacity" in sheets
+    assert "Venue-Estimator" in sheets
 
-    venue_df = pd.read_excel(all_path, sheet_name="Venue-Capacity", header=1)
+    venue_df = pd.read_excel(all_path, sheet_name="Venue-Estimator", header=0)
     assert list(venue_df.columns)[0] == "Event"
     assert "Potential Teams/Entries" in venue_df.columns
     assert "Estimating Teams/Entries" in venue_df.columns
     assert "Teams" in venue_df.columns
     assert "Estimated Court Hours" in venue_df.columns
     # 5 team sports + 6 racquet sports
-    assert len(venue_df) == 11
+    assert len(venue_df[venue_df["Minutes Per Game"].notna()]) == 11  # 5 team + 6 racquet sports
 
     # Column order: Potential before Estimating before Teams
     cols = list(venue_df.columns)
@@ -943,6 +943,7 @@ def test_venue_capacity_tab_only_in_consolidated_export(mock_connectors, tmp_pat
     assert int(vb_men["Estimating Teams/Entries"]) == 0  # no volleyball rosters
     assert str(vb_men["Teams"]) in ("", "nan")
 
-    # Snapshot disclaimer is in row 1 (above the header row)
-    raw = pd.read_excel(all_path, sheet_name="Venue-Capacity", header=None)
-    assert "Roster snapshot as of" in str(raw.iloc[0, 0])
+    # Snapshot disclaimer appears after the data (header + 11 rows + blank = row 13)
+    raw = pd.read_excel(all_path, sheet_name="Venue-Estimator", header=None)
+    note_row_idx = 13  # 0-based: row 14 in Excel (1 header + 11 data + 1 blank + note)
+    assert "Roster snapshot as of" in str(raw.iloc[note_row_idx, 0])

--- a/middleware/tests/test_church_teams_export.py
+++ b/middleware/tests/test_church_teams_export.py
@@ -833,6 +833,27 @@ def test_count_estimating_teams_separates_volleyball_men_and_women(mock_connecto
     assert women["team_codes"] == "RPC, TLC"  # alphabetically sorted
 
 
+def test_count_estimating_teams_soccer_full_label(mock_connectors):
+    """Soccer sport_type is stored as the full Other-Events label, not just 'Soccer'."""
+    exporter = ChurchTeamsExporter()
+
+    # Other-events registrations store the full option string verbatim
+    roster_rows = [
+        {"Church Team": "RPC", "sport_type": "Soccer - Coed Exhibition", "sport_gender": "Mixed"}
+        for _ in range(5)
+    ] + [
+        {"Church Team": "TLC", "sport_type": "Soccer - Coed Exhibition", "sport_gender": "Mixed"}
+        for _ in range(3)
+    ]
+
+    result = exporter._count_estimating_teams(
+        roster_rows, "Soccer - Coed Exhibition", min_team_size=4
+    )
+    assert result["n_estimating"] == 1      # only RPC has >= 4
+    assert result["n_potential"] == 2       # RPC + TLC both have >= 1
+    assert result["team_codes"] == "RPC"
+
+
 def test_count_racquet_entries(mock_connectors):
     """Racquet entries: complete pairs counted as 1, singles as 1; potential = all regs."""
     exporter = ChurchTeamsExporter()

--- a/middleware/tests/test_church_teams_export.py
+++ b/middleware/tests/test_church_teams_export.py
@@ -810,7 +810,7 @@ def test_count_estimating_teams_uses_min_team_size(mock_connectors):
 
     result = exporter._count_estimating_teams(roster_rows, "Basketball - Men Team", min_team_size=5)
     assert result["n_estimating"] == 1       # only RPC qualifies
-    assert result["n_potential"] == 1        # TLC is still forming
+    assert result["n_potential"] == 2        # RPC (estimating) + TLC (partial) = all with >= 1
     assert result["team_codes"] == "RPC"     # sorted, comma-separated
 
 
@@ -831,6 +831,28 @@ def test_count_estimating_teams_separates_volleyball_men_and_women(mock_connecto
     women = exporter._count_estimating_teams(roster_rows, "Volleyball - Women Team", 6)
     assert women["n_estimating"] == 2
     assert women["team_codes"] == "RPC, TLC"  # alphabetically sorted
+
+
+def test_count_racquet_entries(mock_connectors):
+    """Racquet entries: complete pairs counted as 1, singles as 1; potential = all regs."""
+    exporter = ChurchTeamsExporter()
+
+    roster_rows = [
+        # 5 Badminton doubles registrations → 2 complete pairs + 1 waiting
+        {"sport_type": "Badminton", "sport_format": "Mixed Doubles"} for _ in range(5)
+    ] + [
+        # 2 Badminton singles
+        {"sport_type": "Badminton", "sport_format": "Men Singles"},
+        {"sport_type": "Badminton", "sport_format": "Women Singles"},
+    ] + [
+        # Pickleball should not bleed into Badminton count
+        {"sport_type": "Pickleball", "sport_format": "Mixed Doubles"},
+    ]
+
+    result = exporter._count_racquet_entries(roster_rows, "Badminton")
+    assert result["n_estimating"] == 2 + 2   # floor(5/2)=2 pairs + 2 singles
+    assert result["n_potential"] == 5 + 2    # 5 doubles + 2 singles = 7 registrations
+    assert result["team_codes"] == ""
 
 
 def test_venue_capacity_tab_only_in_consolidated_export(mock_connectors, tmp_path):
@@ -876,26 +898,27 @@ def test_venue_capacity_tab_only_in_consolidated_export(mock_connectors, tmp_pat
 
     venue_df = pd.read_excel(all_path, sheet_name="Venue-Capacity", header=1)
     assert list(venue_df.columns)[0] == "Event"
-    assert "Potential Teams" in venue_df.columns
-    assert "Estimating Teams" in venue_df.columns
+    assert "Potential Teams/Entries" in venue_df.columns
+    assert "Estimating Teams/Entries" in venue_df.columns
     assert "Teams" in venue_df.columns
     assert "Estimated Court Hours" in venue_df.columns
-    assert len(venue_df) == 3  # Basketball, Volleyball Men, Volleyball Women
+    # 5 team sports + 6 racquet sports
+    assert len(venue_df) == 11
 
-    # Column order: Potential Teams before Estimating Teams before Teams
+    # Column order: Potential before Estimating before Teams
     cols = list(venue_df.columns)
-    assert cols.index("Potential Teams") < cols.index("Estimating Teams") < cols.index("Teams")
+    assert cols.index("Potential Teams/Entries") < cols.index("Estimating Teams/Entries") < cols.index("Teams")
 
     bball = venue_df[venue_df["Event"] == "Basketball - Men Team"].iloc[0]
-    assert int(bball["Estimating Teams"]) == 1   # RPC's 6 basketball players qualify
-    assert int(bball["Potential Teams"]) == 0    # nobody short of the min
+    assert int(bball["Estimating Teams/Entries"]) == 1   # RPC's 6 basketball players qualify
+    assert int(bball["Potential Teams/Entries"]) == 1    # RPC (estimating) counts in potential too
     assert str(bball["Teams"]) == "RPC"
     assert int(bball["Pool Slots"]) == 1         # ceil(1*2/2) = 1
     assert int(bball["Playoff Teams"]) == 0      # 1 team → no playoff
     assert int(bball["Total Court Slots"]) == 1
 
     vb_men = venue_df[venue_df["Event"] == "Volleyball - Men Team"].iloc[0]
-    assert int(vb_men["Estimating Teams"]) == 0  # no volleyball rosters
+    assert int(vb_men["Estimating Teams/Entries"]) == 0  # no volleyball rosters
     assert str(vb_men["Teams"]) in ("", "nan")
 
     # Snapshot disclaimer is in row 1 (above the header row)

--- a/middleware/tests/test_church_teams_export.py
+++ b/middleware/tests/test_church_teams_export.py
@@ -801,19 +801,21 @@ def test_count_estimating_teams_uses_min_team_size(mock_connectors):
     """A church only counts when its roster meets the min team size (Issue #83)."""
     exporter = ChurchTeamsExporter()
 
-    # RPC has 5 basketball players (meets min=5), TLC has 4 (does not)
+    # RPC has 5 basketball players (meets min=5), TLC has 4 (potential only)
     roster_rows = [
         {"Church Team": "RPC", "sport_type": "Basketball", "sport_gender": "Men"} for _ in range(5)
     ] + [
         {"Church Team": "TLC", "sport_type": "Basketball", "sport_gender": "Men"} for _ in range(4)
     ]
 
-    n = exporter._count_estimating_teams(roster_rows, "Basketball - Men Team", min_team_size=5)
-    assert n == 1  # only RPC qualifies
+    result = exporter._count_estimating_teams(roster_rows, "Basketball - Men Team", min_team_size=5)
+    assert result["n_estimating"] == 1       # only RPC qualifies
+    assert result["n_potential"] == 1        # TLC is still forming
+    assert result["team_codes"] == "RPC"     # sorted, comma-separated
 
 
 def test_count_estimating_teams_separates_volleyball_men_and_women(mock_connectors):
-    """Volleyball Men and Women are distinct events (Issue #83)."""
+    """Volleyball Men and Women are distinct events; team_codes is sorted (Issue #83)."""
     exporter = ChurchTeamsExporter()
 
     roster_rows = (
@@ -822,8 +824,13 @@ def test_count_estimating_teams_separates_volleyball_men_and_women(mock_connecto
         + [{"Church Team": "TLC", "sport_type": "Volleyball", "sport_gender": "Women"} for _ in range(6)]
     )
 
-    assert exporter._count_estimating_teams(roster_rows, "Volleyball - Men Team", 6) == 1
-    assert exporter._count_estimating_teams(roster_rows, "Volleyball - Women Team", 6) == 2
+    men = exporter._count_estimating_teams(roster_rows, "Volleyball - Men Team", 6)
+    assert men["n_estimating"] == 1
+    assert men["team_codes"] == "RPC"
+
+    women = exporter._count_estimating_teams(roster_rows, "Volleyball - Women Team", 6)
+    assert women["n_estimating"] == 2
+    assert women["team_codes"] == "RPC, TLC"  # alphabetically sorted
 
 
 def test_venue_capacity_tab_only_in_consolidated_export(mock_connectors, tmp_path):
@@ -869,18 +876,27 @@ def test_venue_capacity_tab_only_in_consolidated_export(mock_connectors, tmp_pat
 
     venue_df = pd.read_excel(all_path, sheet_name="Venue-Capacity", header=1)
     assert list(venue_df.columns)[0] == "Event"
+    assert "Potential Teams" in venue_df.columns
+    assert "Estimating Teams" in venue_df.columns
+    assert "Teams" in venue_df.columns
     assert "Estimated Court Hours" in venue_df.columns
     assert len(venue_df) == 3  # Basketball, Volleyball Men, Volleyball Women
 
+    # Column order: Potential Teams before Estimating Teams before Teams
+    cols = list(venue_df.columns)
+    assert cols.index("Potential Teams") < cols.index("Estimating Teams") < cols.index("Teams")
+
     bball = venue_df[venue_df["Event"] == "Basketball - Men Team"].iloc[0]
-    assert int(bball["Estimating Teams"]) == 1  # RPC's 6 basketball players
-    assert int(bball["Pool Slots"]) == 1  # ceil(1*2/2) = 1
-    # 1 team → no playoff per default rules
-    assert int(bball["Playoff Teams"]) == 0
+    assert int(bball["Estimating Teams"]) == 1   # RPC's 6 basketball players qualify
+    assert int(bball["Potential Teams"]) == 0    # nobody short of the min
+    assert str(bball["Teams"]) == "RPC"
+    assert int(bball["Pool Slots"]) == 1         # ceil(1*2/2) = 1
+    assert int(bball["Playoff Teams"]) == 0      # 1 team → no playoff
     assert int(bball["Total Court Slots"]) == 1
 
     vb_men = venue_df[venue_df["Event"] == "Volleyball - Men Team"].iloc[0]
     assert int(vb_men["Estimating Teams"]) == 0  # no volleyball rosters
+    assert str(vb_men["Teams"]) in ("", "nan")
 
     # Snapshot disclaimer is in row 1 (above the header row)
     raw = pd.read_excel(all_path, sheet_name="Venue-Capacity", header=None)

--- a/middleware/tests/test_church_teams_export.py
+++ b/middleware/tests/test_church_teams_export.py
@@ -8,6 +8,7 @@ import pytest
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from church_teams_export import ChurchTeamsExporter, CHM_FIELDS, MEMBERSHIP_QUESTION
+from config import SPORT_TYPE
 
 
 @pytest.fixture()
@@ -837,17 +838,17 @@ def test_count_estimating_teams_soccer_full_label(mock_connectors):
     """Soccer sport_type is stored as the full Other-Events label, not just 'Soccer'."""
     exporter = ChurchTeamsExporter()
 
-    # Other-events registrations store the full option string verbatim
+    # Other-events registrations store the full SPORT_TYPE constant value verbatim
     roster_rows = [
-        {"Church Team": "RPC", "sport_type": "Soccer - Coed Exhibition", "sport_gender": "Mixed"}
+        {"Church Team": "RPC", "sport_type": SPORT_TYPE["SOCCER"], "sport_gender": "Mixed"}
         for _ in range(5)
     ] + [
-        {"Church Team": "TLC", "sport_type": "Soccer - Coed Exhibition", "sport_gender": "Mixed"}
+        {"Church Team": "TLC", "sport_type": SPORT_TYPE["SOCCER"], "sport_gender": "Mixed"}
         for _ in range(3)
     ]
 
     result = exporter._count_estimating_teams(
-        roster_rows, "Soccer - Coed Exhibition", min_team_size=4
+        roster_rows, SPORT_TYPE["SOCCER"], min_team_size=4
     )
     assert result["n_estimating"] == 1      # only RPC has >= 4
     assert result["n_potential"] == 2       # RPC + TLC both have >= 1

--- a/middleware/tests/test_church_teams_export.py
+++ b/middleware/tests/test_church_teams_export.py
@@ -631,3 +631,131 @@ def test_issue_based_reverse_partner_suggestion_handles_incomplete_roster_data(m
 
     assert len(issue_rows) == 1
     assert "perhaps Long Chung listed you as partner." in issue_rows[0]["Issue Description"]
+
+
+def test_contacts_status_tab_includes_sports_registered_column(mock_connectors, tmp_path):
+    exporter = ChurchTeamsExporter()
+    filepath = tmp_path / "church-report.xlsx"
+
+    contacts_rows = [
+        {
+            "Church Team": "RPC",
+            "ChMeetings ID": "101",
+            "First Name": "Alice",
+            "Last Name": "Nguyen",
+            "Is_Participant": "Yes",
+            "Is_Member_ChM": "Yes",
+            "Participant ID (WP)": 42,
+            "Approval_Status (WP)": "pending",
+            "Total_Open_ERRORs (WP)": 0,
+            "Gender": "Female",
+            "Birthdate": "2000-01-02",
+            "Age (at Event)": 26,
+            "Mobile Phone": "555-0101",
+            "Email": "alice@test.com",
+            "Registration Date (WP)": "2026-03-01",
+            "Athlete Fee": 30,
+            "First_Open_ERROR_Desc (WP)": "",
+            "Box 1": "", "Box 2": "", "Box 3": "", "Box 4": "", "Box 5": "", "Box 6": "",
+            "Photo URL (WP)": "N/A",
+            "Update_on_ChM": "2026-05-08",
+        },
+        {
+            "Church Team": "RPC",
+            "ChMeetings ID": "102",
+            "First Name": "Bob",
+            "Last Name": "Tran",
+            "Is_Participant": "Yes",
+            "Is_Member_ChM": "Yes",
+            "Participant ID (WP)": 99,
+            "Approval_Status (WP)": "approved",
+            "Total_Open_ERRORs (WP)": 0,
+            "Gender": "Male",
+            "Birthdate": "1998-05-10",
+            "Age (at Event)": 28,
+            "Mobile Phone": "555-0202",
+            "Email": "bob@test.com",
+            "Registration Date (WP)": "2026-03-02",
+            "Athlete Fee": 30,
+            "First_Open_ERROR_Desc (WP)": "",
+            "Box 1": "", "Box 2": "", "Box 3": "", "Box 4": "", "Box 5": "", "Box 6": "",
+            "Photo URL (WP)": "N/A",
+            "Update_on_ChM": "2026-05-08",
+        },
+        # No matching roster entry
+        {
+            "Church Team": "RPC",
+            "ChMeetings ID": "103",
+            "First Name": "Carol",
+            "Last Name": "Pham",
+            "Is_Participant": "No",
+            "Is_Member_ChM": "Yes",
+            "Participant ID (WP)": None,
+            "Approval_Status (WP)": "",
+            "Total_Open_ERRORs (WP)": 0,
+            "Gender": "Female",
+            "Birthdate": "2003-09-15",
+            "Age (at Event)": 22,
+            "Mobile Phone": "555-0303",
+            "Email": "carol@test.com",
+            "Registration Date (WP)": "",
+            "Athlete Fee": "",
+            "First_Open_ERROR_Desc (WP)": "",
+            "Box 1": "", "Box 2": "", "Box 3": "", "Box 4": "", "Box 5": "", "Box 6": "",
+            "Photo URL (WP)": "N/A",
+            "Update_on_ChM": "2026-05-08",
+        },
+    ]
+    roster_rows = [
+        # Alice plays two sports
+        {
+            "Church Team": "RPC", "ChMeetings ID": "101", "Participant ID (WP)": 42,
+            "sport_type": "Badminton", "sport_gender": "Women", "sport_format": "Doubles",
+        },
+        {
+            "Church Team": "RPC", "ChMeetings ID": "101", "Participant ID (WP)": 42,
+            "sport_type": "Basketball", "sport_gender": "", "sport_format": "",
+        },
+        # Bob plays one sport; duplicate roster row should not duplicate the label
+        {
+            "Church Team": "RPC", "ChMeetings ID": "102", "Participant ID (WP)": 99,
+            "sport_type": "Volleyball", "sport_gender": "Men", "sport_format": "",
+        },
+        {
+            "Church Team": "RPC", "ChMeetings ID": "102", "Participant ID (WP)": 99,
+            "sport_type": "Volleyball", "sport_gender": "Men", "sport_format": "",
+        },
+    ]
+    summary_rows = [{
+        "Church Code": "RPC",
+        "Total Members (ChM Team Group)": 3,
+        "Total Participants (in WP)": 2,
+        "Total Approved (WP)": 1,
+        "Total Pending Approval (WP)": 1,
+        "Total Denied (WP)": 0,
+        "Total Participants w/ Open ERRORs (WP)": 0,
+        "Total Open Individual ERRORs (WP)": 0,
+        "Total Open TEAM ERRORs (WP)": 0,
+        "Total Open WARNINGs (WP)": 0,
+        "Total Sports w/ Open TEAM Issues (WP)": 0,
+        "Latest ChM Record Update for Team": "2026-05-08",
+    }]
+
+    exporter._write_excel_report(filepath, summary_rows, contacts_rows, roster_rows, [])
+
+    contacts_df = pd.read_excel(filepath, sheet_name="Contacts-Status")
+    assert "Sports Registered" in contacts_df.columns
+
+    # Column must appear immediately before "Athlete Fee"
+    cols = list(contacts_df.columns)
+    assert cols.index("Sports Registered") == cols.index("Athlete Fee") - 1
+
+    alice_row = contacts_df[contacts_df["First Name"] == "Alice"].iloc[0]
+    sports = [s.strip() for s in alice_row["Sports Registered"].split(",")]
+    assert sorted(sports) == sorted(["Badminton Women Doubles", "Basketball"])
+
+    bob_row = contacts_df[contacts_df["First Name"] == "Bob"].iloc[0]
+    assert bob_row["Sports Registered"] == "Volleyball Men"
+
+    carol_row = contacts_df[contacts_df["First Name"] == "Carol"].iloc[0]
+    assert carol_row["Sports Registered"] == "" or pd.isna(carol_row["Sports Registered"])


### PR DESCRIPTION
## Summary

- **Issue #82** — Added `Sports Registered` column to Contacts-Status tab
- **Issue #83** — Added `Venue-Estimator` tab (renamed from Venue-Capacity) to the ALL export covering all 11 Sports Fest events (5 team + 6 racquet); snapshot note moved to bottom; Soccer zeros bug fixed (Other Events label stored verbatim); magic strings replaced with `SPORT_TYPE` constants
- **Issue #75** — Added `audit-team-groups --remove-orphans`; corrected false "Removed: 21/21" reporting to distinguish confirmed removals from stuck records (ChMeetings bug ticket **#20188**); stuck orphans now logged with ticket reference
- **Gender bug** — Fixed `Basketball Mixed Team` appearing in output due to case-insensitive comparison failure in `sync/participants.py`
- **`SPORT_TYPE["SOCCER"]`** added to config; Soccer added to `SPORT_BY_CATEGORY["TEAM"]` and `COURT_ESTIMATE_EVENTS`
- Per-sport minutes constants (`COURT_ESTIMATE_MINUTES_*`) and `COURT_ESTIMATE_MINUTES_PER_GAME` lookup dict added to config.py
- USAGE.md updated for `--remove-orphans`; CHANGELOG updated throughout

## Test plan

- [x] 159 mock-mode tests passing
- [x] Live export run confirmed — 11-row Venue-Estimator tab, Soccer counts correct
- [x] Live `audit-team-groups --remove-orphans` run — 21 stuck orphans correctly reported
- [x] Issues #75, #82, #83 closed

---
_Generated by [Claude Code](https://claude.ai/code/session_01UQGS4hZuFWs92dxsfde6Qa)_