### PR TITLE
Scheduling pipeline: solver, renderer, and #97 follow-up improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,6 @@
   - 8 solver tests removed (C5/C8/C9); 1 new test added (`test_solve_playoff_slots_passed_through`); 22 tests total
 
 ### Bug Fixes
-  - An unrecognised slot label (e.g. `"Sun-2-14:00"` in a pool that has no Sun-2 resources) logs a warning and is silently skipped rather than crashing
-  - 4 new tests: `earliest_slot` respected, `latest_slot` respected, inverted window → INFEASIBLE, unknown label → ignored
 - Fixed C6 min-rest constraint incorrectly spanning day boundaries — resolves issue #97 A1
   - Global slot indices are contiguous across days, so the last slot of Sat-1 and the first slot of Sun-1 were treated as "adjacent" and a team was falsely forbidden from playing both
   - Added `global_to_day` map in `_solve_one_pool()`; C6 `AddBoolOr` is now skipped when the two adjacent global indices belong to different days

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Bug Fixes
+- Fixed C6 min-rest constraint incorrectly spanning day boundaries — resolves issue #97 A1
+  - Global slot indices are contiguous across days, so the last slot of Sat-1 and the first slot of Sun-1 were treated as "adjacent" and a team was falsely forbidden from playing both
+  - Added `global_to_day` map in `_solve_one_pool()`; C6 `AddBoolOr` is now skipped when the two adjacent global indices belong to different days
+  - Added regression test `test_solve_c6_min_rest_does_not_span_day_boundary`
+
 ### New Features
 - Refactored `solve-schedule` to decompose by resource-type pool — closes issue #93 comment (pool decomposition requirement from live-run testing)
   - Games are partitioned by `resource_type` and each pool runs an independent CP-SAT solve; a Badminton Court shortage no longer cascades into INFEASIBLE for Gym Courts or Tennis

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## Unreleased
 
 ### New Features
-- Added `python main.py export-schedule [--input …] [--schedule-input …] [--output …]` Excel schedule renderer — closes [#94](https://github.com/i12know/vaysf/issues/94)
-  - Reads `schedule_output.json` (produced by `solve-schedule`) and `schedule_input.json` (produced by `export-church-teams`), writes `VAYSF_Schedule_YYYY-MM-DD.xlsx` to `EXPORT_DIR`
+- Added `python main.py produce-schedule [--input …] [--constraint …] [--output …]` Excel schedule renderer — closes [#94](https://github.com/i12know/vaysf/issues/94)
+  - Reads `schedule_output.json` (produced by `solve-schedule`) via `--input` and `schedule_input.json` (produced by `export-church-teams`) via `--constraint`, writes `VAYSF_Schedule_YYYY-MM-DD.xlsx` to `EXPORT_DIR`
   - **Schedule-by-Time** tab: grid view (rows = time slots, columns = courts), color-coded by sport (brown = Basketball, blue = VB Men, pink = VB Women), title row merged, column headers from first session resources, session section headers in grey, blank row between sessions, freeze at A3
   - **Schedule-by-Sport** tab: flat list sorted by event → stage order (Pool < R1 < QF < Semi < Final < 3rd) → round → slot, auto-filter, freeze at A2, unscheduled section in red at bottom when applicable, snapshot note at bottom of both tabs
   - Both tabs carry a snapshot line: `Generated: … | Status: … | Scheduled: N | Unscheduled: N`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,9 @@
   - Volleyball Women now uses the same 2-game/team baseline as Basketball and Volleyball Men
   - `Venue-Estimator` now shows target vs actual pool games/team, pool composition, and BYE slots so the workbook matches the generated pool policy
   - `docs/SCHEDULING.md` now correctly states that `earliest_slot` / `latest_slot` remain reserved fields and are not currently enforced by the solver
+- Added command-level and local pipeline regression coverage for scheduling commands
+  - New `tests/test_main.py` covers `parse_args()`, default path resolution in `main.py`, and a local `export-church-teams -> solve-schedule -> produce-schedule` happy path using a repo-local fake export artifact
+  - This closes the remaining `#97` testing gaps around CLI wiring (C1) and a deterministic end-to-end scheduling pipeline check (C2)
 
 
 - Added `--remove-orphans` flag to `python main.py audit-team-groups`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 ## Unreleased
 
 ### Bug Fixes
+- Implemented C8 per-game time-window constraints — resolves issue #97 B1
+  - `earliest_slot` and `latest_slot` fields in `schedule_input.json` game objects are now enforced by the CP-SAT solver (`Add(gslot >= lo)` / `Add(gslot <= hi)` on the game's global slot IntVar)
+  - `SCHEDULE_STAGE_WINDOWS` dict added to `config.py`: maps `(event_name, stage)` to `(earliest_slot, latest_slot)` slot labels; pool/QF/Semi games are pinned to Weekend 1 (Sat-1/Sun-1), Finals/3rd to Weekend 2 (Sat-2 onward); edit this dict to move the finale block or add Bible Challenge windows
+  - `_build_gym_game_objects()` now reads `SCHEDULE_STAGE_WINDOWS` and populates `earliest_slot`/`latest_slot` on every game object instead of always emitting `None`
+  - An unrecognised slot label (e.g. `"Sun-2-14:00"` in a pool that has no Sun-2 resources) logs a warning and is silently skipped rather than crashing
+  - 4 new tests: `earliest_slot` respected, `latest_slot` respected, inverted window → INFEASIBLE, unknown label → ignored
 - Fixed C6 min-rest constraint incorrectly spanning day boundaries — resolves issue #97 A1
   - Global slot indices are contiguous across days, so the last slot of Sat-1 and the first slot of Sun-1 were treated as "adjacent" and a team was falsely forbidden from playing both
   - Added `global_to_day` map in `_solve_one_pool()`; C6 `AddBoolOr` is now skipped when the two adjacent global indices belong to different days

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 ## Unreleased
 
 ### New Features
+- Added `python main.py export-schedule [--input …] [--schedule-input …] [--output …]` Excel schedule renderer — closes [#94](https://github.com/i12know/vaysf/issues/94)
+  - Reads `schedule_output.json` (produced by `solve-schedule`) and `schedule_input.json` (produced by `export-church-teams`), writes `VAYSF_Schedule_YYYY-MM-DD.xlsx` to `EXPORT_DIR`
+  - **Schedule-by-Time** tab: grid view (rows = time slots, columns = courts), color-coded by sport (brown = Basketball, blue = VB Men, pink = VB Women), title row merged, column headers from first session resources, session section headers in grey, blank row between sessions, freeze at A3
+  - **Schedule-by-Sport** tab: flat list sorted by event → stage order (Pool < R1 < QF < Semi < Final < 3rd) → round → slot, auto-filter, freeze at A2, unscheduled section in red at bottom when applicable, snapshot note at bottom of both tabs
+  - Both tabs carry a snapshot line: `Generated: … | Status: … | Scheduled: N | Unscheduled: N`
+  - Implemented via `_build_schedule_output_flat_rows()` and `_write_schedule_output_report()` static methods on `ChurchTeamsExporter`
+  - 9 new tests covering flat-row count, field presence, sort order, time extraction, day display, empty input, tab presence, grid content, and unscheduled section
 - Added `python main.py solve-schedule [--input …] [--output …]` CP-SAT scheduler — closes [#93](https://github.com/i12know/vaysf/issues/93)
   - Reads `schedule_input.json` (produced by `export-church-teams`), solves a CP-SAT assignment model, writes `schedule_output.json`
   - Implements seven constraints: C1 (each game assigned to one slot/court), C2 (one game per slot/court, multi-slot aware), C3 (no team plays two games in the same slot), C4 (court-type routing — gym games to Gym Courts, racquet games to their matching resource type), C5 (stage ordering — Pool before Semi, Semi before Final via the `precedence` rules in the input), C6 (minimum rest — no team plays in adjacent global time slots), C7 (multi-slot games — duration > slot_minutes blocks consecutive slots)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,25 @@
 ## Unreleased
 
 ### New Features
+- Added `python main.py solve-schedule [--input …] [--output …]` CP-SAT scheduler — closes [#93](https://github.com/i12know/vaysf/issues/93)
+  - Reads `schedule_input.json` (produced by `export-church-teams`), solves a CP-SAT assignment model, writes `schedule_output.json`
+  - Implements seven constraints: C1 (each game assigned to one slot/court), C2 (one game per slot/court, multi-slot aware), C3 (no team plays two games in the same slot), C4 (court-type routing — gym games to Gym Courts, racquet games to their matching resource type), C5 (stage ordering — Pool before Semi, Semi before Final via the `precedence` rules in the input), C6 (minimum rest — no team plays in adjacent global time slots), C7 (multi-slot games — duration > slot_minutes blocks consecutive slots)
+  - Objective: pack games toward the earliest slots (minimize latest occupied global slot)
+  - Exit codes: 0 = OPTIMAL/FEASIBLE, 1 = INFEASIBLE, 2 = error (missing input or ortools not installed)
+  - Timeout configurable via `SCHEDULE_SOLVER_TIMEOUT` env var (default 30 s)
+  - Import guard: `from ortools.sat.python import cp_model` is inside the function so the module is importable without ortools
+  - 15 new tests in `middleware/tests/test_scheduler.py`
+- Hardened `schedule_input.json` contract for solver-ready team IDs, pool IDs, and gym resource selection — closes [#96](https://github.com/i12know/vaysf/issues/96)
+  - Pool games now carry stable placeholder team IDs (`BBM-P1-T1`, `BBM-P1-T2`, …) instead of `null`; the same ID is reused across all games involving that team so the solver can enforce C3 and C6 constraints in planning mode
+  - Teams are distributed into balanced pools of size `gpg + 1`; a full round-robin within each pool gives each team exactly `gpg` games
+  - Playoff games use explicit seed/winner references (`BBM-Seed-1`, `WIN-BBM-QF-1`, `WIN-BBM-Semi-1`, `LOSE-BBM-Semi-2`) rather than `null`
+  - Pool games now emit a non-empty `pool_id` (`"P1"`, `"P2"`, …); playoff/final games emit `""`
+  - `schedule_input.json` now includes `gym_court_scenario` (the explicit court count used); controlled by new `SCHEDULE_SOLVER_GYM_COURTS = 4` constant in `config.py` — change the constant to switch between 3/4/5-court scenarios without touching code
+  - `_build_schedule_input()` calls `_build_gym_resource_objects(SCHEDULE_SOLVER_GYM_COURTS)` explicitly instead of relying on the invisible `n_courts=4` default
+  - New helper `_make_pool_game_pairs()` encapsulates pool generation and team ID assignment
+  - 4 new tests; existing structure tests updated
+
+
 - Added `--remove-orphans` flag to `python main.py audit-team-groups`
   - After identifying each orphaned Team-group membership (person_id returns 404 from ChMeetings), the membership is deleted from the group via `DELETE /api/v1/groups/{group_id}/memberships/{person_id}`
   - Audit summary line now includes a `Removed: N/M (stuck/API-undeleteable: K)` count when removal is active; "stuck" records are ones where DELETE also returns 404 due to a ChMeetings platform bug (filed as ChMeetings support ticket **#20188** — follow up if stuck count remains non-zero after resolution)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,20 @@
 
 ## Unreleased
 
+### Breaking Changes / Refactor
+- Solver now handles **pool play only**; playoffs managed via Playoff-Slots tab in `venue_input.xlsx`
+  - Gym sport playoff games (QF/Semi/Final/3rd) removed from `schedule_input.json` `games` array — `_build_gym_game_objects()` now emits pool-play games only
+  - New `Playoff-Slots` tab in `venue_input.xlsx`: coordinators fill in one row per playoff game with columns `game_id`, `event`, `stage`, `resource_id`, `slot`; optional `team_a_id`, `team_b_id`, `duration_minutes`
+  - If the tab is absent, a `WARNING` is logged and `playoff_slots` is an empty list — no crash
+  - Playoff slots are stored in `schedule_input.json` under `"playoff_slots"` and merged into `schedule_output.json` `"assignments"` by the solver unchanged — last-minute changes require only editing the tab and re-running `produce-schedule` (no re-solve needed)
+  - Finale order is now controlled by row order in the Playoff-Slots tab rather than solver constraints
+  - Removed constraints C5 (stage ordering), C8 (per-game time windows), C9 (finale sequence) from the CP-SAT solver
+  - Removed config constants: `SCHEDULE_STAGE_WINDOWS`, `SCHEDULE_FINAL_SEQUENCE`, `GYM_SPORT_EVENTS`
+  - Removed methods: `_build_precedence_objects()`, `_build_sequence_objects()`; replaced with `_load_playoff_slots()`
+  - Updated `_write_schedule_input_tab()`: Precedence section replaced with Playoff-Slots section
+  - 8 solver tests removed (C5/C8/C9); 1 new test added (`test_solve_playoff_slots_passed_through`); 22 tests total
+
 ### Bug Fixes
-- Implemented C9 finale sequence constraint — exact cross-sport ordering for closing ceremony
-  - Added `SCHEDULE_FINAL_SEQUENCE` list to `config.py`: an ordered list of `(event_name, stage)` tuples specifying the exact back-to-back game order; default is VB Women → VB Men → Basketball finals
-  - `_build_sequence_objects()` converts consecutive pairs in the list into `{earlier_game_id, later_game_id}` rules emitted in `schedule_input.json` under `"sequence"`
-  - Solver C9: for each sequence rule where both game IDs appear in the same pool, `Add(game_global_slot[later] > game_global_slot[earlier])` enforces the declared order
-  - Cross-resource-type pairs (e.g. a pod sport followed by a gym sport) are routed to both pools; each pool's solver silently skips the rule for the absent game ID — handle these via exact-slot pinning in `SCHEDULE_STAGE_WINDOWS`
-  - 3 new tests: ordering respected, circular cycle → INFEASIBLE, cross-pool rule skipped gracefully
-- Implemented C8 per-game time-window constraints — resolves issue #97 B1
-  - `earliest_slot` and `latest_slot` fields in `schedule_input.json` game objects are now enforced by the CP-SAT solver (`Add(gslot >= lo)` / `Add(gslot <= hi)` on the game's global slot IntVar)
-  - `SCHEDULE_STAGE_WINDOWS` dict added to `config.py`: maps `(event_name, stage)` to `(earliest_slot, latest_slot)` slot labels; pool/QF/Semi games are pinned to Weekend 1 (Sat-1/Sun-1), Finals/3rd to Weekend 2 (Sat-2 onward); edit this dict to move the finale block or add Bible Challenge windows
-  - `_build_gym_game_objects()` now reads `SCHEDULE_STAGE_WINDOWS` and populates `earliest_slot`/`latest_slot` on every game object instead of always emitting `None`
   - An unrecognised slot label (e.g. `"Sun-2-14:00"` in a pool that has no Sun-2 resources) logs a warning and is silently skipped rather than crashing
   - 4 new tests: `earliest_slot` respected, `latest_slot` respected, inverted window → INFEASIBLE, unknown label → ignored
 - Fixed C6 min-rest constraint incorrectly spanning day boundaries — resolves issue #97 A1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,13 +56,17 @@
   - 15 new tests in `middleware/tests/test_scheduler.py`
 - Hardened `schedule_input.json` contract for solver-ready team IDs, pool IDs, and gym resource selection — closes [#96](https://github.com/i12know/vaysf/issues/96)
   - Pool games now carry stable placeholder team IDs (`BBM-P1-T1`, `BBM-P1-T2`, …) instead of `null`; the same ID is reused across all games involving that team so the solver can enforce C3 and C6 constraints in planning mode
-  - Teams are distributed into balanced pools of size `gpg + 1`; a full round-robin within each pool gives each team exactly `gpg` games
+  - Gym/team pool planning now uses deterministic templates instead of generic round-robin inference: `2` teams -> direct match, `3` -> RR-3, `4` -> 4-match matrix, `5` -> 5-match cycle, `6+` -> a 3/4-pool composition that keeps every team at exactly 2 pool games
   - Playoff games use explicit seed/winner references (`BBM-Seed-1`, `WIN-BBM-QF-1`, `WIN-BBM-Semi-1`, `LOSE-BBM-Semi-2`) rather than `null`
   - Pool games now emit a non-empty `pool_id` (`"P1"`, `"P2"`, …); playoff/final games emit `""`
   - `schedule_input.json` now includes `gym_court_scenario` (the explicit court count used); controlled by new `SCHEDULE_SOLVER_GYM_COURTS = 4` constant in `config.py` — change the constant to switch between 3/4/5-court scenarios without touching code
   - `_build_schedule_input()` calls `_build_gym_resource_objects(SCHEDULE_SOLVER_GYM_COURTS)` explicitly instead of relying on the invisible `n_courts=4` default
   - New helper `_make_pool_game_pairs()` encapsulates pool generation and team ID assignment
   - 4 new tests; existing structure tests updated
+- Normalized Layer 1 team-sport planning around exact two-game pool play
+  - Volleyball Women now uses the same 2-game/team baseline as Basketball and Volleyball Men
+  - `Venue-Estimator` now shows target vs actual pool games/team, pool composition, and BYE slots so the workbook matches the generated pool policy
+  - `docs/SCHEDULING.md` now correctly states that `earliest_slot` / `latest_slot` remain reserved fields and are not currently enforced by the solver
 
 
 - Added `--remove-orphans` flag to `python main.py audit-team-groups`
@@ -89,7 +93,7 @@
   - Game IDs are sequential placeholders (`BBM01`–`BBMnn` Basketball Men, `VBM01`–`VBMnn` Volleyball Men, `VBW01`–`VBWnn` Volleyball Women) — no actual team assignments or conflict enforcement
   - Games are color-coded: brown (Basketball), blue (Volleyball Men), pink (Volleyball Women)
   - Pool games are interleaved across sports (BBM01, VBM01, VBW01, BBM02, …) to balance court load
-  - Inputs summary row shows pool games/team, minutes/game, and 3rd-place flag; game count totals per sport shown on row 2
+  - Inputs summary row now shows target/actual pool games per team, minutes/game, and 3rd-place flag; row 2 shows actual pool-game totals plus pool composition
   - Falls back to 8 teams per sport when fewer than 2 estimating teams exist (planning mode)
   - **Excel-only planning artifact** — no data is written to WordPress `sf_schedules` until the OR-Tools scheduling review step
   - Tab is absent from per-church exports; only appears in the consolidated ALL export alongside `Venue-Estimator`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,23 @@
   - 8 solver tests removed (C5/C8/C9); 1 new test added (`test_solve_playoff_slots_passed_through`); 22 tests total
 
 ### Bug Fixes
+- Reserve manual playoff slots from the pool-play solver
+  - New `validate_playoff_slots()` validates each playoff row (real `resource_id`, real `slot` label, no duplicate court/slot) and extracts per-pool `blocked_slots` so the CP-SAT pool-play solver cannot place a pool game on a court/time already given to a playoff game
+  - New `ensure_unique_assignment_slots()` guards the merged output against collisions
+  - 2 new solver tests: pool game pushed off a reserved slot, duplicate playoff reservation raises
 - Fixed C6 min-rest constraint incorrectly spanning day boundaries — resolves issue #97 A1
   - Global slot indices are contiguous across days, so the last slot of Sat-1 and the first slot of Sun-1 were treated as "adjacent" and a team was falsely forbidden from playing both
   - Added `global_to_day` map in `_solve_one_pool()`; C6 `AddBoolOr` is now skipped when the two adjacent global indices belong to different days
   - Added regression test `test_solve_c6_min_rest_does_not_span_day_boundary`
 
 ### New Features
+- Added gym-mode venue modeling to `venue_input.xlsx` for gyms that can be configured one way or another but not both at once (e.g. 1 Basketball Court **or** 2 Volleyball Courts per time block)
+  - New `Exclusive Venue Group` column in the `Venue-Input` tab: rows sharing a group value compete for the same physical gym; `_load_venue_input_rows()` attaches the value to each resource object as `exclusive_group` (empty string when blank)
+  - New `Gym-Modes` tab: one row per gym with `Gym Name` and per-mode capacity columns (`Basketball Courts`, `Volleyball Courts`, `Badminton Courts`, `Pickleball Courts`, `Soccer Fields`)
+  - New `_load_gym_modes()` loader returns `{gym_name: {resource_type: courts_per_block}}`; trailing footer/note rows are ignored
+  - If the file or `Gym-Modes` tab is absent, a `WARNING` is logged and `gym_modes` is an empty dict — no crash (same graceful-degradation pattern as `Playoff-Slots`)
+  - `schedule_input.json` gains a top-level `gym_modes` object; the Schedule-Input tab gains a `GYM-MODES` section and an `exclusive_group` column in the Resources section
+  - 6 new tests covering the `Exclusive Venue Group` reader and the `Gym-Modes` loader
 - Refactored `solve-schedule` to decompose by resource-type pool — closes issue #93 comment (pool decomposition requirement from live-run testing)
   - Games are partitioned by `resource_type` and each pool runs an independent CP-SAT solve; a Badminton Court shortage no longer cascades into INFEASIBLE for Gym Courts or Tennis
   - New top-level status `PARTIAL` (some pools solved, some failed); exit code 1 covers PARTIAL/INFEASIBLE/UNKNOWN

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 ## Unreleased
 
 ### Bug Fixes
+- Implemented C9 finale sequence constraint — exact cross-sport ordering for closing ceremony
+  - Added `SCHEDULE_FINAL_SEQUENCE` list to `config.py`: an ordered list of `(event_name, stage)` tuples specifying the exact back-to-back game order; default is VB Women → VB Men → Basketball finals
+  - `_build_sequence_objects()` converts consecutive pairs in the list into `{earlier_game_id, later_game_id}` rules emitted in `schedule_input.json` under `"sequence"`
+  - Solver C9: for each sequence rule where both game IDs appear in the same pool, `Add(game_global_slot[later] > game_global_slot[earlier])` enforces the declared order
+  - Cross-resource-type pairs (e.g. a pod sport followed by a gym sport) are routed to both pools; each pool's solver silently skips the rule for the absent game ID — handle these via exact-slot pinning in `SCHEDULE_STAGE_WINDOWS`
+  - 3 new tests: ordering respected, circular cycle → INFEASIBLE, cross-pool rule skipped gracefully
 - Implemented C8 per-game time-window constraints — resolves issue #97 B1
   - `earliest_slot` and `latest_slot` fields in `schedule_input.json` game objects are now enforced by the CP-SAT solver (`Add(gslot >= lo)` / `Add(gslot <= hi)` on the game's global slot IntVar)
   - `SCHEDULE_STAGE_WINDOWS` dict added to `config.py`: maps `(event_name, stage)` to `(earliest_slot, latest_slot)` slot labels; pool/QF/Semi games are pinned to Weekend 1 (Sat-1/Sun-1), Finals/3rd to Weekend 2 (Sat-2 onward); edit this dict to move the finale block or add Bible Challenge windows

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 ## Unreleased
 
 ### New Features
+- Refactored `solve-schedule` to decompose by resource-type pool — closes issue #93 comment (pool decomposition requirement from live-run testing)
+  - Games are partitioned by `resource_type` and each pool runs an independent CP-SAT solve; a Badminton Court shortage no longer cascades into INFEASIBLE for Gym Courts or Tennis
+  - New top-level status `PARTIAL` (some pools solved, some failed); exit code 1 covers PARTIAL/INFEASIBLE/UNKNOWN
+  - `schedule_output.json` now includes `pool_results` array with per-pool `{resource_type, status, assignments, unscheduled, diagnostics?}`; diagnostics are attached to the failing pool rather than at the top level
+  - `produce-schedule` Schedule-by-Sport tab gains a **Pool Results** section showing per-pool status and shortage summaries when `pool_results` is present
+  - 4 new tests covering pool decomposition: `pool_results` always present, partial feasibility, two independent pools both optimal, partial exit code
 - Added `python main.py produce-schedule [--input …] [--constraint …] [--output …]` Excel schedule renderer — closes [#94](https://github.com/i12know/vaysf/issues/94)
   - Reads `schedule_output.json` (produced by `solve-schedule`) via `--input` and `schedule_input.json` (produced by `export-church-teams`) via `--constraint`, writes `VAYSF_Schedule_YYYY-MM-DD.xlsx` to `EXPORT_DIR`
   - **Schedule-by-Time** tab: grid view (rows = time slots, columns = courts), color-coded by sport (brown = Basketball, blue = VB Men, pink = VB Women), title row merged, column headers from first session resources, session section headers in grey, blank row between sessions, freeze at A3

--- a/docs/SCHEDULING.md
+++ b/docs/SCHEDULING.md
@@ -144,6 +144,14 @@ Output shape:
 }
 ```
 
+When the solver returns `INFEASIBLE`, `schedule_output.json` also includes an
+optional **`diagnostics`** array with lower-bound capacity summaries such as:
+
+- per-resource-type required slots vs available slots
+- per-event required slot estimates inside that shared resource pool
+
+Example use: `Badminton Court requires at least 24 slots, but only 20 are available`.
+
 ### Step 4 — Excel output (`produce-schedule`) — Issue #94 (done)
 
 ```bash

--- a/docs/SCHEDULING.md
+++ b/docs/SCHEDULING.md
@@ -38,25 +38,46 @@ Key constants that shape the output live in `config.py`:
 `SCHEDULE_SKETCH_SUNDAY_START`, `SCHEDULE_SKETCH_SUNDAY_LAST_GAME`,
 `COURT_ESTIMATE_DEFAULT_MINUTES_PER_GAME`, `GYM_RESOURCE_TYPE`.
 
-### Step 2 — `schedule_input.json` schema
+### Step 2 — `schedule_input.json` schema (hardened by Issue #96)
+
+The top-level object includes a `gym_court_scenario` field that records the
+explicit court count used to build the gym resources for this run.  Change
+`SCHEDULE_SOLVER_GYM_COURTS` in `config.py` (currently 4) to switch scenarios;
+do not rely on any default inside the code.
 
 Every **game object** looks like:
 
 ```json
 {
-  "game_id":          "BBM-P1-R2-G1",
+  "game_id":          "BBM-01",
   "event":            "Basketball - Men Team",
   "stage":            "Pool",
   "pool_id":          "P1",
-  "round":            2,
-  "team_a_id":        "ANH",
-  "team_b_id":        "GAC",
+  "round":            1,
+  "team_a_id":        "BBM-P1-T1",
+  "team_b_id":        "BBM-P1-T2",
   "duration_minutes": 60,
   "resource_type":    "Gym Court",
   "earliest_slot":    null,
   "latest_slot":      null
 }
 ```
+
+**`team_a_id` / `team_b_id` in planning mode:**
+- Pool games use stable placeholder IDs like `BBM-P1-T1`, `BBM-P1-T2`.
+  The same placeholder ID is reused across every game that team plays, so
+  the solver can enforce team-overlap (C3) and min-rest (C6) constraints
+  even before final church assignments are known.
+- Teams are grouped into balanced pools of size `gpg + 1` (full round-robin
+  within each pool gives each team exactly `gpg` games).
+- Playoff QF games use pool-seed references: `BBM-Seed-1`, `BBM-Seed-8`, etc.
+- Playoff Semi/Final/3rd games use winner/loser references:
+  `WIN-BBM-QF-1`, `WIN-BBM-Semi-1`, `LOSE-BBM-Semi-2`, etc.
+- `null` is never emitted; every game has non-null `team_a_id` and `team_b_id`.
+
+**`pool_id`:**
+- Non-empty string (`"P1"`, `"P2"`, …) for pool games.
+- Empty string `""` for all playoff/final games.
 
 Every **resource object** looks like:
 
@@ -72,35 +93,44 @@ Every **resource object** looks like:
 }
 ```
 
+**`gym_court_scenario`:** The number of gym courts used to build the `GYM-*`
+resources in this run.  Controlled by `SCHEDULE_SOLVER_GYM_COURTS` in
+`config.py`.  The solver reads this to know which scenario was selected —
+no hidden defaults.
+
 Every **precedence object** looks like:
 
 ```json
 {
-  "rule":          "stage_order",
+  "rule":          "All Pool before Semi",
   "event":         "Basketball - Men Team",
   "earlier_stage": "Pool",
-  "later_stage":   "Final"
+  "later_stage":   "Semi"
 }
 ```
 
 Field notes:
 - `resource_type` must match between game and resource; this is how the
-  solver knows which court pool to draw from.
-- `pool_id` is `""` for playoff/final games.
+  solver knows which court pool to draw from (C4 — court-type routing).
 - `earliest_slot` / `latest_slot` are optional hard windows per game
-  (`null` = unconstrained).
+  (`null` = unconstrained; wiring them up in the solver is a one-liner).
 - Gym sports (Basketball, Volleyball Men, Volleyball Women) use
   `GYM_RESOURCE_TYPE = "Gym Court"`. Pod sports each have their own
   `POD_RESOURCE_TYPE_*` constant.
 
-### Step 3 — CP-SAT solver (`solve-schedule`) — Issue #93
+### Step 3 — CP-SAT solver (`solve-schedule`) — Issue #93 (done)
 
 ```bash
-python main.py solve-schedule [--input path/to/schedule_input.json]
+python main.py solve-schedule [--input path/to/schedule_input.json] [--output path/to/schedule_output.json]
 ```
 
 Reads `schedule_input.json`, runs the OR-Tools CP-SAT model, writes
-`schedule_output.json` to `DATA_DIR`. Output shape:
+`schedule_output.json` to `DATA_DIR` (or `--output` path). Exit codes:
+0 = OPTIMAL/FEASIBLE, 1 = INFEASIBLE, 2 = error (bad input or ortools missing).
+
+Configurable timeout via `SCHEDULE_SOLVER_TIMEOUT` env var (default: 30 s).
+
+Output shape:
 
 ```json
 {
@@ -130,6 +160,23 @@ Reads `schedule_output.json`, writes `VAYSF_Schedule_YYYY-MM-DD.xlsx` to
 
 The JSON file stays in `DATA_DIR` as the machine-readable backup.
 
+**Constraints implemented in `scheduler.py`:**
+
+| ID | Constraint | CP-SAT construct |
+|----|-----------|-----------------|
+| C1 | Each game assigned to exactly one (resource, start_slot) | `AddExactlyOne` |
+| C2 | Each (resource, slot) hosts at most one game (multi-slot aware) | `AddAtMostOne` |
+| C3 | No team plays two games in the same time slot | `AddAtMostOne` per (team, slot_label) |
+| C4 | Court-type routing — game assigned only to matching `resource_type` | filter before building vars |
+| C5 | Stage ordering — earlier_stage games precede later_stage games | pairwise `Add(g_l_slot > g_e_slot)` on global slot IntVars |
+| C6 | Minimum rest — no team plays in two adjacent global slots | `AddBoolOr([v1.Not(), v2.Not()])` for adjacent slot pairs |
+| C7 | Multi-slot games — duration > slot_minutes blocks consecutive slots | restrict start positions; expand slot_occupancy |
+
+**Out of scope (future work):**
+- Cross-sport participant conflicts (person in both Basketball and Badminton).
+- Church-requested blackout windows (`earliest_slot` / `latest_slot` fields
+  already in the schema — wiring them up is a one-liner).
+
 ---
 
 ## OR-Tools POC — What Was Proven
@@ -154,31 +201,19 @@ validated the `schedule_input.json` schema. Full findings are in
 
 ## Constraint Gaps (POC → Production)
 
-The POC modelled only Basketball Men pool play. Five constraints are still
-missing and must be added in Issue #93:
+All five constraints identified in the POC report have been implemented in
+`middleware/scheduler.py` (Issue #93).  See the constraint table in the
+Step 3 section above.
 
-1. **Court-type routing.** Basketball games must be assigned to `Gym Court`
-   resources; racquet games to their respective `POD_RESOURCE_TYPE_*` courts.
-   Fix: filter the court pool by `resource_type` before building variables.
+Remaining future work (out of scope for Issue #93):
 
-2. **Stage ordering.** Playoff games must be scheduled after all pool games
-   finish. Fix: use the `precedence` list from `schedule_input.json` to add
-   `model.Add(playoff_slot > max_pool_slot)` constraints.
-
-3. **Session windowing.** Games must fall within the open/close window of
-   their resource. The POC hard-coded `Sat-1 08:00–20:00`; the full solver
-   must read `open_time`/`close_time` per resource object and restrict the
-   slot domain accordingly.
-
-4. **Minimum rest between games.** A team that plays at slot T should not
-   play again at slot T+1. Fix: for each team, add `AddAtMostOne` over
-   consecutive-slot pairs.
-
-5. **Multi-slot games.** A 60-min game in a 30-min slot resolution blocks 2
-   consecutive slots on the same court. Fix: use `model.NewIntervalVar` (or
-   keep slot resolution == game duration within each sport, which is the
-   current approach and works as long as all games in a sport share the same
-   duration).
+- **Cross-sport participant conflicts.** A person registered for both
+  Basketball and Badminton must not have games at the same time.  Requires
+  a participant → games mapping (from roster data), which is not yet in
+  `schedule_input.json`.
+- **Church-requested blackout windows.** `earliest_slot` / `latest_slot`
+  fields are already in the game schema.  Wiring them up in the solver
+  is a one-liner once they are populated upstream.
 
 ---
 

--- a/docs/SCHEDULING.md
+++ b/docs/SCHEDULING.md
@@ -126,31 +126,65 @@ python main.py solve-schedule [--input path/to/schedule_input.json] [--output pa
 
 Reads `schedule_input.json`, runs the OR-Tools CP-SAT model, writes
 `schedule_output.json` to `DATA_DIR` (or `--output` path). Exit codes:
-0 = OPTIMAL/FEASIBLE, 1 = INFEASIBLE, 2 = error (bad input or ortools missing).
+0 = OPTIMAL/FEASIBLE (all pools solved), 1 = PARTIAL/INFEASIBLE/UNKNOWN, 2 = error.
 
 Configurable timeout via `SCHEDULE_SOLVER_TIMEOUT` env var (default: 30 s).
+
+**Pool decomposition:** games are partitioned by `resource_type` and solved in
+independent CP-SAT models. A capacity shortage in one pool (e.g. Badminton Court)
+does not cascade into an INFEASIBLE result for other pools (e.g. Gym Courts).
+Top-level `status` values:
+
+| Status | Meaning |
+|--------|---------|
+| `OPTIMAL` | Every pool solved optimally |
+| `FEASIBLE` | Every pool solved (at least one FEASIBLE) |
+| `PARTIAL` | At least one pool solved; at least one pool failed |
+| `INFEASIBLE` | No pools produced any assignments |
+| `UNKNOWN` | Timeout with no solution found |
 
 Output shape:
 
 ```json
 {
   "solved_at": "...",
-  "status": "OPTIMAL",
-  "solver_wall_seconds": 0.4,
+  "status": "PARTIAL",
+  "solver_wall_seconds": 1.2,
   "assignments": [
-    {"game_id": "BBM-P1-R2-G1", "resource_id": "GYM-Sat-1-1", "slot": "Sat-1-09:00"}
+    {"game_id": "BBM-01", "resource_id": "GYM-Sat-1-1", "slot": "Sat-1-09:00"}
   ],
-  "unscheduled": []
+  "unscheduled": ["BAD-01", "BAD-02"],
+  "pool_results": [
+    {
+      "resource_type": "Gym Court",
+      "status": "OPTIMAL",
+      "solver_wall_seconds": 0.4,
+      "assignments": [...],
+      "unscheduled": []
+    },
+    {
+      "resource_type": "Badminton Court",
+      "status": "INFEASIBLE",
+      "solver_wall_seconds": 0.8,
+      "assignments": [],
+      "unscheduled": ["BAD-01", "BAD-02"],
+      "diagnostics": [
+        {
+          "resource_type": "Badminton Court",
+          "required_slots": 24,
+          "available_slots": 20,
+          "shortage_slots": 4,
+          "events": [...]
+        }
+      ]
+    }
+  ]
 }
 ```
 
-When the solver returns `INFEASIBLE`, `schedule_output.json` also includes an
-optional **`diagnostics`** array with lower-bound capacity summaries such as:
-
-- per-resource-type required slots vs available slots
-- per-event required slot estimates inside that shared resource pool
-
-Example use: `Badminton Court requires at least 24 slots, but only 20 are available`.
+When a pool returns `INFEASIBLE` or `UNKNOWN`, its entry in `pool_results`
+includes a **`diagnostics`** array with lower-bound capacity summaries
+(required slots vs available slots per resource type and per event).
 
 ### Step 4 — Excel output (`produce-schedule`) — Issue #94 (done)
 

--- a/docs/SCHEDULING.md
+++ b/docs/SCHEDULING.md
@@ -30,11 +30,40 @@ alongside the xlsx) containing:
   (Basketball, VB Men, VB Women); pod sports (single-elimination) are also
   included here for solver assignment.
 - **`resources`** — one object per physical court or table, expanded from
-  `venue_input.xlsx` quantities, each annotated with day and time window.
+  `venue_input.xlsx` quantities, each annotated with day, time window, and
+  `exclusive_group` (see below).
 - **`playoff_slots`** — pre-assigned playoff games loaded from the
   **Playoff-Slots** tab of `venue_input.xlsx` (see below).  If the tab is
   absent, a `WARNING` is logged and `playoff_slots` is an empty list — the
   pipeline does not crash.
+- **`gym_modes`** — per-gym mode capacities loaded from the **Gym-Modes**
+  tab of `venue_input.xlsx` (see below).  If the tab is absent, a `WARNING`
+  is logged and `gym_modes` is an empty dict — the pipeline does not crash.
+
+**`Exclusive Venue Group` column** (`venue_input.xlsx` → `Venue-Input` tab):
+
+A physical gym can often be configured one way *or* another but not both at
+once — e.g. 1 Basketball Court **or** 2 Volleyball Courts per time block.
+Add one Venue-Input row per mode and tag every row for the same physical gym
+with the same `Exclusive Venue Group` value.  Rows that share a group value
+compete for that one gym.  Leave the column blank for standalone resources.
+
+**Gym-Modes tab** (`venue_input.xlsx` → sheet `Gym-Modes`):
+
+Records the capacity-per-mode coefficients used by the gym-mode capacity
+estimator.  One row per gym.  Columns:
+
+| Column | Example | Notes |
+|--------|---------|-------|
+| `Gym Name` | `Midsize Gym` | Physical gym identifier |
+| `Basketball Courts` | `1` | Courts yielded in BB mode per time block |
+| `Volleyball Courts` | `2` | Courts yielded in VB mode per time block |
+| `Badminton Courts` | `6` | Courts yielded in BM mode per time block |
+| `Pickleball Courts` | `8` | Courts yielded in PB mode per time block |
+| `Soccer Fields` | `1` | Fields yielded in Soccer mode per time block |
+
+`0` means the mode is not available in that gym.  A trailing footer/note row
+(text in `Gym Name`, no capacities) is ignored.
 
 **Playoff-Slots tab** (`venue_input.xlsx` → sheet `Playoff-Slots`):
 
@@ -103,15 +132,20 @@ Every **resource object** looks like:
 
 ```json
 {
-  "resource_id":   "GYM-Sat-1-1",
-  "resource_type": "Gym Court",
-  "label":         "Court-1",
-  "day":           "Sat-1",
-  "open_time":     "08:00",
-  "close_time":    "21:00",
-  "slot_minutes":  60
+  "resource_id":     "GYM-Sat-1-1",
+  "resource_type":   "Gym Court",
+  "label":           "Court-1",
+  "day":             "Sat-1",
+  "open_time":       "08:00",
+  "close_time":      "21:00",
+  "slot_minutes":    60,
+  "exclusive_group": "Midsize Gym"
 }
 ```
+
+`exclusive_group` is the `Exclusive Venue Group` value from `venue_input.xlsx`
+(empty string for standalone resources, or for gym courts built from the
+`SCHEDULE_SOLVER_GYM_COURTS` scenario).
 
 Every **playoff_slot object** looks like:
 
@@ -124,6 +158,22 @@ Every **playoff_slot object** looks like:
   "slot":        "Sat-2-14:00"
 }
 ```
+
+The top-level **`gym_modes`** object maps each gym to its capacity per mode:
+
+```json
+{
+  "Midsize Gym": {
+    "Basketball Court": 1,
+    "Volleyball Court": 2,
+    "Badminton Court":  6,
+    "Pickleball Court": 8,
+    "Soccer Field":     1
+  }
+}
+```
+
+It is an empty object when the Gym-Modes tab is absent.
 
 **`gym_court_scenario`:** The number of gym courts used to build the `GYM-*`
 resources in this run.  Controlled by `SCHEDULE_SOLVER_GYM_COURTS` in

--- a/docs/SCHEDULING.md
+++ b/docs/SCHEDULING.md
@@ -216,7 +216,7 @@ The JSON file stays in `DATA_DIR` as the machine-readable backup.
 | C3 | No team plays two games in the same time slot | `AddAtMostOne` per (team, slot_label) |
 | C4 | Court-type routing — game assigned only to matching `resource_type` | filter before building vars |
 | C5 | Stage ordering — earlier_stage games precede later_stage games | pairwise `Add(g_l_slot > g_e_slot)` on global slot IntVars |
-| C6 | Minimum rest — no team plays in two adjacent global slots | `AddBoolOr([v1.Not(), v2.Not()])` for adjacent slot pairs |
+| C6 | Minimum rest — no team plays in two adjacent global slots (within the same day only; cross-day pairs are skipped) | `AddBoolOr([v1.Not(), v2.Not()])` for same-day adjacent slot pairs |
 | C7 | Multi-slot games — duration > slot_minutes blocks consecutive slots | restrict start positions; expand slot_occupancy |
 
 **Out of scope (future work):**

--- a/docs/SCHEDULING.md
+++ b/docs/SCHEDULING.md
@@ -120,8 +120,11 @@ Every **game object** (pool play only) looks like:
   The same placeholder ID is reused across every game that team plays, so
   the solver can enforce team-overlap (C3) and min-rest (C6) constraints
   even before final church assignments are known.
-- Teams are grouped into balanced pools of size `gpg + 1` (full round-robin
-  within each pool gives each team exactly `gpg` games).
+- Team sports currently use a deterministic normalized pool format for
+  planning: `2` teams -> direct match, `3` -> 3-team round robin,
+  `4` -> fixed 4-match matrix, `5` -> fixed 5-match cycle, `6+` -> a
+  composition of 3-team and 4-team pools that keeps every team at exactly
+  `2` pool games.
 - `null` is never emitted; every game has non-null `team_a_id` and `team_b_id`.
 
 **`pool_id`:**
@@ -326,9 +329,9 @@ Remaining future work:
   a participant → games mapping (from roster data), which is not yet in
   `schedule_input.json`.
 - **Pool play time windows.** `earliest_slot` / `latest_slot` fields are
-  enforced by the solver via `Add(gslot >= lo)` / `Add(gslot <= hi)` on each
-  game's global slot variable.  Stage windows are configured in
-  `SCHEDULE_STAGE_WINDOWS` in `config.py`.
+  present in the schema but are currently emitted as `null` and are not
+  enforced by the solver. Restore a C8-style constraint only after upstream
+  data starts populating real pool-game blackout or window values.
 
 ---
 

--- a/docs/SCHEDULING.md
+++ b/docs/SCHEDULING.md
@@ -146,14 +146,19 @@ python main.py solve-schedule [--input path/to/schedule_input.json] [--output pa
 ```
 
 Reads `schedule_input.json`, runs the OR-Tools CP-SAT model for **pool play
-games only**, then merges pre-assigned `playoff_slots` from the input into the
-output.  Writes `schedule_output.json` to `DATA_DIR` (or `--output` path).
+games only**, reserves any manual `playoff_slots` from the same court/time
+inventory, then merges those playoff assignments into the output. Writes
+`schedule_output.json` to `DATA_DIR` (or `--output` path).
 Exit codes: 0 = OPTIMAL/FEASIBLE (all pools solved), 1 = PARTIAL/INFEASIBLE/UNKNOWN,
 2 = error.
 
-Playoff slots are passed through unchanged — the solver does not re-assign or
-validate them.  If `playoff_slots` is empty (tab missing from `venue_input.xlsx`),
-the output `assignments` array contains only pool play games.
+Playoff slots are not re-assigned by the solver, but they **are** validated
+against the resource list and reserved before pool play is packed. If a
+playoff row points at an unknown court, an invalid slot label, or duplicates an
+existing playoff reservation, `solve-schedule` fails loudly instead of emitting
+a silent collision. If `playoff_slots` is empty (tab missing from
+`venue_input.xlsx`), the output `assignments` array contains only pool play
+games.
 
 Configurable timeout via `SCHEDULE_SOLVER_TIMEOUT` env var (default: 30 s).
 

--- a/docs/SCHEDULING.md
+++ b/docs/SCHEDULING.md
@@ -291,8 +291,6 @@ re-running `produce-schedule` (no solver re-run needed).
 
 **Out of scope (future work):**
 - Cross-sport participant conflicts (person in both Basketball and Badminton).
-- Church-requested blackout windows for pool play (`earliest_slot` / `latest_slot`
-  fields are in the schema — wiring them up in the solver is a one-liner).
 
 ---
 
@@ -328,8 +326,9 @@ Remaining future work:
   a participant → games mapping (from roster data), which is not yet in
   `schedule_input.json`.
 - **Pool play time windows.** `earliest_slot` / `latest_slot` fields are
-  present in pool game objects.  Wiring them up in the solver is a one-liner
-  once they are populated upstream.
+  enforced by the solver via `Add(gslot >= lo)` / `Add(gslot <= hi)` on each
+  game's global slot variable.  Stage windows are configured in
+  `SCHEDULE_STAGE_WINDOWS` in `config.py`.
 
 ---
 

--- a/docs/SCHEDULING.md
+++ b/docs/SCHEDULING.md
@@ -39,7 +39,11 @@ Key constants that shape the output live in `config.py`:
 `COURT_ESTIMATE_DEFAULT_MINUTES_PER_GAME`, `GYM_RESOURCE_TYPE`,
 `SCHEDULE_STAGE_WINDOWS` (per-stage `earliest_slot`/`latest_slot` bounds written
 into every game object — edit this dict to move the finals block or pin pool
-rounds to Weekend 1).
+rounds to Weekend 1),
+`SCHEDULE_FINAL_SEQUENCE` (ordered list of `(event_name, stage)` tuples that
+determines the exact back-to-back order of the closing ceremony games — edit
+this list to reorder the finale; same-resource-type pairs are enforced by C9
+in the solver, cross-resource-type pairs require C8 exact-slot pinning).
 
 ### Step 2 — `schedule_input.json` schema (hardened by Issue #96)
 
@@ -222,6 +226,7 @@ The JSON file stays in `DATA_DIR` as the machine-readable backup.
 | C6 | Minimum rest — no team plays in two adjacent global slots (within the same day only; cross-day pairs are skipped) | `AddBoolOr([v1.Not(), v2.Not()])` for same-day adjacent slot pairs |
 | C7 | Multi-slot games — duration > slot_minutes blocks consecutive slots | restrict start positions; expand slot_occupancy |
 | C8 | Per-game time windows — `earliest_slot` / `latest_slot` from `schedule_input.json` | `Add(gslot >= lo)` / `Add(gslot <= hi)` on global slot IntVar |
+| C9 | Finale sequence — exact cross-sport ordering between named game IDs via `sequence` rules | pairwise `Add(g_l_slot > g_e_slot)` on global slot IntVars |
 
 **Out of scope (future work):**
 - Cross-sport participant conflicts (person in both Basketball and Badminton).

--- a/docs/SCHEDULING.md
+++ b/docs/SCHEDULING.md
@@ -36,7 +36,10 @@ alongside the xlsx) containing:
 Key constants that shape the output live in `config.py`:
 `SCHEDULE_SKETCH_SATURDAY_START`, `SCHEDULE_SKETCH_SATURDAY_LAST_GAME`,
 `SCHEDULE_SKETCH_SUNDAY_START`, `SCHEDULE_SKETCH_SUNDAY_LAST_GAME`,
-`COURT_ESTIMATE_DEFAULT_MINUTES_PER_GAME`, `GYM_RESOURCE_TYPE`.
+`COURT_ESTIMATE_DEFAULT_MINUTES_PER_GAME`, `GYM_RESOURCE_TYPE`,
+`SCHEDULE_STAGE_WINDOWS` (per-stage `earliest_slot`/`latest_slot` bounds written
+into every game object — edit this dict to move the finals block or pin pool
+rounds to Weekend 1).
 
 ### Step 2 — `schedule_input.json` schema (hardened by Issue #96)
 
@@ -218,6 +221,7 @@ The JSON file stays in `DATA_DIR` as the machine-readable backup.
 | C5 | Stage ordering — earlier_stage games precede later_stage games | pairwise `Add(g_l_slot > g_e_slot)` on global slot IntVars |
 | C6 | Minimum rest — no team plays in two adjacent global slots (within the same day only; cross-day pairs are skipped) | `AddBoolOr([v1.Not(), v2.Not()])` for same-day adjacent slot pairs |
 | C7 | Multi-slot games — duration > slot_minutes blocks consecutive slots | restrict start positions; expand slot_occupancy |
+| C8 | Per-game time windows — `earliest_slot` / `latest_slot` from `schedule_input.json` | `Add(gslot >= lo)` / `Add(gslot <= hi)` on global slot IntVar |
 
 **Out of scope (future work):**
 - Cross-sport participant conflicts (person in both Basketball and Badminton).

--- a/docs/SCHEDULING.md
+++ b/docs/SCHEDULING.md
@@ -12,7 +12,7 @@ and Claude sessions do not need to reverse-engineer the design from code.
 Step 1                  Step 2                  Step 3                  Step 4
 export-church-teams  →  schedule_input.json  →  solve-schedule       →  export-schedule
                         + Schedule-Input tab    schedule_output.json    VAYSF_Schedule_*.xlsx
-                        (Issue #87, done)       (Issue #93, open)       (Issue #94, open)
+                        (Issue #87, done)       (Issue #93, done)       (Issue #94, done)
 ```
 
 ### Step 1 — Build scheduling inputs (`export-church-teams`)
@@ -144,10 +144,10 @@ Output shape:
 }
 ```
 
-### Step 4 — Excel output (`export-schedule`) — Issue #94
+### Step 4 — Excel output (`export-schedule`) — Issue #94 (done)
 
 ```bash
-python main.py export-schedule [--input path/to/schedule_output.json]
+python main.py export-schedule [--input path/to/schedule_output.json] [--schedule-input path/to/schedule_input.json] [--output path/to/VAYSF_Schedule.xlsx]
 ```
 
 Reads `schedule_output.json`, writes `VAYSF_Schedule_YYYY-MM-DD.xlsx` to
@@ -237,7 +237,7 @@ The general workflow when a new scheduling rule is needed:
 |------|----------|
 | Schedule-Input implementation | Issue #87; `church_teams_export.py` → `_build_schedule_input()` |
 | OR-Tools POC | Issue #90; `middleware/scratch/ortools_poc.py` + `ortools_poc_report.md` |
-| CP-SAT solver module | Issue #93 (open) |
-| Excel schedule output | Issue #94 (open, depends on #93) |
+| CP-SAT solver module | Issue #93 (done); `middleware/scheduler.py` |
+| Excel schedule output | Issue #94 (done); `church_teams_export.py` → `_write_schedule_output_report()` |
 | Venue resource template | `middleware/data/venue_input.xlsx` (gitignored; template at `venue_input_template.xlsx`) |
 | Schedule config constants | `middleware/config.py` — `SCHEDULE_SKETCH_*`, `COURT_ESTIMATE_*`, `GYM_RESOURCE_TYPE`, `POD_RESOURCE_TYPE_*` |

--- a/docs/SCHEDULING.md
+++ b/docs/SCHEDULING.md
@@ -144,10 +144,10 @@ Output shape:
 }
 ```
 
-### Step 4 — Excel output (`export-schedule`) — Issue #94 (done)
+### Step 4 — Excel output (`produce-schedule`) — Issue #94 (done)
 
 ```bash
-python main.py export-schedule [--input path/to/schedule_output.json] [--schedule-input path/to/schedule_input.json] [--output path/to/VAYSF_Schedule.xlsx]
+python main.py produce-schedule [--input path/to/schedule_output.json] [--constraint path/to/schedule_input.json] [--output path/to/VAYSF_Schedule.xlsx]
 ```
 
 Reads `schedule_output.json`, writes `VAYSF_Schedule_YYYY-MM-DD.xlsx` to

--- a/docs/SCHEDULING.md
+++ b/docs/SCHEDULING.md
@@ -200,6 +200,11 @@ Reads `schedule_output.json`, writes `VAYSF_Schedule_YYYY-MM-DD.xlsx` to
 - **Schedule-by-Sport** — flat list with auto-filter, for sport directors
   checking their division.
 
+When one day mixes resources with different time windows or slot lengths
+(common for pod sports), **Schedule-by-Time** renders separate sections per
+uniform day/resource/window group so pod assignments are not collapsed into one
+misaligned `Day-1` grid.
+
 The JSON file stays in `DATA_DIR` as the machine-readable backup.
 
 **Constraints implemented in `scheduler.py`:**

--- a/docs/SCHEDULING.md
+++ b/docs/SCHEDULING.md
@@ -10,7 +10,7 @@ and Claude sessions do not need to reverse-engineer the design from code.
 
 ```
 Step 1                  Step 2                  Step 3                  Step 4
-export-church-teams  →  schedule_input.json  →  solve-schedule       →  export-schedule
+export-church-teams  →  schedule_input.json  →  solve-schedule       →  produce-schedule
                         + Schedule-Input tab    schedule_output.json    VAYSF_Schedule_*.xlsx
                         (Issue #87, done)       (Issue #93, done)       (Issue #94, done)
 ```
@@ -26,24 +26,40 @@ When `middleware/data/venue_input.xlsx` is present, the workbook also gets a
 **Schedule-Input** tab and a companion **`schedule_input.json`** (written
 alongside the xlsx) containing:
 
-- **`games`** — one object per match placeholder (pool rounds + playoff
-  bracket for gym sports; single-elimination bracket for pod sports).
+- **`games`** — one object per pool-play match placeholder for gym sports
+  (Basketball, VB Men, VB Women); pod sports (single-elimination) are also
+  included here for solver assignment.
 - **`resources`** — one object per physical court or table, expanded from
   `venue_input.xlsx` quantities, each annotated with day and time window.
-- **`precedence`** — stage-ordering rules (e.g. Pool must finish before
-  Semi-Final).
+- **`playoff_slots`** — pre-assigned playoff games loaded from the
+  **Playoff-Slots** tab of `venue_input.xlsx` (see below).  If the tab is
+  absent, a `WARNING` is logged and `playoff_slots` is an empty list — the
+  pipeline does not crash.
+
+**Playoff-Slots tab** (`venue_input.xlsx` → sheet `Playoff-Slots`):
+
+This is how you control the exact order and timing of QF/Semi/Final/3rd-place
+games.  Add one row per playoff game.  Required columns:
+
+| Column | Example | Notes |
+|--------|---------|-------|
+| `game_id` | `BBM-Final` | Unique identifier used in the schedule output |
+| `event` | `Basketball - Men Team` | Must match the event name exactly |
+| `stage` | `Final` | QF, Semi, Final, or 3rd |
+| `resource_id` | `GYM-Sat-2-1` | Must match a resource_id in the Resources section |
+| `slot` | `Sat-2-14:00` | Slot label in `Day-HH:MM` format |
+
+Optional columns: `team_a_id`, `team_b_id`, `duration_minutes`.
+
+To specify the exact finale order (e.g. VB Women → VB Men → Basketball back-to-back),
+simply put those games in that row order with consecutive `slot` values.  No solver
+constraints are needed — the timetable is the authority.
 
 Key constants that shape the output live in `config.py`:
 `SCHEDULE_SKETCH_SATURDAY_START`, `SCHEDULE_SKETCH_SATURDAY_LAST_GAME`,
 `SCHEDULE_SKETCH_SUNDAY_START`, `SCHEDULE_SKETCH_SUNDAY_LAST_GAME`,
 `COURT_ESTIMATE_DEFAULT_MINUTES_PER_GAME`, `GYM_RESOURCE_TYPE`,
-`SCHEDULE_STAGE_WINDOWS` (per-stage `earliest_slot`/`latest_slot` bounds written
-into every game object — edit this dict to move the finals block or pin pool
-rounds to Weekend 1),
-`SCHEDULE_FINAL_SEQUENCE` (ordered list of `(event_name, stage)` tuples that
-determines the exact back-to-back order of the closing ceremony games — edit
-this list to reorder the finale; same-resource-type pairs are enforced by C9
-in the solver, cross-resource-type pairs require C8 exact-slot pinning).
+`SCHEDULE_SOLVER_GYM_COURTS` (change to switch between 3/4/5-court scenarios).
 
 ### Step 2 — `schedule_input.json` schema (hardened by Issue #96)
 
@@ -52,7 +68,7 @@ explicit court count used to build the gym resources for this run.  Change
 `SCHEDULE_SOLVER_GYM_COURTS` in `config.py` (currently 4) to switch scenarios;
 do not rely on any default inside the code.
 
-Every **game object** looks like:
+Every **game object** (pool play only) looks like:
 
 ```json
 {
@@ -77,14 +93,11 @@ Every **game object** looks like:
   even before final church assignments are known.
 - Teams are grouped into balanced pools of size `gpg + 1` (full round-robin
   within each pool gives each team exactly `gpg` games).
-- Playoff QF games use pool-seed references: `BBM-Seed-1`, `BBM-Seed-8`, etc.
-- Playoff Semi/Final/3rd games use winner/loser references:
-  `WIN-BBM-QF-1`, `WIN-BBM-Semi-1`, `LOSE-BBM-Semi-2`, etc.
 - `null` is never emitted; every game has non-null `team_a_id` and `team_b_id`.
 
 **`pool_id`:**
 - Non-empty string (`"P1"`, `"P2"`, …) for pool games.
-- Empty string `""` for all playoff/final games.
+- Playoff games are not in `games` — they live in `playoff_slots`.
 
 Every **resource object** looks like:
 
@@ -100,27 +113,28 @@ Every **resource object** looks like:
 }
 ```
 
+Every **playoff_slot object** looks like:
+
+```json
+{
+  "game_id":     "BBM-Final",
+  "event":       "Basketball - Men Team",
+  "stage":       "Final",
+  "resource_id": "GYM-Sat-2-1",
+  "slot":        "Sat-2-14:00"
+}
+```
+
 **`gym_court_scenario`:** The number of gym courts used to build the `GYM-*`
 resources in this run.  Controlled by `SCHEDULE_SOLVER_GYM_COURTS` in
 `config.py`.  The solver reads this to know which scenario was selected —
 no hidden defaults.
 
-Every **precedence object** looks like:
-
-```json
-{
-  "rule":          "All Pool before Semi",
-  "event":         "Basketball - Men Team",
-  "earlier_stage": "Pool",
-  "later_stage":   "Semi"
-}
-```
-
 Field notes:
 - `resource_type` must match between game and resource; this is how the
   solver knows which court pool to draw from (C4 — court-type routing).
-- `earliest_slot` / `latest_slot` are optional hard windows per game
-  (`null` = unconstrained; wiring them up in the solver is a one-liner).
+- `earliest_slot` / `latest_slot` are present in pool game objects but
+  always `null` — they are reserved for future use.
 - Gym sports (Basketball, Volleyball Men, Volleyball Women) use
   `GYM_RESOURCE_TYPE = "Gym Court"`. Pod sports each have their own
   `POD_RESOURCE_TYPE_*` constant.
@@ -131,9 +145,15 @@ Field notes:
 python main.py solve-schedule [--input path/to/schedule_input.json] [--output path/to/schedule_output.json]
 ```
 
-Reads `schedule_input.json`, runs the OR-Tools CP-SAT model, writes
-`schedule_output.json` to `DATA_DIR` (or `--output` path). Exit codes:
-0 = OPTIMAL/FEASIBLE (all pools solved), 1 = PARTIAL/INFEASIBLE/UNKNOWN, 2 = error.
+Reads `schedule_input.json`, runs the OR-Tools CP-SAT model for **pool play
+games only**, then merges pre-assigned `playoff_slots` from the input into the
+output.  Writes `schedule_output.json` to `DATA_DIR` (or `--output` path).
+Exit codes: 0 = OPTIMAL/FEASIBLE (all pools solved), 1 = PARTIAL/INFEASIBLE/UNKNOWN,
+2 = error.
+
+Playoff slots are passed through unchanged — the solver does not re-assign or
+validate them.  If `playoff_slots` is empty (tab missing from `venue_input.xlsx`),
+the output `assignments` array contains only pool play games.
 
 Configurable timeout via `SCHEDULE_SOLVER_TIMEOUT` env var (default: 30 s).
 
@@ -158,34 +178,12 @@ Output shape:
   "status": "PARTIAL",
   "solver_wall_seconds": 1.2,
   "assignments": [
-    {"game_id": "BBM-01", "resource_id": "GYM-Sat-1-1", "slot": "Sat-1-09:00"}
+    {"game_id": "BBM-01",    "resource_id": "GYM-Sat-1-1", "slot": "Sat-1-09:00"},
+    {"game_id": "BBM-Final", "event": "Basketball - Men Team", "stage": "Final",
+     "resource_id": "GYM-Sat-2-1", "slot": "Sat-2-14:00"}
   ],
   "unscheduled": ["BAD-01", "BAD-02"],
-  "pool_results": [
-    {
-      "resource_type": "Gym Court",
-      "status": "OPTIMAL",
-      "solver_wall_seconds": 0.4,
-      "assignments": [...],
-      "unscheduled": []
-    },
-    {
-      "resource_type": "Badminton Court",
-      "status": "INFEASIBLE",
-      "solver_wall_seconds": 0.8,
-      "assignments": [],
-      "unscheduled": ["BAD-01", "BAD-02"],
-      "diagnostics": [
-        {
-          "resource_type": "Badminton Court",
-          "required_slots": 24,
-          "available_slots": 20,
-          "shortage_slots": 4,
-          "events": [...]
-        }
-      ]
-    }
-  ]
+  "pool_results": [...]
 }
 ```
 
@@ -207,6 +205,10 @@ Reads `schedule_output.json`, writes `VAYSF_Schedule_YYYY-MM-DD.xlsx` to
 - **Schedule-by-Sport** — flat list with auto-filter, for sport directors
   checking their division.
 
+Playoff assignments (which carry `event` and `stage` in the assignment object
+itself) are rendered alongside pool play assignments.  The renderer falls back
+to the assignment's own fields when a game_id is not in the `games` list.
+
 When one day mixes resources with different time windows or slot lengths
 (common for pod sports), **Schedule-by-Time** renders separate sections per
 uniform day/resource/window group so pod assignments are not collapsed into one
@@ -222,16 +224,20 @@ The JSON file stays in `DATA_DIR` as the machine-readable backup.
 | C2 | Each (resource, slot) hosts at most one game (multi-slot aware) | `AddAtMostOne` |
 | C3 | No team plays two games in the same time slot | `AddAtMostOne` per (team, slot_label) |
 | C4 | Court-type routing — game assigned only to matching `resource_type` | filter before building vars |
-| C5 | Stage ordering — earlier_stage games precede later_stage games | pairwise `Add(g_l_slot > g_e_slot)` on global slot IntVars |
 | C6 | Minimum rest — no team plays in two adjacent global slots (within the same day only; cross-day pairs are skipped) | `AddBoolOr([v1.Not(), v2.Not()])` for same-day adjacent slot pairs |
 | C7 | Multi-slot games — duration > slot_minutes blocks consecutive slots | restrict start positions; expand slot_occupancy |
-| C8 | Per-game time windows — `earliest_slot` / `latest_slot` from `schedule_input.json` | `Add(gslot >= lo)` / `Add(gslot <= hi)` on global slot IntVar |
-| C9 | Finale sequence — exact cross-sport ordering between named game IDs via `sequence` rules | pairwise `Add(g_l_slot > g_e_slot)` on global slot IntVars |
+
+**Playoff scheduling (not solver constraints):**
+Playoff game timing is controlled entirely by the Playoff-Slots tab in
+`venue_input.xlsx` — the exact slot and court for each QF/Semi/Final/3rd game
+is specified there by the coordinator.  The solver only packs pool play.
+Last-minute changes during the tournament are handled by editing the tab and
+re-running `produce-schedule` (no solver re-run needed).
 
 **Out of scope (future work):**
 - Cross-sport participant conflicts (person in both Basketball and Badminton).
-- Church-requested blackout windows (`earliest_slot` / `latest_slot` fields
-  already in the schema — wiring them up is a one-liner).
+- Church-requested blackout windows for pool play (`earliest_slot` / `latest_slot`
+  fields are in the schema — wiring them up in the solver is a one-liner).
 
 ---
 
@@ -257,19 +263,18 @@ validated the `schedule_input.json` schema. Full findings are in
 
 ## Constraint Gaps (POC → Production)
 
-All five constraints identified in the POC report have been implemented in
-`middleware/scheduler.py` (Issue #93).  See the constraint table in the
-Step 3 section above.
+Constraints C1–C4, C6, C7 are implemented in `middleware/scheduler.py`
+(Issue #93).  See the constraint table in the Step 3 section above.
 
-Remaining future work (out of scope for Issue #93):
+Remaining future work:
 
 - **Cross-sport participant conflicts.** A person registered for both
   Basketball and Badminton must not have games at the same time.  Requires
   a participant → games mapping (from roster data), which is not yet in
   `schedule_input.json`.
-- **Church-requested blackout windows.** `earliest_slot` / `latest_slot`
-  fields are already in the game schema.  Wiring them up in the solver
-  is a one-liner once they are populated upstream.
+- **Pool play time windows.** `earliest_slot` / `latest_slot` fields are
+  present in pool game objects.  Wiring them up in the solver is a one-liner
+  once they are populated upstream.
 
 ---
 
@@ -296,4 +301,4 @@ The general workflow when a new scheduling rule is needed:
 | CP-SAT solver module | Issue #93 (done); `middleware/scheduler.py` |
 | Excel schedule output | Issue #94 (done); `church_teams_export.py` → `_write_schedule_output_report()` |
 | Venue resource template | `middleware/data/venue_input.xlsx` (gitignored; template at `venue_input_template.xlsx`) |
-| Schedule config constants | `middleware/config.py` — `SCHEDULE_SKETCH_*`, `COURT_ESTIMATE_*`, `GYM_RESOURCE_TYPE`, `POD_RESOURCE_TYPE_*` |
+| Schedule config constants | `middleware/config.py` — `SCHEDULE_SKETCH_*`, `COURT_ESTIMATE_*`, `GYM_RESOURCE_TYPE`, `POD_RESOURCE_TYPE_*`, `SCHEDULE_SOLVER_GYM_COURTS` |

--- a/middleware/church_teams_export.py
+++ b/middleware/church_teams_export.py
@@ -55,6 +55,7 @@ from config import (
     POD_FIT_COLOR_RED,
     POD_FIT_YELLOW_MAX,
     SCHEDULE_STAGE_WINDOWS,
+    SCHEDULE_FINAL_SEQUENCE,
 )
 from validation.name_matcher import normalized_name as _norm_name
 from chmeetings.backend_connector import ChMeetingsConnector
@@ -1797,6 +1798,37 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
                     })
         return rules
 
+    @staticmethod
+    def _build_sequence_objects(
+        all_games: List[Dict[str, Any]],
+    ) -> List[Dict[str, Any]]:
+        """Return C9 ordering constraints from SCHEDULE_FINAL_SEQUENCE.
+
+        Consecutive (event, stage) pairs in the config list are converted to
+        {earlier_game_id, later_game_id} rules.  Only pairs where both game IDs
+        exist in all_games are emitted; cross-resource-type pairs where one game
+        is absent from a given pool are silently skipped by the solver.
+        """
+        game_id_by_event_stage: dict[tuple[str, str], list[str]] = {}
+        for g in all_games:
+            key = (g["event"], g["stage"])
+            game_id_by_event_stage.setdefault(key, []).append(g["game_id"])
+
+        rules: List[Dict[str, Any]] = []
+        for i in range(len(SCHEDULE_FINAL_SEQUENCE) - 1):
+            earlier_key = SCHEDULE_FINAL_SEQUENCE[i]
+            later_key   = SCHEDULE_FINAL_SEQUENCE[i + 1]
+            earlier_ids = game_id_by_event_stage.get(earlier_key, [])
+            later_ids   = game_id_by_event_stage.get(later_key, [])
+            for e_id in earlier_ids:
+                for l_id in later_ids:
+                    rules.append({
+                        "rule":            f"Finale order: {earlier_key[0]} {earlier_key[1]} before {later_key[0]} {later_key[1]}",
+                        "earlier_game_id": e_id,
+                        "later_game_id":   l_id,
+                    })
+        return rules
+
     def _build_schedule_input(
         self,
         roster_rows: List[Dict[str, Any]],
@@ -1821,6 +1853,7 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
         all_resources = gym_resources + pod_resources
 
         precedence = self._build_precedence_objects(gym_games)
+        sequence   = self._build_sequence_objects(all_games)
 
         return {
             "generated_at":       datetime.now().isoformat(timespec="seconds"),
@@ -1830,6 +1863,7 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
             "games":              all_games,
             "resources":          all_resources,
             "precedence":         precedence,
+            "sequence":           sequence,
         }
 
     @staticmethod

--- a/middleware/church_teams_export.py
+++ b/middleware/church_teams_export.py
@@ -54,8 +54,6 @@ from config import (
     POD_FIT_COLOR_YELLOW,
     POD_FIT_COLOR_RED,
     POD_FIT_YELLOW_MAX,
-    SCHEDULE_STAGE_WINDOWS,
-    SCHEDULE_FINAL_SEQUENCE,
 )
 from validation.name_matcher import normalized_name as _norm_name
 from chmeetings.backend_connector import ChMeetingsConnector
@@ -1524,14 +1522,14 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
     def _build_gym_game_objects(
         self, roster_rows: List[Dict[str, Any]]
     ) -> List[Dict[str, Any]]:
-        """Return game placeholder dicts for gym sports (Basketball, VB Men, VB Women).
+        """Return pool-play game placeholder dicts for gym sports (Basketball, VB Men, VB Women).
 
         Pool games carry stable placeholder team IDs (e.g. BBM-P1-T1, BBM-P1-T2)
         and non-empty pool_id values so the solver can enforce team-overlap and
         min-rest constraints even before final church assignments are known.
 
-        Playoff games use seed/winner references (e.g. BBM-Seed-1, WIN-BBM-QF-1)
-        rather than null, documenting the bracket dependency for the solver.
+        Playoff games (QF/Semi/Final/3rd) are pre-assigned via the Playoff-Slots
+        tab in venue_input.xlsx and are not included here.
         """
         sport_defs = [
             (SPORT_TYPE["BASKETBALL"],       "BBM"),
@@ -1539,7 +1537,6 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
             (SPORT_TYPE["VOLLEYBALL_WOMEN"], "VBW"),
         ]
         mpg = COURT_ESTIMATE_DEFAULT_MINUTES_PER_GAME
-        include_third = COURT_ESTIMATE_INCLUDE_THIRD_PLACE_GAME
         games: List[Dict[str, Any]] = []
 
         for event_name, prefix in sport_defs:
@@ -1549,15 +1546,10 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
             gpg = COURT_ESTIMATE_POOL_GAMES_PER_TEAM.get(
                 event_name, COURT_ESTIMATE_DEFAULT_POOL_GAMES_PER_TEAM
             )
-            s = self._compute_court_slots(n_teams, mpg, pool_games_per_team=gpg)
-            early_ids, final_ids = self._make_playoff_ids(
-                prefix, s["playoff_teams"], include_third
-            )
 
             # Pool games — stable team IDs and non-empty pool_id
             pool_pairs = self._make_pool_game_pairs(prefix, n_teams, gpg)
             for pair_idx, (team_a_id, team_b_id, pool_id) in enumerate(pool_pairs, start=1):
-                _pool_window = SCHEDULE_STAGE_WINDOWS.get((event_name, "Pool"), (None, None))
                 games.append({
                     "game_id": f"{prefix}-{pair_idx:02d}",
                     "event": event_name,
@@ -1568,64 +1560,8 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
                     "team_b_id": team_b_id,
                     "duration_minutes": mpg,
                     "resource_type": GYM_RESOURCE_TYPE,
-                    "earliest_slot": _pool_window[0],
-                    "latest_slot":   _pool_window[1],
-                })
-
-            # Early playoff games (QF, Semi) — seed/winner references
-            qf_count = 0
-            semi_count = 0
-            for i, gid in enumerate(early_ids, start=1):
-                stage = gid.split("-")[1]
-                if stage == "QF":
-                    qf_count += 1
-                    team_a_id = f"{prefix}-Seed-{qf_count}"
-                    team_b_id = f"{prefix}-Seed-{s['playoff_teams'] - qf_count + 1}"
-                else:  # Semi
-                    semi_count += 1
-                    if s["playoff_teams"] >= 8:
-                        team_a_id = f"WIN-{prefix}-QF-{(semi_count - 1) * 3 + 1}"
-                        team_b_id = f"WIN-{prefix}-QF-{(semi_count - 1) * 3 + 4}"
-                    else:
-                        team_a_id = f"{prefix}-Seed-{semi_count * 2 - 1}"
-                        team_b_id = f"{prefix}-Seed-{semi_count * 2}"
-                _early_window = SCHEDULE_STAGE_WINDOWS.get((event_name, stage), (None, None))
-                games.append({
-                    "game_id": gid,
-                    "event": event_name,
-                    "stage": stage,
-                    "pool_id": "",
-                    "round": i,
-                    "team_a_id": team_a_id,
-                    "team_b_id": team_b_id,
-                    "duration_minutes": mpg,
-                    "resource_type": GYM_RESOURCE_TYPE,
-                    "earliest_slot": _early_window[0],
-                    "latest_slot":   _early_window[1],
-                })
-
-            # Final games (Final and optional 3rd) — winner/loser references
-            for i, gid in enumerate(final_ids, start=1):
-                stage = gid.split("-")[1] if "-" in gid else "Final"
-                if stage == "Final":
-                    team_a_id = f"WIN-{prefix}-Semi-1"
-                    team_b_id = f"WIN-{prefix}-Semi-2"
-                else:  # 3rd place
-                    team_a_id = f"LOSE-{prefix}-Semi-1"
-                    team_b_id = f"LOSE-{prefix}-Semi-2"
-                _final_window = SCHEDULE_STAGE_WINDOWS.get((event_name, stage), (None, None))
-                games.append({
-                    "game_id": gid,
-                    "event": event_name,
-                    "stage": stage,
-                    "pool_id": "",
-                    "round": i,
-                    "team_a_id": team_a_id,
-                    "team_b_id": team_b_id,
-                    "duration_minutes": mpg,
-                    "resource_type": GYM_RESOURCE_TYPE,
-                    "earliest_slot": _final_window[0],
-                    "latest_slot":   _final_window[1],
+                    "earliest_slot": None,
+                    "latest_slot":   None,
                 })
 
         return games
@@ -1772,62 +1708,56 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
         return rows
 
     @staticmethod
-    def _build_precedence_objects(
-        gym_games: List[Dict[str, Any]]
-    ) -> List[Dict[str, Any]]:
-        """Return stage-ordering constraints: Pool → QF/Semi → Final → 3rd place."""
-        stage_pairs = [
-            ("Pool", "QF"),
-            ("Pool", "Semi"),
-            ("QF",   "Semi"),
-            ("Semi", "Final"),
-            ("Semi", "3rd"),
-            ("Final", "3rd"),
-        ]
-        rules: List[Dict[str, Any]] = []
-        events = sorted({g["event"] for g in gym_games})
-        for event in events:
-            stages_present = {g["stage"] for g in gym_games if g["event"] == event}
-            for earlier, later in stage_pairs:
-                if earlier in stages_present and later in stages_present:
-                    rules.append({
-                        "rule":          f"All {earlier} before {later}",
-                        "event":         event,
-                        "earlier_stage": earlier,
-                        "later_stage":   later,
-                    })
-        return rules
+    def _load_playoff_slots(venue_input_path: Path) -> List[Dict[str, Any]]:
+        """Load pre-assigned playoff game slots from the Playoff-Slots tab in venue_input.xlsx.
 
-    @staticmethod
-    def _build_sequence_objects(
-        all_games: List[Dict[str, Any]],
-    ) -> List[Dict[str, Any]]:
-        """Return C9 ordering constraints from SCHEDULE_FINAL_SEQUENCE.
-
-        Consecutive (event, stage) pairs in the config list are converted to
-        {earlier_game_id, later_game_id} rules.  Only pairs where both game IDs
-        exist in all_games are emitted; cross-resource-type pairs where one game
-        is absent from a given pool are silently skipped by the solver.
+        Returns an empty list (with a WARNING) if the file or tab is absent.
+        Expected columns: game_id, event, stage, resource_id, slot
+        Optional columns: team_a_id, team_b_id, duration_minutes
         """
-        game_id_by_event_stage: dict[tuple[str, str], list[str]] = {}
-        for g in all_games:
-            key = (g["event"], g["stage"])
-            game_id_by_event_stage.setdefault(key, []).append(g["game_id"])
+        if not venue_input_path.exists():
+            return []
+        try:
+            df = pd.read_excel(venue_input_path, sheet_name="Playoff-Slots", engine="openpyxl")
+        except Exception:
+            logger.warning(
+                "venue_input.xlsx is present but has no 'Playoff-Slots' tab — "
+                "playoff games will not appear in the schedule. "
+                "Add a 'Playoff-Slots' tab to include them."
+            )
+            return []
 
-        rules: List[Dict[str, Any]] = []
-        for i in range(len(SCHEDULE_FINAL_SEQUENCE) - 1):
-            earlier_key = SCHEDULE_FINAL_SEQUENCE[i]
-            later_key   = SCHEDULE_FINAL_SEQUENCE[i + 1]
-            earlier_ids = game_id_by_event_stage.get(earlier_key, [])
-            later_ids   = game_id_by_event_stage.get(later_key, [])
-            for e_id in earlier_ids:
-                for l_id in later_ids:
-                    rules.append({
-                        "rule":            f"Finale order: {earlier_key[0]} {earlier_key[1]} before {later_key[0]} {later_key[1]}",
-                        "earlier_game_id": e_id,
-                        "later_game_id":   l_id,
-                    })
-        return rules
+        required = {"game_id", "event", "stage", "resource_id", "slot"}
+        cols = {str(c).strip() for c in df.columns}
+        missing = required - cols
+        if missing:
+            logger.warning(
+                f"Playoff-Slots tab is missing required columns {sorted(missing)}; "
+                "playoff games will not appear in the schedule."
+            )
+            return []
+
+        slots: List[Dict[str, Any]] = []
+        for _, row in df.iterrows():
+            game_id = ChurchTeamsExporter._clean_excel_text(row.get("game_id"))
+            if not game_id:
+                continue
+            entry: Dict[str, Any] = {
+                "game_id":     game_id,
+                "event":       ChurchTeamsExporter._clean_excel_text(row.get("event", "")),
+                "stage":       ChurchTeamsExporter._clean_excel_text(row.get("stage", "")),
+                "resource_id": ChurchTeamsExporter._clean_excel_text(row.get("resource_id", "")),
+                "slot":        ChurchTeamsExporter._clean_excel_text(row.get("slot", "")),
+            }
+            for optional in ("team_a_id", "team_b_id", "duration_minutes"):
+                val = row.get(optional)
+                if val is not None and str(val).strip() not in ("", "nan"):
+                    entry[optional] = ChurchTeamsExporter._clean_excel_text(str(val)) if optional != "duration_minutes" else int(val)
+            if entry["resource_id"] and entry["slot"]:
+                slots.append(entry)
+            else:
+                logger.warning(f"Playoff-Slots row for {game_id!r} missing resource_id or slot; skipped.")
+        return slots
 
     def _build_schedule_input(
         self,
@@ -1838,7 +1768,7 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
         """Assemble the full schedule_input package consumed by OR-Tools.
 
         Returns a dict with keys: generated_at, gym_court_scenario, game_count,
-        resource_count, games, resources, precedence.
+        resource_count, games, resources, playoff_slots.
 
         Gym resources are built from the explicit SCHEDULE_SOLVER_GYM_COURTS
         constant (config.py) so the solver knows exactly which court scenario
@@ -1852,8 +1782,7 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
         pod_resources = self._load_venue_input_rows(venue_input_path)
         all_resources = gym_resources + pod_resources
 
-        precedence = self._build_precedence_objects(gym_games)
-        sequence   = self._build_sequence_objects(all_games)
+        playoff_slots = self._load_playoff_slots(venue_input_path)
 
         return {
             "generated_at":       datetime.now().isoformat(timespec="seconds"),
@@ -1862,13 +1791,12 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
             "resource_count":     len(all_resources),
             "games":              all_games,
             "resources":          all_resources,
-            "precedence":         precedence,
-            "sequence":           sequence,
+            "playoff_slots":      playoff_slots,
         }
 
     @staticmethod
     def _write_schedule_input_tab(ws, schedule_input: Dict[str, Any]) -> None:
-        """Write Schedule-Input tab with Games, Resources, and Precedence sections."""
+        """Write Schedule-Input tab with Games, Resources, and Playoff-Slots sections."""
         from openpyxl.styles import PatternFill, Font, Alignment
         from openpyxl.utils import get_column_letter
 
@@ -1886,7 +1814,7 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
             "resource_id", "resource_type", "label", "day",
             "open_time", "close_time", "slot_minutes",
         ]
-        precedence_cols = ["rule", "event", "earlier_stage", "later_stage"]
+        playoff_slot_cols = ["game_id", "event", "stage", "resource_id", "slot"]
 
         current_row = 1
 
@@ -1917,9 +1845,15 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
                 current_row += 1
             current_row += 1  # blank separator
 
-        _write_section("GAMES",      game_cols,      schedule_input["games"])
-        _write_section("RESOURCES",  resource_cols,  schedule_input["resources"])
-        _write_section("PRECEDENCE", precedence_cols, schedule_input["precedence"])
+        playoff_slots = schedule_input.get("playoff_slots", [])
+        playoff_note_rows = (
+            playoff_slots if playoff_slots
+            else [{"game_id": "No playoff slots loaded — add Playoff-Slots tab to venue_input.xlsx"}]
+        )
+
+        _write_section("GAMES",          game_cols,          schedule_input["games"])
+        _write_section("RESOURCES",      resource_cols,      schedule_input["resources"])
+        _write_section("PLAYOFF-SLOTS",  playoff_slot_cols,  playoff_note_rows)
 
         # Column widths
         col_widths = [20, 30, 10, 10, 8, 16, 16, 18, 22, 14, 12]
@@ -3035,7 +2969,9 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
             gid  = a["game_id"]
             rid  = a["resource_id"]
             slot = a["slot"]
-            game = game_meta.get(gid, {})
+            # Fall back to the assignment dict itself for playoff games whose
+            # game_id is not in schedule_input games (they carry event/stage fields).
+            game = game_meta.get(gid, a)
             res  = res_meta.get(rid, {})
             time_part = slot.rsplit("-", maxsplit=1)[-1] if "-" in slot else slot
             rows.append({

--- a/middleware/church_teams_export.py
+++ b/middleware/church_teams_export.py
@@ -2109,9 +2109,11 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
     ) -> List[Tuple[str, str, str]]:
         """Return (team_a_id, team_b_id, pool_id) tuples for pool-play games.
 
-        Teams are split into balanced pools of size (gpg+1).  A full round-robin
-        within a pool of that size gives each team exactly gpg games.  Edge pools
-        (when n_teams is not divisible by gpg+1) produce fewer games for those teams.
+        Teams are split into balanced pools of size ≥ (gpg+1).  Floor division
+        is used for n_pools so every pool has at least gpg+1 teams, guaranteeing
+        each team plays at least gpg games.  Teams distribute via round-robin so
+        pool sizes differ by at most 1 (some pools may be gpg+2 when n_teams is
+        not divisible by gpg+1, giving those teams one extra game).
 
         Team IDs are stable planning placeholders: {prefix}-P{pool}-T{slot}.
         The same placeholder is reused across all games involving that team,
@@ -2120,7 +2122,7 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
         if n_teams < 2:
             return []
         target_pool_size = max(2, gpg + 1)
-        n_pools = max(1, -(-n_teams // target_pool_size))  # ceil division
+        n_pools = max(1, n_teams // target_pool_size)  # floor: all pools ≥ target
 
         pools: List[List[int]] = [[] for _ in range(n_pools)]
         for i in range(n_teams):

--- a/middleware/church_teams_export.py
+++ b/middleware/church_teams_export.py
@@ -47,6 +47,7 @@ from config import (
     SCHEDULE_SKETCH_COLOR_SECTION,
     SCHEDULE_SKETCH_COLOR_HEADER,
     GYM_RESOURCE_TYPE,
+    SCHEDULE_SOLVER_GYM_COURTS,
     VENUE_INPUT_FILENAME,
     POD_RESOURCE_EVENT_TYPE,
     POD_FIT_COLOR_GREEN,
@@ -1521,8 +1522,12 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
     ) -> List[Dict[str, Any]]:
         """Return game placeholder dicts for gym sports (Basketball, VB Men, VB Women).
 
-        Pool IDs are sequential (BBM-01, VBM-01, …).  Team assignments are null —
-        this is a planning input for the OR-Tools scheduler.
+        Pool games carry stable placeholder team IDs (e.g. BBM-P1-T1, BBM-P1-T2)
+        and non-empty pool_id values so the solver can enforce team-overlap and
+        min-rest constraints even before final church assignments are known.
+
+        Playoff games use seed/winner references (e.g. BBM-Seed-1, WIN-BBM-QF-1)
+        rather than null, documenting the bracket dependency for the solver.
         """
         sport_defs = [
             (SPORT_TYPE["BASKETBALL"],       "BBM"),
@@ -1545,35 +1550,75 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
                 prefix, s["playoff_teams"], include_third
             )
 
-            for i, gid in enumerate(
-                [f"{prefix}-{j:02d}" for j in range(1, s["pool_slots"] + 1)], start=1
-            ):
+            # Pool games — stable team IDs and non-empty pool_id
+            pool_pairs = self._make_pool_game_pairs(prefix, n_teams, gpg)
+            for pair_idx, (team_a_id, team_b_id, pool_id) in enumerate(pool_pairs, start=1):
                 games.append({
-                    "game_id": gid, "event": event_name, "stage": "Pool",
-                    "pool_id": "", "round": i,
-                    "team_a_id": None, "team_b_id": None,
-                    "duration_minutes": mpg, "resource_type": GYM_RESOURCE_TYPE,
-                    "earliest_slot": None, "latest_slot": None,
+                    "game_id": f"{prefix}-{pair_idx:02d}",
+                    "event": event_name,
+                    "stage": "Pool",
+                    "pool_id": pool_id,
+                    "round": pair_idx,
+                    "team_a_id": team_a_id,
+                    "team_b_id": team_b_id,
+                    "duration_minutes": mpg,
+                    "resource_type": GYM_RESOURCE_TYPE,
+                    "earliest_slot": None,
+                    "latest_slot": None,
                 })
 
+            # Early playoff games (QF, Semi) — seed/winner references
+            qf_count = 0
+            semi_count = 0
             for i, gid in enumerate(early_ids, start=1):
-                stage = gid.split("-")[1] if "-" in gid else "Playoff"
+                stage = gid.split("-")[1]
+                if stage == "QF":
+                    qf_count += 1
+                    team_a_id = f"{prefix}-Seed-{qf_count}"
+                    team_b_id = f"{prefix}-Seed-{s['playoff_teams'] - qf_count + 1}"
+                else:  # Semi
+                    semi_count += 1
+                    if s["playoff_teams"] >= 8:
+                        team_a_id = f"WIN-{prefix}-QF-{(semi_count - 1) * 3 + 1}"
+                        team_b_id = f"WIN-{prefix}-QF-{(semi_count - 1) * 3 + 4}"
+                    else:
+                        team_a_id = f"{prefix}-Seed-{semi_count * 2 - 1}"
+                        team_b_id = f"{prefix}-Seed-{semi_count * 2}"
                 games.append({
-                    "game_id": gid, "event": event_name, "stage": stage,
-                    "pool_id": "", "round": i,
-                    "team_a_id": None, "team_b_id": None,
-                    "duration_minutes": mpg, "resource_type": GYM_RESOURCE_TYPE,
-                    "earliest_slot": None, "latest_slot": None,
+                    "game_id": gid,
+                    "event": event_name,
+                    "stage": stage,
+                    "pool_id": "",
+                    "round": i,
+                    "team_a_id": team_a_id,
+                    "team_b_id": team_b_id,
+                    "duration_minutes": mpg,
+                    "resource_type": GYM_RESOURCE_TYPE,
+                    "earliest_slot": None,
+                    "latest_slot": None,
                 })
 
+            # Final games (Final and optional 3rd) — winner/loser references
             for i, gid in enumerate(final_ids, start=1):
                 stage = gid.split("-")[1] if "-" in gid else "Final"
+                if stage == "Final":
+                    team_a_id = f"WIN-{prefix}-Semi-1"
+                    team_b_id = f"WIN-{prefix}-Semi-2"
+                else:  # 3rd place
+                    team_a_id = f"LOSE-{prefix}-Semi-1"
+                    team_b_id = f"LOSE-{prefix}-Semi-2"
                 games.append({
-                    "game_id": gid, "event": event_name, "stage": stage,
-                    "pool_id": "", "round": i,
-                    "team_a_id": None, "team_b_id": None,
-                    "duration_minutes": mpg, "resource_type": GYM_RESOURCE_TYPE,
-                    "earliest_slot": None, "latest_slot": None,
+                    "game_id": gid,
+                    "event": event_name,
+                    "stage": stage,
+                    "pool_id": "",
+                    "round": i,
+                    "team_a_id": team_a_id,
+                    "team_b_id": team_b_id,
+                    "duration_minutes": mpg,
+                    "resource_type": GYM_RESOURCE_TYPE,
+                    "earliest_slot": None,
+                    "latest_slot": None,
                 })
 
         return games
@@ -1754,26 +1799,31 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
     ) -> Dict[str, Any]:
         """Assemble the full schedule_input package consumed by OR-Tools.
 
-        Returns a dict with keys: generated_at, game_count, resource_count,
-        games, resources, precedence.
+        Returns a dict with keys: generated_at, gym_court_scenario, game_count,
+        resource_count, games, resources, precedence.
+
+        Gym resources are built from the explicit SCHEDULE_SOLVER_GYM_COURTS
+        constant (config.py) so the solver knows exactly which court scenario
+        was chosen for this run.
         """
         gym_games = self._build_gym_game_objects(roster_rows)
         pod_games = self._build_pod_game_objects(roster_rows, validation_rows)
         all_games = gym_games + pod_games
 
-        gym_resources = self._build_gym_resource_objects()
+        gym_resources = self._build_gym_resource_objects(SCHEDULE_SOLVER_GYM_COURTS)
         pod_resources = self._load_venue_input_rows(venue_input_path)
         all_resources = gym_resources + pod_resources
 
         precedence = self._build_precedence_objects(gym_games)
 
         return {
-            "generated_at":   datetime.now().isoformat(timespec="seconds"),
-            "game_count":     len(all_games),
-            "resource_count": len(all_resources),
-            "games":          all_games,
-            "resources":      all_resources,
-            "precedence":     precedence,
+            "generated_at":       datetime.now().isoformat(timespec="seconds"),
+            "gym_court_scenario": SCHEDULE_SOLVER_GYM_COURTS,
+            "game_count":         len(all_games),
+            "resource_count":     len(all_resources),
+            "games":              all_games,
+            "resources":          all_resources,
+            "precedence":         precedence,
         }
 
     @staticmethod
@@ -1978,6 +2028,47 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
                     grids[s][t][c] = game_id
 
         return grids
+
+    @staticmethod
+    @staticmethod
+    def _make_pool_game_pairs(
+        prefix: str, n_teams: int, gpg: int
+    ) -> List[Tuple[str, str, str]]:
+        """Return (team_a_id, team_b_id, pool_id) tuples for pool-play games.
+
+        Teams are split into balanced pools of size (gpg+1).  A full round-robin
+        within a pool of that size gives each team exactly gpg games.  Edge pools
+        (when n_teams is not divisible by gpg+1) produce fewer games for those teams.
+
+        Team IDs are stable planning placeholders: {prefix}-P{pool}-T{slot}.
+        The same placeholder is reused across all games involving that team,
+        allowing the solver to enforce team-overlap and min-rest constraints.
+        """
+        if n_teams < 2:
+            return []
+        target_pool_size = max(2, gpg + 1)
+        n_pools = max(1, -(-n_teams // target_pool_size))  # ceil division
+
+        pools: List[List[int]] = [[] for _ in range(n_pools)]
+        for i in range(n_teams):
+            pools[i % n_pools].append(i + 1)  # 1-indexed team number
+
+        team_id: Dict[int, str] = {}
+        for p_idx, pool_teams in enumerate(pools, start=1):
+            for t_idx, team_num in enumerate(pool_teams, start=1):
+                team_id[team_num] = f"{prefix}-P{p_idx}-T{t_idx}"
+
+        pairs: List[Tuple[str, str, str]] = []
+        for p_idx, pool_teams in enumerate(pools, start=1):
+            pool_id = f"P{p_idx}"
+            for i in range(len(pool_teams)):
+                for j in range(i + 1, len(pool_teams)):
+                    pairs.append((
+                        team_id[pool_teams[i]],
+                        team_id[pool_teams[j]],
+                        pool_id,
+                    ))
+        return pairs
 
     @staticmethod
     def _make_playoff_ids(

--- a/middleware/church_teams_export.py
+++ b/middleware/church_teams_export.py
@@ -1114,8 +1114,8 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
 
         # When the caller already knows the exact game count (e.g. from
         # _make_pool_game_pairs), use it directly so the Venue-Estimator and
-        # schedule_input.json agree on the number of pool games (B3 fix).
-        # The formula ceil(n*gpg/2) over-counts when pools are uneven.
+        # schedule_input.json stay aligned with the current pool-generation
+        # policy instead of falling back to a rough ceil(n*gpg/2) estimate.
         if actual_pool_games is not None:
             pool_slots = actual_pool_games
         else:
@@ -1485,15 +1485,20 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
             counts = self._count_estimating_teams(roster_rows, event_name, min_team_size)
             mpg = COURT_ESTIMATE_MINUTES_PER_GAME.get(event_name, COURT_ESTIMATE_DEFAULT_MINUTES_PER_GAME)
             gpg = COURT_ESTIMATE_POOL_GAMES_PER_TEAM.get(event_name, COURT_ESTIMATE_DEFAULT_POOL_GAMES_PER_TEAM)
+            pool_plan = self._summarize_pool_policy(counts["n_estimating"], gpg)
             actual = len(self._make_pool_game_pairs("_", counts["n_estimating"], gpg))
             s = self._compute_court_slots(counts["n_estimating"], minutes_per_game=mpg,
-                                          pool_games_per_team=gpg, actual_pool_games=actual)
+                                          pool_games_per_team=gpg,
+                                          actual_pool_games=actual)
             rows.append({
                 "Event": event_name,
                 "Potential Teams/Entries": counts["n_potential"],
                 "Estimating Teams/Entries": counts["n_estimating"],
                 "Teams": counts["team_codes"],
-                "Pool Games Per Team": s["pool_games_per_team"],
+                "Target Pool Games/Team": pool_plan["target_pool_games_per_team"],
+                "Actual Pool Games/Team": pool_plan["actual_pool_games_per_team"],
+                "Pool Composition": pool_plan["pool_composition"],
+                "BYE Slots": pool_plan["bye_slots"],
                 "Minutes Per Game": s["minutes_per_game"],
                 "Pool Slots": s["pool_slots"],
                 "Playoff Teams": s["playoff_teams"],
@@ -1514,7 +1519,10 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
                 "Potential Teams/Entries": counts["n_potential"],
                 "Estimating Teams/Entries": counts["n_estimating"],
                 "Teams": counts["team_codes"],
-                "Pool Games Per Team": s["pool_games_per_team"],
+                "Target Pool Games/Team": None,
+                "Actual Pool Games/Team": None,
+                "Pool Composition": "",
+                "BYE Slots": None,
                 "Minutes Per Game": s["minutes_per_game"],
                 "Pool Slots": s["pool_slots"],
                 "Playoff Teams": s["playoff_teams"],
@@ -2103,30 +2111,68 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
         return grids
 
     @staticmethod
-    @staticmethod
-    def _make_pool_game_pairs(
-        prefix: str, n_teams: int, gpg: int
-    ) -> List[Tuple[str, str, str]]:
-        """Return (team_a_id, team_b_id, pool_id) tuples for pool-play games.
-
-        Teams are split into balanced pools of size ≥ (gpg+1).  Floor division
-        is used for n_pools so every pool has at least gpg+1 teams, guaranteeing
-        each team plays at least gpg games.  Teams distribute via round-robin so
-        pool sizes differ by at most 1 (some pools may be gpg+2 when n_teams is
-        not divisible by gpg+1, giving those teams one extra game).
-
-        Team IDs are stable planning placeholders: {prefix}-P{pool}-T{slot}.
-        The same placeholder is reused across all games involving that team,
-        allowing the solver to enforce team-overlap and min-rest constraints.
-        """
+    def _two_game_pool_sizes(n_teams: int) -> List[int]:
+        """Return deterministic pool sizes for the normalized 2-game/team policy."""
         if n_teams < 2:
             return []
+        if n_teams in (2, 3, 4, 5):
+            return [n_teams]
+
+        for n_fours in range(n_teams // 4, -1, -1):
+            remainder = n_teams - (4 * n_fours)
+            if remainder >= 0 and remainder % 3 == 0:
+                return ([4] * n_fours) + ([3] * (remainder // 3))
+
+        raise ValueError(f"Unable to build normalized 2-game pools for n_teams={n_teams}")
+
+    @staticmethod
+    def _summarize_pool_policy(n_teams: int, gpg: int) -> Dict[str, Any]:
+        """Return operator-facing metadata for the current pool-generation policy."""
+        if n_teams < 2:
+            return {
+                "target_pool_games_per_team": gpg,
+                "actual_pool_games_per_team": 0,
+                "pool_composition": "",
+                "bye_slots": 0,
+                "actual_pool_games": 0,
+            }
+
+        if gpg != 2:
+            actual_pool_games = len(
+                ChurchTeamsExporter._make_legacy_pool_game_pairs("_", n_teams, gpg)
+            )
+            return {
+                "target_pool_games_per_team": gpg,
+                "actual_pool_games_per_team": None,
+                "pool_composition": "",
+                "bye_slots": 0,
+                "actual_pool_games": actual_pool_games,
+            }
+
+        pool_sizes = ChurchTeamsExporter._two_game_pool_sizes(n_teams)
+        games_by_pool_size = {2: 1, 3: 3, 4: 4, 5: 5}
+        return {
+            "target_pool_games_per_team": gpg,
+            "actual_pool_games_per_team": 1 if n_teams == 2 else 2,
+            "pool_composition": " + ".join(str(size) for size in pool_sizes),
+            "bye_slots": 5 * pool_sizes.count(5),
+            "actual_pool_games": sum(games_by_pool_size[size] for size in pool_sizes),
+        }
+
+    @staticmethod
+    def _make_legacy_pool_game_pairs(
+        prefix: str, n_teams: int, gpg: int
+    ) -> List[Tuple[str, str, str]]:
+        """Legacy balanced round-robin fallback for non-default pool-game targets."""
+        if n_teams < 2:
+            return []
+
         target_pool_size = max(2, gpg + 1)
-        n_pools = max(1, n_teams // target_pool_size)  # floor: all pools ≥ target
+        n_pools = max(1, n_teams // target_pool_size)
 
         pools: List[List[int]] = [[] for _ in range(n_pools)]
         for i in range(n_teams):
-            pools[i % n_pools].append(i + 1)  # 1-indexed team number
+            pools[i % n_pools].append(i + 1)
 
         team_id: Dict[int, str] = {}
         for p_idx, pool_teams in enumerate(pools, start=1):
@@ -2143,6 +2189,56 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
                         team_id[pool_teams[j]],
                         pool_id,
                     ))
+        return pairs
+
+    @staticmethod
+    def _make_pool_game_pairs(
+        prefix: str, n_teams: int, gpg: int
+    ) -> List[Tuple[str, str, str]]:
+        """Return (team_a_id, team_b_id, pool_id) tuples for pool-play games.
+
+        Current Layer 1 planning normalizes team sports around exact two-game
+        pool play:
+        - 2 teams  -> one direct match
+        - 3 teams  -> 3-team round robin
+        - 4 teams  -> 4-match matrix (every team plays exactly twice)
+        - 5 teams  -> 5-match cycle (every team plays exactly twice)
+        - 6+ teams -> deterministic composition of 3-team and 4-team pools
+
+        If a non-default target is requested, fall back to the older balanced
+        round-robin pool builder so the helper remains backwards-compatible for
+        tests and historical data exploration.
+
+        Team IDs are stable planning placeholders: {prefix}-P{pool}-T{slot}.
+        The same placeholder is reused across all games involving that team,
+        allowing the solver to enforce team-overlap and min-rest constraints.
+        """
+        if n_teams < 2:
+            return []
+        if gpg != 2:
+            return ChurchTeamsExporter._make_legacy_pool_game_pairs(prefix, n_teams, gpg)
+
+        template_pairs = {
+            2: [(0, 1)],
+            3: [(0, 1), (0, 2), (1, 2)],
+            4: [(0, 1), (2, 3), (0, 2), (1, 3)],
+            5: [(0, 1), (1, 2), (2, 3), (3, 4), (4, 0)],
+        }
+        pool_sizes = ChurchTeamsExporter._two_game_pool_sizes(n_teams)
+
+        pairs: List[Tuple[str, str, str]] = []
+        for p_idx, pool_size in enumerate(pool_sizes, start=1):
+            pool_id = f"P{p_idx}"
+            pool_team_ids = [
+                f"{prefix}-P{p_idx}-T{slot_idx}"
+                for slot_idx in range(1, pool_size + 1)
+            ]
+            for team_a_idx, team_b_idx in template_pairs[pool_size]:
+                pairs.append((
+                    pool_team_ids[team_a_idx],
+                    pool_team_ids[team_b_idx],
+                    pool_id,
+                ))
         return pairs
 
     @staticmethod
@@ -2209,8 +2305,14 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
             counts = self._count_estimating_teams(roster_rows, event_name, min_sz)
             n_teams = counts["n_estimating"] if counts["n_estimating"] >= 2 else 8
             gpg = COURT_ESTIMATE_POOL_GAMES_PER_TEAM.get(event_name, COURT_ESTIMATE_DEFAULT_POOL_GAMES_PER_TEAM)
+            pool_plan = self._summarize_pool_policy(n_teams, gpg)
             actual = len(self._make_pool_game_pairs("_", n_teams, gpg))
-            s = self._compute_court_slots(n_teams, mpg, pool_games_per_team=gpg, actual_pool_games=actual)
+            s = self._compute_court_slots(
+                n_teams,
+                mpg,
+                pool_games_per_team=gpg,
+                actual_pool_games=actual,
+            )
             early_ids, final_ids = self._make_playoff_ids(
                 prefix, s["playoff_teams"], include_third
             )
@@ -2218,7 +2320,9 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
                 "prefix": prefix,
                 "color": color,
                 "n_teams": n_teams,
-                "pool_gpg": gpg,
+                "target_pool_gpg": pool_plan["target_pool_games_per_team"],
+                "actual_pool_gpg": pool_plan["actual_pool_games_per_team"],
+                "pool_composition": pool_plan["pool_composition"],
                 "pool_ids":   [f"{prefix}-{i:02d}" for i in range(1, s["pool_slots"] + 1)],
                 "early_ids":  early_ids,   # QF + Semi → 2nd Saturday
                 "final_ids":  final_ids,   # Final + 3rd → 2nd Sunday
@@ -2275,12 +2379,19 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
         COL_HDR_ROW     = 4
         DATA_START_ROW  = 5
 
-        # --- Row 1: inputs summary (per-sport pool games per team) ---
+        # --- Row 1: inputs summary (target/actual pool games per team) ---
         ws.cell(row=INPUTS_ROW, column=1, value="Inputs:").font = bold_font
         col = 2
         for ev, prefix, _ in sport_defs:
-            ws.cell(row=INPUTS_ROW, column=col,
-                    value=f"{prefix} pool games/team: {sport_meta[ev]['pool_gpg']}")
+            meta = sport_meta[ev]
+            ws.cell(
+                row=INPUTS_ROW,
+                column=col,
+                value=(
+                    f"{prefix} pool target/actual: "
+                    f"{meta['target_pool_gpg']}/{meta['actual_pool_gpg']}"
+                ),
+            )
             col += 3
         ws.cell(row=INPUTS_ROW, column=col,     value=f"Minutes/game: {mpg}")
         ws.cell(row=INPUTS_ROW, column=col + 3, value=f"3rd place: {'Yes' if include_third else 'No'}")
@@ -2291,7 +2402,10 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
         for ev, prefix, _ in sport_defs:
             meta = sport_meta[ev]
             total = len(meta["pool_ids"]) + len(meta["early_ids"]) + len(meta["final_ids"])
-            label = f"{prefix}: {meta['n_teams']} teams, {total} games ({len(meta['pool_ids'])} pool)"
+            label = (
+                f"{prefix}: {meta['n_teams']} teams, {total} games "
+                f"({len(meta['pool_ids'])} pool, pools {meta['pool_composition']})"
+            )
             ws.cell(row=2, column=col_offset, value=label)
             col_offset += 5
 
@@ -2674,7 +2788,8 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
                     venue_rows = self._build_venue_capacity_rows(roster_rows)
                     venue_cols = [
                         "Event", "Potential Teams/Entries", "Estimating Teams/Entries", "Teams",
-                        "Pool Games Per Team", "Minutes Per Game", "Pool Slots",
+                        "Target Pool Games/Team", "Actual Pool Games/Team",
+                        "Pool Composition", "BYE Slots", "Minutes Per Game", "Pool Slots",
                         "Playoff Teams", "Playoff Slots", "Third Place?",
                         "Third Place Slots", "Total Court Slots", "Estimated Court Hours",
                     ]

--- a/middleware/church_teams_export.py
+++ b/middleware/church_teams_export.py
@@ -3103,15 +3103,56 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
                 return f"{gid}\n{a} vs {b}"
             return gid
 
-        # Group resources by session
-        sessions: Dict[str, List[Dict[str, Any]]] = {}
+        def _time_sort_key(hhmm: str) -> int:
+            h, m = map(int, hhmm.split(":"))
+            return h * 60 + m
+
+        def _resource_group_key(res: Dict[str, Any]) -> Tuple[str, str, str, str, int]:
+            return (
+                str(res.get("day", "")),
+                str(res.get("resource_type", "")),
+                str(res.get("open_time", "")),
+                str(res.get("close_time", "")),
+                int(res.get("slot_minutes", 0) or 0),
+            )
+
+        # Group resources by uniform day/window/resource pool so pod schedules with
+        # mixed slot lengths do not get collapsed into one broken "Day-1" grid.
+        resource_groups: Dict[Tuple[str, str, str, str, int], List[Dict[str, Any]]] = {}
         for res in schedule_input.get("resources", []):
-            sessions.setdefault(res["day"], []).append(res)
-        sorted_days = sorted(
-            sessions.keys(), key=lambda d: (_DAY_ORDER.get(d, 99), d)
+            resource_groups.setdefault(_resource_group_key(res), []).append(res)
+
+        group_counts_by_day: Dict[str, int] = {}
+        for day, _, _, _, _ in resource_groups.keys():
+            group_counts_by_day[day] = group_counts_by_day.get(day, 0) + 1
+
+        sorted_group_keys = sorted(
+            resource_groups.keys(),
+            key=lambda key: (
+                _DAY_ORDER.get(key[0], 99),
+                key[0],
+                _time_sort_key(key[2]) if key[2] else 0,
+                _time_sort_key(key[3]) if key[3] else 0,
+                key[4],
+                key[1],
+            ),
         )
-        max_courts = max((len(v) for v in sessions.values()), default=4)
-        n_cols     = 1 + max_courts
+        max_resources = max((len(v) for v in resource_groups.values()), default=4)
+        n_cols        = 1 + max_resources
+
+        def _section_label(group_key: Tuple[str, str, str, str, int]) -> str:
+            day, resource_type, open_time, close_time, slot_minutes = group_key
+            day_label = _DAY_DISPLAY.get(day, day)
+            if (
+                day in _DAY_DISPLAY
+                and resource_type == GYM_RESOURCE_TYPE
+                and group_counts_by_day.get(day, 0) == 1
+            ):
+                return day_label
+            return (
+                f"{day_label} — {resource_type} "
+                f"({open_time}-{close_time}, {slot_minutes}m)"
+            )
 
         wb = Workbook()
 
@@ -3124,19 +3165,11 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
         c = ws1.cell(row=1, column=1, value="VAY Sports Fest — Schedule by Time")
         c.fill, c.font, c.alignment = hdr_fill, hdr_font, center
 
-        # Row 2 — column headers: Time + court labels from first session
-        ws1.cell(row=2, column=1, value="Time").font = bold_font
-        first_res = sorted(
-            sessions.get(sorted_days[0], [])[:max_courts], key=lambda r: r["resource_id"]
-        ) if sorted_days else []
-        for ci, res in enumerate(first_res, start=2):
-            c = ws1.cell(row=2, column=ci, value=res["label"])
-            c.fill, c.font, c.alignment = sec_fill, bold_font, center
-        ws1.freeze_panes = "A3"
+        ws1.freeze_panes = "A2"
 
         cur_row = 3
-        for day in sorted_days:
-            day_res = sorted(sessions[day], key=lambda r: r["resource_id"])
+        for group_key in sorted_group_keys:
+            day_res = sorted(resource_groups[group_key], key=lambda r: r["resource_id"])
             if not day_res:
                 continue
 
@@ -3145,11 +3178,21 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
                 start_row=cur_row, start_column=1,
                 end_row=cur_row, end_column=n_cols,
             )
-            c = ws1.cell(row=cur_row, column=1, value=_DAY_DISPLAY.get(day, day))
+            c = ws1.cell(row=cur_row, column=1, value=_section_label(group_key))
             c.fill, c.font, c.alignment = sec_fill, bold_font, center
             cur_row += 1
 
-            # Data rows — one per time slot in this session
+            # Column headers for this group
+            ws1.cell(row=cur_row, column=1, value="Time").font = bold_font
+            ws1.cell(row=cur_row, column=1).fill = sec_fill
+            ws1.cell(row=cur_row, column=1).alignment = center
+            for ci, res in enumerate(day_res, start=2):
+                c = ws1.cell(row=cur_row, column=ci, value=res["label"])
+                c.fill, c.font, c.alignment = sec_fill, bold_font, center
+            cur_row += 1
+
+            day = group_key[0]
+            # Data rows — one per time slot in this uniform resource group
             for t_str in _slot_times(day_res[0]):
                 slot_label = f"{day}-{t_str}"
                 ws1.cell(row=cur_row, column=1, value=t_str).alignment = center

--- a/middleware/church_teams_export.py
+++ b/middleware/church_teams_export.py
@@ -1633,6 +1633,7 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
                     "open_time":     open_time,
                     "close_time":    close_time,
                     "slot_minutes":  mpg,
+                    "exclusive_group": "",
                 })
         return resources
 
@@ -1799,7 +1800,8 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
             )
             return {}
 
-        cols = {str(c).strip() for c in df.columns}
+        df = df.rename(columns=lambda c: str(c).strip())
+        cols = set(df.columns)
         if "Gym Name" not in cols:
             logger.warning(
                 "Gym-Modes tab is missing the 'Gym Name' column — "

--- a/middleware/church_teams_export.py
+++ b/middleware/church_teams_export.py
@@ -54,6 +54,7 @@ from config import (
     POD_FIT_COLOR_YELLOW,
     POD_FIT_COLOR_RED,
     POD_FIT_YELLOW_MAX,
+    SCHEDULE_STAGE_WINDOWS,
 )
 from validation.name_matcher import normalized_name as _norm_name
 from chmeetings.backend_connector import ChMeetingsConnector
@@ -1555,6 +1556,7 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
             # Pool games — stable team IDs and non-empty pool_id
             pool_pairs = self._make_pool_game_pairs(prefix, n_teams, gpg)
             for pair_idx, (team_a_id, team_b_id, pool_id) in enumerate(pool_pairs, start=1):
+                _pool_window = SCHEDULE_STAGE_WINDOWS.get((event_name, "Pool"), (None, None))
                 games.append({
                     "game_id": f"{prefix}-{pair_idx:02d}",
                     "event": event_name,
@@ -1565,8 +1567,8 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
                     "team_b_id": team_b_id,
                     "duration_minutes": mpg,
                     "resource_type": GYM_RESOURCE_TYPE,
-                    "earliest_slot": None,
-                    "latest_slot": None,
+                    "earliest_slot": _pool_window[0],
+                    "latest_slot":   _pool_window[1],
                 })
 
             # Early playoff games (QF, Semi) — seed/winner references
@@ -1586,6 +1588,7 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
                     else:
                         team_a_id = f"{prefix}-Seed-{semi_count * 2 - 1}"
                         team_b_id = f"{prefix}-Seed-{semi_count * 2}"
+                _early_window = SCHEDULE_STAGE_WINDOWS.get((event_name, stage), (None, None))
                 games.append({
                     "game_id": gid,
                     "event": event_name,
@@ -1596,8 +1599,8 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
                     "team_b_id": team_b_id,
                     "duration_minutes": mpg,
                     "resource_type": GYM_RESOURCE_TYPE,
-                    "earliest_slot": None,
-                    "latest_slot": None,
+                    "earliest_slot": _early_window[0],
+                    "latest_slot":   _early_window[1],
                 })
 
             # Final games (Final and optional 3rd) — winner/loser references
@@ -1609,6 +1612,7 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
                 else:  # 3rd place
                     team_a_id = f"LOSE-{prefix}-Semi-1"
                     team_b_id = f"LOSE-{prefix}-Semi-2"
+                _final_window = SCHEDULE_STAGE_WINDOWS.get((event_name, stage), (None, None))
                 games.append({
                     "game_id": gid,
                     "event": event_name,
@@ -1619,8 +1623,8 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
                     "team_b_id": team_b_id,
                     "duration_minutes": mpg,
                     "resource_type": GYM_RESOURCE_TYPE,
-                    "earliest_slot": None,
-                    "latest_slot": None,
+                    "earliest_slot": _final_window[0],
+                    "latest_slot":   _final_window[1],
                 })
 
         return games

--- a/middleware/church_teams_export.py
+++ b/middleware/church_teams_export.py
@@ -1677,6 +1677,12 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
             resource_type = ChurchTeamsExporter._clean_excel_text(row.get("Resource Type"))
             if not resource_type:
                 continue
+            # Exclusive Venue Group: rows sharing a group value compete for the
+            # same physical gym (only one mode active per time block). Optional
+            # column — blank means the resource stands alone.
+            exclusive_group = ChurchTeamsExporter._clean_excel_text(
+                row.get("Exclusive Venue Group")
+            )
             qty = max(1, int(ChurchTeamsExporter._float_from_excel(row.get("Quantity"), 1)))
             slot_min = max(1, int(ChurchTeamsExporter._float_from_excel(row.get("Slot Minutes"), 60)))
             start = ChurchTeamsExporter._parse_hour(row.get("Start Time"))
@@ -1694,13 +1700,14 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
                     f"Table-{i}" if "table" in resource_type.lower() else f"Court-{i}"
                 )
                 rows.append({
-                    "resource_id":   f"{abbrev}-{rc}",
-                    "resource_type": resource_type,
-                    "label":         label,
-                    "day":           "Day-1",
-                    "open_time":     open_time,
-                    "close_time":    close_time,
-                    "slot_minutes":  slot_min,
+                    "resource_id":     f"{abbrev}-{rc}",
+                    "resource_type":   resource_type,
+                    "label":           label,
+                    "day":             "Day-1",
+                    "open_time":       open_time,
+                    "close_time":      close_time,
+                    "slot_minutes":    slot_min,
+                    "exclusive_group": exclusive_group,
                 })
             resource_counts[resource_type] = rc
 
@@ -1759,6 +1766,74 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
                 logger.warning(f"Playoff-Slots row for {game_id!r} missing resource_id or slot; skipped.")
         return slots
 
+    @staticmethod
+    def _load_gym_modes(venue_input_path: Path) -> Dict[str, Dict[str, int]]:
+        """Load per-gym mode capacities from the Gym-Modes tab in venue_input.xlsx.
+
+        A gym that can be configured as either-or (e.g. 1 Basketball Court OR
+        2 Volleyball Courts per time block) records both options on one row.
+        Returns {gym_name: {resource_type: courts_per_block}}; 0 means that
+        mode is not available in that gym.
+
+        Returns an empty dict (with a WARNING) if the file or tab is absent —
+        the schedule is still produced; the gym-mode capacity estimator simply
+        has no mode data to work with.
+        """
+        # Maps a Gym-Modes column header to the resource_type it represents.
+        mode_column_map = {
+            "Basketball Courts": "Basketball Court",
+            "Volleyball Courts": "Volleyball Court",
+            "Badminton Courts":  "Badminton Court",
+            "Pickleball Courts": "Pickleball Court",
+            "Soccer Fields":     "Soccer Field",
+        }
+        if not venue_input_path.exists():
+            return {}
+        try:
+            df = pd.read_excel(venue_input_path, sheet_name="Gym-Modes", engine="openpyxl")
+        except Exception:
+            logger.warning(
+                "venue_input.xlsx is present but has no 'Gym-Modes' tab — "
+                "gym-mode capacity estimation will be skipped. "
+                "Add a 'Gym-Modes' tab to enable it."
+            )
+            return {}
+
+        cols = {str(c).strip() for c in df.columns}
+        if "Gym Name" not in cols:
+            logger.warning(
+                "Gym-Modes tab is missing the 'Gym Name' column — "
+                "gym-mode capacity estimation will be skipped."
+            )
+            return {}
+
+        active_modes = {col: rt for col, rt in mode_column_map.items() if col in cols}
+        if not active_modes:
+            logger.warning(
+                "Gym-Modes tab has no recognized mode columns "
+                f"({sorted(mode_column_map)}); gym-mode capacity estimation "
+                "will be skipped."
+            )
+            return {}
+
+        gym_modes: Dict[str, Dict[str, int]] = {}
+        for _, row in df.iterrows():
+            gym_name = ChurchTeamsExporter._clean_excel_text(row.get("Gym Name"))
+            if not gym_name:
+                continue
+            capacities = {
+                rt: int(ChurchTeamsExporter._float_from_excel(row.get(col), 0))
+                for col, rt in active_modes.items()
+            }
+            # Skip note/blank rows — a "gym" with zero capacity in every mode
+            # is the documentation footer, not a real venue.
+            if not any(capacities.values()):
+                continue
+            gym_modes[gym_name] = capacities
+
+        logger.debug(f"Loaded {len(gym_modes)} gym mode rows from {venue_input_path}")
+        return gym_modes
+
     def _build_schedule_input(
         self,
         roster_rows: List[Dict[str, Any]],
@@ -1768,7 +1843,7 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
         """Assemble the full schedule_input package consumed by OR-Tools.
 
         Returns a dict with keys: generated_at, gym_court_scenario, game_count,
-        resource_count, games, resources, playoff_slots.
+        resource_count, games, resources, playoff_slots, gym_modes.
 
         Gym resources are built from the explicit SCHEDULE_SOLVER_GYM_COURTS
         constant (config.py) so the solver knows exactly which court scenario
@@ -1783,6 +1858,7 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
         all_resources = gym_resources + pod_resources
 
         playoff_slots = self._load_playoff_slots(venue_input_path)
+        gym_modes = self._load_gym_modes(venue_input_path)
 
         return {
             "generated_at":       datetime.now().isoformat(timespec="seconds"),
@@ -1792,6 +1868,7 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
             "games":              all_games,
             "resources":          all_resources,
             "playoff_slots":      playoff_slots,
+            "gym_modes":          gym_modes,
         }
 
     @staticmethod
@@ -1812,7 +1889,7 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
         ]
         resource_cols = [
             "resource_id", "resource_type", "label", "day",
-            "open_time", "close_time", "slot_minutes",
+            "open_time", "close_time", "slot_minutes", "exclusive_group",
         ]
         playoff_slot_cols = ["game_id", "event", "stage", "resource_id", "slot"]
 
@@ -1851,9 +1928,19 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
             else [{"game_id": "No playoff slots loaded — add Playoff-Slots tab to venue_input.xlsx"}]
         )
 
+        gym_modes = schedule_input.get("gym_modes", {})
+        gym_mode_rtypes = sorted({rt for caps in gym_modes.values() for rt in caps})
+        gym_mode_cols = ["gym_name", *gym_mode_rtypes]
+        gym_mode_rows = (
+            [{"gym_name": name, **caps} for name, caps in sorted(gym_modes.items())]
+            if gym_modes
+            else [{"gym_name": "No Gym-Modes tab loaded — add Gym-Modes tab to venue_input.xlsx"}]
+        )
+
         _write_section("GAMES",          game_cols,          schedule_input["games"])
         _write_section("RESOURCES",      resource_cols,      schedule_input["resources"])
         _write_section("PLAYOFF-SLOTS",  playoff_slot_cols,  playoff_note_rows)
+        _write_section("GYM-MODES",      gym_mode_cols,      gym_mode_rows)
 
         # Column widths
         col_widths = [20, 30, 10, 10, 8, 16, 16, 18, 22, 14, 12]

--- a/middleware/church_teams_export.py
+++ b/middleware/church_teams_export.py
@@ -1108,10 +1108,18 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
 
     def _compute_court_slots(self, n_teams: int,
                               minutes_per_game: int = COURT_ESTIMATE_DEFAULT_MINUTES_PER_GAME,
-                              pool_games_per_team: int = COURT_ESTIMATE_DEFAULT_POOL_GAMES_PER_TEAM) -> Dict[str, Any]:
+                              pool_games_per_team: int = COURT_ESTIMATE_DEFAULT_POOL_GAMES_PER_TEAM,
+                              actual_pool_games: Optional[int] = None) -> Dict[str, Any]:
         include_third = COURT_ESTIMATE_INCLUDE_THIRD_PLACE_GAME
 
-        pool_slots = ceil((n_teams * pool_games_per_team) / 2) if n_teams > 0 else 0
+        # When the caller already knows the exact game count (e.g. from
+        # _make_pool_game_pairs), use it directly so the Venue-Estimator and
+        # schedule_input.json agree on the number of pool games (B3 fix).
+        # The formula ceil(n*gpg/2) over-counts when pools are uneven.
+        if actual_pool_games is not None:
+            pool_slots = actual_pool_games
+        else:
+            pool_slots = ceil((n_teams * pool_games_per_team) / 2) if n_teams > 0 else 0
         playoff_teams = self._get_playoff_teams(n_teams)
         playoff_slots = max(playoff_teams - 1, 0)
         third_place_slots = 1 if include_third and playoff_teams >= 4 else 0
@@ -1477,7 +1485,9 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
             counts = self._count_estimating_teams(roster_rows, event_name, min_team_size)
             mpg = COURT_ESTIMATE_MINUTES_PER_GAME.get(event_name, COURT_ESTIMATE_DEFAULT_MINUTES_PER_GAME)
             gpg = COURT_ESTIMATE_POOL_GAMES_PER_TEAM.get(event_name, COURT_ESTIMATE_DEFAULT_POOL_GAMES_PER_TEAM)
-            s = self._compute_court_slots(counts["n_estimating"], minutes_per_game=mpg, pool_games_per_team=gpg)
+            actual = len(self._make_pool_game_pairs("_", counts["n_estimating"], gpg))
+            s = self._compute_court_slots(counts["n_estimating"], minutes_per_game=mpg,
+                                          pool_games_per_team=gpg, actual_pool_games=actual)
             rows.append({
                 "Event": event_name,
                 "Potential Teams/Entries": counts["n_potential"],
@@ -2197,7 +2207,8 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
             counts = self._count_estimating_teams(roster_rows, event_name, min_sz)
             n_teams = counts["n_estimating"] if counts["n_estimating"] >= 2 else 8
             gpg = COURT_ESTIMATE_POOL_GAMES_PER_TEAM.get(event_name, COURT_ESTIMATE_DEFAULT_POOL_GAMES_PER_TEAM)
-            s = self._compute_court_slots(n_teams, mpg, pool_games_per_team=gpg)
+            actual = len(self._make_pool_game_pairs("_", n_teams, gpg))
+            s = self._compute_court_slots(n_teams, mpg, pool_games_per_team=gpg, actual_pool_games=actual)
             early_ids, final_ids = self._make_playoff_ids(
                 prefix, s["playoff_teams"], include_third
             )
@@ -3037,6 +3048,36 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
             return False
                     
     @staticmethod
+    @staticmethod
+    def _warn_if_schedules_mismatched(
+        schedule_output: Dict[str, Any],
+        schedule_input: Dict[str, Any],
+    ) -> bool:
+        """Warn if schedule_output assignments reference game IDs absent from schedule_input.
+
+        Returns True when the files are consistent, False when orphaned game IDs are found.
+        Orphaned IDs typically mean --input and --constraint came from different runs, which
+        causes produce-schedule to silently render rows with blank event/stage fields (B5).
+        """
+        known_ids = (
+            {g["game_id"] for g in schedule_input.get("games", [])}
+            | {ps["game_id"] for ps in schedule_input.get("playoff_slots", [])}
+        )
+        assignment_ids = {
+            a["game_id"] for a in schedule_output.get("assignments", [])
+        }
+        orphaned = assignment_ids - known_ids
+        if orphaned:
+            logger.warning(
+                f"{len(orphaned)} assignment game_id(s) not found in schedule_input — "
+                "--input and --constraint may be from different runs. "
+                "Affected rows will render with blank event/stage. "
+                f"Orphaned IDs: {sorted(orphaned)}"
+            )
+            return False
+        return True
+
+    @staticmethod
     def _build_schedule_output_flat_rows(
         schedule_output: Dict[str, Any],
         schedule_input: Dict[str, Any],
@@ -3046,6 +3087,7 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
         Each row joins one assignment from schedule_output with game metadata
         from schedule_input.  Rows are sorted by event → stage order → round → slot.
         """
+        ChurchTeamsExporter._warn_if_schedules_mismatched(schedule_output, schedule_input)
         game_meta = {g["game_id"]: g for g in schedule_input.get("games", [])}
         res_meta  = {r["resource_id"]: r for r in schedule_input.get("resources", [])}
         _STAGE_ORDER = {"Pool": 0, "R1": 1, "QF": 2, "Semi": 3, "Final": 4, "3rd": 5}

--- a/middleware/church_teams_export.py
+++ b/middleware/church_teams_export.py
@@ -1262,7 +1262,9 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
                 "sport_type": sport_type,
                 "sport_gender": sport_gender,
                 "sport_format": div["sport_format"],
-                "resource_type": "Court",
+                # Keep pod division rows aligned with venue_input.xlsx and the solver's
+                # exact C4 resource-type matching. Generic "Court" breaks all pod games.
+                "resource_type": POD_RESOURCE_EVENT_TYPE.get(sport_type, "Court"),
                 "minutes_per_game": mpg,
                 "planning_entries": planning,
                 "confirmed_entries": confirmed,

--- a/middleware/church_teams_export.py
+++ b/middleware/church_teams_export.py
@@ -3218,6 +3218,39 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
                 ws2.cell(row=ri, column=1, value=gid).fill = red_fill
             ri += 2
 
+        # Pool results summary — shown when pool_results present
+        pool_results = schedule_output.get("pool_results", [])
+        if pool_results:
+            ws2.merge_cells(
+                start_row=ri, start_column=1, end_row=ri, end_column=len(col_defs)
+            )
+            c = ws2.cell(row=ri, column=1, value="Pool Results")
+            c.fill, c.font = sec_fill, Font(bold=True)
+            ri += 1
+            for pr in pool_results:
+                pr_status = pr.get("status", "")
+                pr_fill   = red_fill if pr_status not in ("OPTIMAL", "FEASIBLE") else PatternFill(
+                    fgColor="C6EFCE", fill_type="solid"
+                )
+                ws2.cell(row=ri, column=1, value=pr.get("resource_type", "")).fill = pr_fill
+                ws2.cell(row=ri, column=2, value=pr_status).fill                   = pr_fill
+                ws2.cell(row=ri, column=3, value=f"Assigned: {len(pr.get('assignments', []))}").fill  = pr_fill
+                ws2.cell(row=ri, column=4, value=f"Unscheduled: {len(pr.get('unscheduled', []))}").fill = pr_fill
+                ri += 1
+                for diag in pr.get("diagnostics", []):
+                    for line in (diag.get("missing_resource_events") or []):
+                        ws2.cell(row=ri, column=2,
+                                 value=f"  No resources: {line.get('event','')} ({line.get('game_count',0)} games)"
+                                 ).fill = red_fill
+                        ri += 1
+                    if diag.get("shortage_slots", 0) > 0:
+                        ws2.cell(row=ri, column=2,
+                                 value=f"  Short {diag['shortage_slots']} slot(s): "
+                                       f"need {diag['required_slots']}, have {diag['available_slots']}"
+                                 ).fill = red_fill
+                        ri += 1
+            ri += 1
+
         ws2.cell(row=ri, column=1, value=snapshot)
         for ci, (_, width) in enumerate(col_defs, start=1):
             ws2.column_dimensions[get_column_letter(ci)].width = width

--- a/middleware/church_teams_export.py
+++ b/middleware/church_teams_export.py
@@ -2973,6 +2973,256 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
             logger.error(f"Error resending approval for participant {participant_contact.get('First Name')} {participant_contact.get('Last Name')}: {e}", exc_info=True)
             return False
                     
+    @staticmethod
+    def _build_schedule_output_flat_rows(
+        schedule_output: Dict[str, Any],
+        schedule_input: Dict[str, Any],
+    ) -> List[Dict[str, Any]]:
+        """Build sorted flat-list rows for the Schedule-by-Sport tab.
+
+        Each row joins one assignment from schedule_output with game metadata
+        from schedule_input.  Rows are sorted by event → stage order → round → slot.
+        """
+        game_meta = {g["game_id"]: g for g in schedule_input.get("games", [])}
+        res_meta  = {r["resource_id"]: r for r in schedule_input.get("resources", [])}
+        _STAGE_ORDER = {"Pool": 0, "R1": 1, "QF": 2, "Semi": 3, "Final": 4, "3rd": 5}
+        _DAY_DISPLAY = {
+            "Sat-1": "1st Sat", "Sun-1": "1st Sun",
+            "Sat-2": "2nd Sat", "Sun-2": "2nd Sun",
+        }
+        rows: List[Dict[str, Any]] = []
+        for a in schedule_output.get("assignments", []):
+            gid  = a["game_id"]
+            rid  = a["resource_id"]
+            slot = a["slot"]
+            game = game_meta.get(gid, {})
+            res  = res_meta.get(rid, {})
+            time_part = slot.rsplit("-", maxsplit=1)[-1] if "-" in slot else slot
+            rows.append({
+                "game_id":          gid,
+                "event":            game.get("event", ""),
+                "stage":            game.get("stage", ""),
+                "round":            game.get("round", ""),
+                "team_a_id":        game.get("team_a_id", ""),
+                "team_b_id":        game.get("team_b_id", ""),
+                "resource_label":   res.get("label", rid),
+                "day":              _DAY_DISPLAY.get(res.get("day", ""), res.get("day", "")),
+                "slot":             time_part,
+                "duration_minutes": game.get("duration_minutes", ""),
+            })
+        rows.sort(key=lambda r: (
+            r["event"],
+            _STAGE_ORDER.get(str(r["stage"]), 99),
+            int(r["round"]) if isinstance(r["round"], int) else 0,
+            r["slot"],
+        ))
+        return rows
+
+    @staticmethod
+    def _write_schedule_output_report(
+        filepath: Path,
+        schedule_output: Dict[str, Any],
+        schedule_input: Dict[str, Any],
+    ) -> None:
+        """Write Schedule-by-Time and Schedule-by-Sport Excel tabs from solver output.
+
+        Tab 1 — Schedule-by-Time: grid (rows = time slots, columns = courts),
+          colour-coded by sport, with session sections separated by grey rows.
+        Tab 2 — Schedule-by-Sport: flat list sorted by event → stage → round,
+          with auto-filter and an unscheduled section when applicable.
+        """
+        from openpyxl import Workbook
+        from openpyxl.styles import PatternFill, Font, Alignment
+        from openpyxl.utils import get_column_letter
+
+        game_meta: Dict[str, Dict[str, Any]] = {
+            g["game_id"]: g for g in schedule_input.get("games", [])
+        }
+        res_meta: Dict[str, Dict[str, Any]] = {
+            r["resource_id"]: r for r in schedule_input.get("resources", [])
+        }
+        assign_map: Dict[Tuple[str, str], Dict[str, Any]] = {
+            (a["resource_id"], a["slot"]): game_meta.get(a["game_id"], {"game_id": a["game_id"]})
+            for a in schedule_output.get("assignments", [])
+        }
+
+        solved_at     = schedule_output.get("solved_at", "")
+        status        = schedule_output.get("status", "")
+        n_assigned    = len(schedule_output.get("assignments", []))
+        n_unscheduled = len(schedule_output.get("unscheduled", []))
+        snapshot      = (
+            f"Generated: {solved_at}  |  Status: {status}  |  "
+            f"Scheduled: {n_assigned}  |  Unscheduled: {n_unscheduled}"
+        )
+
+        sec_fill = PatternFill(fgColor=SCHEDULE_SKETCH_COLOR_SECTION, fill_type="solid")
+        hdr_fill = PatternFill(fgColor=SCHEDULE_SKETCH_COLOR_HEADER,  fill_type="solid")
+        hdr_font = Font(bold=True, color="FFFFFF")
+        bold_font = Font(bold=True)
+        center   = Alignment(horizontal="center", vertical="center", wrap_text=True)
+        left     = Alignment(horizontal="left",   vertical="center", wrap_text=True)
+        red_fill = PatternFill(fgColor="FFC7CE", fill_type="solid")
+
+        _SPORT_COLORS: Dict[str, str] = {
+            SPORT_TYPE["BASKETBALL"]:       SCHEDULE_SKETCH_COLOR_BASKETBALL,
+            SPORT_TYPE["VOLLEYBALL_MEN"]:   SCHEDULE_SKETCH_COLOR_VB_MEN,
+            SPORT_TYPE["VOLLEYBALL_WOMEN"]: SCHEDULE_SKETCH_COLOR_VB_WOMEN,
+        }
+        _DAY_ORDER   = {"Sat-1": 0, "Sun-1": 1, "Sat-2": 2, "Sun-2": 3}
+        _DAY_DISPLAY = {
+            "Sat-1": "1st Saturday", "Sun-1": "1st Sunday",
+            "Sat-2": "2nd Saturday", "Sun-2": "2nd Sunday",
+        }
+
+        def _sport_fill(event: str) -> PatternFill:
+            return PatternFill(
+                fgColor=_SPORT_COLORS.get(event, "EBF1DE"), fill_type="solid"
+            )
+
+        def _slot_times(res: Dict[str, Any]) -> List[str]:
+            o_h, o_m = map(int, res["open_time"].split(":"))
+            c_h, c_m = map(int, res["close_time"].split(":"))
+            sm        = res["slot_minutes"]
+            open_min  = o_h * 60 + o_m
+            close_min = c_h * 60 + c_m
+            times: List[str] = []
+            t = open_min
+            while t + sm <= close_min:
+                times.append(f"{t // 60:02d}:{t % 60:02d}")
+                t += sm
+            return times
+
+        def _cell_text(game: Dict[str, Any]) -> str:
+            gid = game.get("game_id", "")
+            a   = str(game.get("team_a_id") or "")
+            b   = str(game.get("team_b_id") or "")
+            # Show teams only when they look like real church codes (≤5 chars, no hyphens)
+            if a and b and len(a) <= 5 and "-" not in a:
+                return f"{gid}\n{a} vs {b}"
+            return gid
+
+        # Group resources by session
+        sessions: Dict[str, List[Dict[str, Any]]] = {}
+        for res in schedule_input.get("resources", []):
+            sessions.setdefault(res["day"], []).append(res)
+        sorted_days = sorted(
+            sessions.keys(), key=lambda d: (_DAY_ORDER.get(d, 99), d)
+        )
+        max_courts = max((len(v) for v in sessions.values()), default=4)
+        n_cols     = 1 + max_courts
+
+        wb = Workbook()
+
+        # ── Tab 1: Schedule-by-Time ──────────────────────────────────────────
+        ws1       = wb.active
+        ws1.title = "Schedule-by-Time"
+
+        # Row 1 — report title (merged)
+        ws1.merge_cells(start_row=1, start_column=1, end_row=1, end_column=n_cols)
+        c = ws1.cell(row=1, column=1, value="VAY Sports Fest — Schedule by Time")
+        c.fill, c.font, c.alignment = hdr_fill, hdr_font, center
+
+        # Row 2 — column headers: Time + court labels from first session
+        ws1.cell(row=2, column=1, value="Time").font = bold_font
+        first_res = sorted(
+            sessions.get(sorted_days[0], [])[:max_courts], key=lambda r: r["resource_id"]
+        ) if sorted_days else []
+        for ci, res in enumerate(first_res, start=2):
+            c = ws1.cell(row=2, column=ci, value=res["label"])
+            c.fill, c.font, c.alignment = sec_fill, bold_font, center
+        ws1.freeze_panes = "A3"
+
+        cur_row = 3
+        for day in sorted_days:
+            day_res = sorted(sessions[day], key=lambda r: r["resource_id"])
+            if not day_res:
+                continue
+
+            # Section header (grey, merged)
+            ws1.merge_cells(
+                start_row=cur_row, start_column=1,
+                end_row=cur_row, end_column=n_cols,
+            )
+            c = ws1.cell(row=cur_row, column=1, value=_DAY_DISPLAY.get(day, day))
+            c.fill, c.font, c.alignment = sec_fill, bold_font, center
+            cur_row += 1
+
+            # Data rows — one per time slot in this session
+            for t_str in _slot_times(day_res[0]):
+                slot_label = f"{day}-{t_str}"
+                ws1.cell(row=cur_row, column=1, value=t_str).alignment = center
+                for ci, res in enumerate(day_res, start=2):
+                    game = assign_map.get((res["resource_id"], slot_label))
+                    cell = ws1.cell(row=cur_row, column=ci)
+                    if game:
+                        cell.value = _cell_text(game)
+                        cell.fill  = _sport_fill(game.get("event", ""))
+                    cell.alignment = center
+                cur_row += 1
+
+            cur_row += 1  # blank row between sessions
+
+        ws1.cell(row=cur_row + 1, column=1, value=snapshot)
+        ws1.column_dimensions["A"].width = 7
+        for ci in range(2, n_cols + 1):
+            ws1.column_dimensions[get_column_letter(ci)].width = 18
+
+        # ── Tab 2: Schedule-by-Sport ─────────────────────────────────────────
+        ws2       = wb.create_sheet("Schedule-by-Sport")
+        flat_rows = ChurchTeamsExporter._build_schedule_output_flat_rows(
+            schedule_output, schedule_input
+        )
+        col_defs = [
+            ("game_id",          14),
+            ("event",            28),
+            ("stage",             8),
+            ("round",             6),
+            ("team_a_id",        20),
+            ("team_b_id",        20),
+            ("resource_label",   14),
+            ("day",              10),
+            ("slot",              8),
+            ("duration_minutes", 16),
+        ]
+        cols = [col for col, _ in col_defs]
+
+        for ci, (col, _) in enumerate(col_defs, start=1):
+            cell = ws2.cell(row=1, column=ci, value=col)
+            cell.fill, cell.font = hdr_fill, hdr_font
+            cell.alignment = Alignment(horizontal="center")
+        ws2.freeze_panes = "A2"
+        ws2.auto_filter.ref = f"A1:{get_column_letter(len(col_defs))}1"
+
+        for ri, row in enumerate(flat_rows, start=2):
+            fill = _sport_fill(row.get("event", ""))
+            for ci, col in enumerate(cols, start=1):
+                cell = ws2.cell(row=ri, column=ci, value=row.get(col, ""))
+                cell.fill, cell.alignment = fill, left
+
+        # Unscheduled section at bottom
+        unscheduled = schedule_output.get("unscheduled", [])
+        ri = len(flat_rows) + 3
+        if unscheduled:
+            ws2.merge_cells(
+                start_row=ri, start_column=1, end_row=ri, end_column=len(col_defs)
+            )
+            c = ws2.cell(
+                row=ri, column=1,
+                value=f"Unscheduled Games ({len(unscheduled)})",
+            )
+            c.fill, c.font = red_fill, Font(bold=True)
+            for gid in unscheduled:
+                ri += 1
+                ws2.cell(row=ri, column=1, value=gid).fill = red_fill
+            ri += 2
+
+        ws2.cell(row=ri, column=1, value=snapshot)
+        for ci, (_, width) in enumerate(col_defs, start=1):
+            ws2.column_dimensions[get_column_letter(ci)].width = width
+
+        wb.save(filepath)
+        logger.info(f"Schedule output report written to: {filepath}")
+
     def close(self):
         """Closes any open connections (if necessary)."""
         logger.info("Closing ChurchTeamsExporter resources.") # MODIFIED LOGGER MESSAGE

--- a/middleware/config.py
+++ b/middleware/config.py
@@ -541,6 +541,10 @@ SCHEDULE_SKETCH_COLOR_VB_WOMEN    = "F4B8C1"   # pink
 SCHEDULE_SKETCH_COLOR_SECTION     = "D9D9D9"   # grey section divider
 SCHEDULE_SKETCH_COLOR_HEADER      = "595959"   # dark grey scenario header
 
+# Gym court count used when generating schedule_input.json for the CP-SAT solver.
+# Change this constant (not the code) to switch between 3/4/5-court scenarios.
+SCHEDULE_SOLVER_GYM_COURTS = 4
+
 # Configuration class
 class Config:
     """Configuration settings for VAYSF middleware."""

--- a/middleware/config.py
+++ b/middleware/config.py
@@ -428,11 +428,13 @@ COURT_ESTIMATE_RACQUET_EVENTS = [
 ]
 
 # Pool games per team — tune per sport once a venue is confirmed.
-# Kept at 2 as the minimum planning baseline.
+# Layer 1 team-sport planning is normalized around two pool games per team.
+# Individual events may still override this, but the current Sports Fest policy
+# keeps the live schedule-prep path on the exact-2-game baseline.
 COURT_ESTIMATE_DEFAULT_POOL_GAMES_PER_TEAM = 2
 COURT_ESTIMATE_POOL_GAMES_BASKETBALL       = 2
 COURT_ESTIMATE_POOL_GAMES_VOLLEYBALL_MEN   = 2
-COURT_ESTIMATE_POOL_GAMES_VOLLEYBALL_WOMEN = 3
+COURT_ESTIMATE_POOL_GAMES_VOLLEYBALL_WOMEN = 2
 COURT_ESTIMATE_POOL_GAMES_SOCCER           = 2
 COURT_ESTIMATE_POOL_GAMES_BIBLE_CHALLENGE  = 2
 

--- a/middleware/config.py
+++ b/middleware/config.py
@@ -567,6 +567,25 @@ SCHEDULE_STAGE_WINDOWS: dict[tuple[str, str], tuple[str | None, str | None]] = {
     **{(ev, "3rd"):   ("Sat-2-08:00", None)           for ev in GYM_SPORT_EVENTS},
 }
 
+# Finale sequence — ordered list of (event_name, stage) specifying the exact
+# back-to-back order for the closing ceremony block.  Consecutive pairs generate
+# C9 ordering constraints in the CP-SAT solver so the solver cannot swap them.
+#
+# Rules:
+#   • Same resource_type pairs (e.g. all three gym sports) are enforced by the
+#     solver directly — no extra config needed beyond this list.
+#   • Cross-resource-type pairs (e.g. a pod sport followed by a gym sport) are
+#     enforced via exact-slot pinning: set earliest_slot == latest_slot for the
+#     pod game in SCHEDULE_STAGE_WINDOWS so the solver for that pool is forced
+#     to a specific slot, then set the gym sport's earliest_slot to the next slot.
+#
+# Change the order here to change the finale order — no code changes required.
+SCHEDULE_FINAL_SEQUENCE: list[tuple[str, str]] = [
+    ("Volleyball - Women Team", "Final"),
+    ("Volleyball - Men Team",   "Final"),
+    ("Basketball - Men Team",   "Final"),
+]
+
 # Configuration class
 class Config:
     """Configuration settings for VAYSF middleware."""

--- a/middleware/config.py
+++ b/middleware/config.py
@@ -545,6 +545,28 @@ SCHEDULE_SKETCH_COLOR_HEADER      = "595959"   # dark grey scenario header
 # Change this constant (not the code) to switch between 3/4/5-court scenarios.
 SCHEDULE_SOLVER_GYM_COURTS = 4
 
+# Per-stage time-window constraints written into schedule_input.json.
+# Keys are (event_name, stage); values are (earliest_slot, latest_slot) using
+# slot-label format "Day-HH:MM" (must match a label the solver will see).
+# None for either bound means unconstrained on that side.
+# Pool/QF/Semi on Weekend 1 → leave unconstrained so the solver packs freely.
+# Finals on Weekend 2 → pin to the shared finale block so spectators can watch
+# Basketball, VB Men, VB Women, and Bible Challenge back-to-back on one court.
+GYM_SPORT_EVENTS = (
+    "Basketball - Men Team",
+    "Volleyball - Men Team",
+    "Volleyball - Women Team",
+)
+SCHEDULE_STAGE_WINDOWS: dict[tuple[str, str], tuple[str | None, str | None]] = {
+    # Pool and early rounds — Weekend 1 only (Sat-1 / Sun-1)
+    **{(ev, "Pool"):  ("Sat-1-08:00", "Sun-1-21:00") for ev in GYM_SPORT_EVENTS},
+    **{(ev, "QF"):    ("Sat-1-08:00", "Sun-1-21:00") for ev in GYM_SPORT_EVENTS},
+    **{(ev, "Semi"):  ("Sat-1-08:00", "Sun-1-21:00") for ev in GYM_SPORT_EVENTS},
+    # Finals — Weekend 2 afternoon finale block
+    **{(ev, "Final"): ("Sat-2-08:00", None)          for ev in GYM_SPORT_EVENTS},
+    **{(ev, "3rd"):   ("Sat-2-08:00", None)           for ev in GYM_SPORT_EVENTS},
+}
+
 # Configuration class
 class Config:
     """Configuration settings for VAYSF middleware."""

--- a/middleware/config.py
+++ b/middleware/config.py
@@ -545,6 +545,11 @@ SCHEDULE_SKETCH_COLOR_HEADER      = "595959"   # dark grey scenario header
 # Change this constant (not the code) to switch between 3/4/5-court scenarios.
 SCHEDULE_SOLVER_GYM_COURTS = 4
 
+# Fixed random seed for the CP-SAT solver.  Keeps schedules reproducible across
+# runs with identical inputs — the same optimal assignment is produced every time.
+# Change to 0 to disable the seed (CP-SAT default: non-deterministic).
+SCHEDULE_SOLVER_RANDOM_SEED = 42
+
 # Configuration class
 class Config:
     """Configuration settings for VAYSF middleware."""

--- a/middleware/config.py
+++ b/middleware/config.py
@@ -545,47 +545,6 @@ SCHEDULE_SKETCH_COLOR_HEADER      = "595959"   # dark grey scenario header
 # Change this constant (not the code) to switch between 3/4/5-court scenarios.
 SCHEDULE_SOLVER_GYM_COURTS = 4
 
-# Per-stage time-window constraints written into schedule_input.json.
-# Keys are (event_name, stage); values are (earliest_slot, latest_slot) using
-# slot-label format "Day-HH:MM" (must match a label the solver will see).
-# None for either bound means unconstrained on that side.
-# Pool/QF/Semi on Weekend 1 → leave unconstrained so the solver packs freely.
-# Finals on Weekend 2 → pin to the shared finale block so spectators can watch
-# Basketball, VB Men, VB Women, and Bible Challenge back-to-back on one court.
-GYM_SPORT_EVENTS = (
-    "Basketball - Men Team",
-    "Volleyball - Men Team",
-    "Volleyball - Women Team",
-)
-SCHEDULE_STAGE_WINDOWS: dict[tuple[str, str], tuple[str | None, str | None]] = {
-    # Pool and early rounds — Weekend 1 only (Sat-1 / Sun-1)
-    **{(ev, "Pool"):  ("Sat-1-08:00", "Sun-1-21:00") for ev in GYM_SPORT_EVENTS},
-    **{(ev, "QF"):    ("Sat-1-08:00", "Sun-1-21:00") for ev in GYM_SPORT_EVENTS},
-    **{(ev, "Semi"):  ("Sat-1-08:00", "Sun-1-21:00") for ev in GYM_SPORT_EVENTS},
-    # Finals — Weekend 2 afternoon finale block
-    **{(ev, "Final"): ("Sat-2-08:00", None)          for ev in GYM_SPORT_EVENTS},
-    **{(ev, "3rd"):   ("Sat-2-08:00", None)           for ev in GYM_SPORT_EVENTS},
-}
-
-# Finale sequence — ordered list of (event_name, stage) specifying the exact
-# back-to-back order for the closing ceremony block.  Consecutive pairs generate
-# C9 ordering constraints in the CP-SAT solver so the solver cannot swap them.
-#
-# Rules:
-#   • Same resource_type pairs (e.g. all three gym sports) are enforced by the
-#     solver directly — no extra config needed beyond this list.
-#   • Cross-resource-type pairs (e.g. a pod sport followed by a gym sport) are
-#     enforced via exact-slot pinning: set earliest_slot == latest_slot for the
-#     pod game in SCHEDULE_STAGE_WINDOWS so the solver for that pool is forced
-#     to a specific slot, then set the gym sport's earliest_slot to the next slot.
-#
-# Change the order here to change the finale order — no code changes required.
-SCHEDULE_FINAL_SEQUENCE: list[tuple[str, str]] = [
-    ("Volleyball - Women Team", "Final"),
-    ("Volleyball - Men Team",   "Final"),
-    ("Basketball - Men Team",   "Final"),
-]
-
 # Configuration class
 class Config:
     """Configuration settings for VAYSF middleware."""

--- a/middleware/main.py
+++ b/middleware/main.py
@@ -171,24 +171,24 @@ def parse_args() -> argparse.Namespace:
         help="Path for schedule_output.json (default: DATA_DIR/schedule_output.json)",
     )
 
-    # Export-schedule command
-    export_schedule_parser = subparsers.add_parser(
-        "export-schedule",
+    # Produce-schedule command
+    produce_schedule_parser = subparsers.add_parser(
+        "produce-schedule",
         help="Render schedule_output.json as a human-readable Excel timetable",
     )
-    export_schedule_parser.add_argument(
+    produce_schedule_parser.add_argument(
         "--input",
         default=None,
         dest="schedule_output",
         help="Path to schedule_output.json (default: DATA_DIR/schedule_output.json)",
     )
-    export_schedule_parser.add_argument(
-        "--schedule-input",
+    produce_schedule_parser.add_argument(
+        "--constraint",
         default=None,
         dest="schedule_input",
         help="Path to schedule_input.json (default: DATA_DIR/schedule_input.json)",
     )
-    export_schedule_parser.add_argument(
+    produce_schedule_parser.add_argument(
         "--output",
         default=None,
         help="Output path for xlsx (default: EXPORT_DIR/VAYSF_Schedule_YYYY-MM-DD.xlsx)",
@@ -800,7 +800,7 @@ def main() -> None:
         output_path = Path(args.output) if args.output else DATA_DIR / "schedule_output.json"
         exit_code = run_solve_schedule(input_path, output_path)
         sys.exit(exit_code)
-    elif args.command == "export-schedule":
+    elif args.command == "produce-schedule":
         so_path = Path(args.schedule_output) if args.schedule_output else DATA_DIR / "schedule_output.json"
         si_path = Path(args.schedule_input)  if args.schedule_input  else DATA_DIR / "schedule_input.json"
         if args.output:

--- a/middleware/main.py
+++ b/middleware/main.py
@@ -171,6 +171,29 @@ def parse_args() -> argparse.Namespace:
         help="Path for schedule_output.json (default: DATA_DIR/schedule_output.json)",
     )
 
+    # Export-schedule command
+    export_schedule_parser = subparsers.add_parser(
+        "export-schedule",
+        help="Render schedule_output.json as a human-readable Excel timetable",
+    )
+    export_schedule_parser.add_argument(
+        "--input",
+        default=None,
+        dest="schedule_output",
+        help="Path to schedule_output.json (default: DATA_DIR/schedule_output.json)",
+    )
+    export_schedule_parser.add_argument(
+        "--schedule-input",
+        default=None,
+        dest="schedule_input",
+        help="Path to schedule_input.json (default: DATA_DIR/schedule_input.json)",
+    )
+    export_schedule_parser.add_argument(
+        "--output",
+        default=None,
+        help="Output path for xlsx (default: EXPORT_DIR/VAYSF_Schedule_YYYY-MM-DD.xlsx)",
+    )
+
     # Generate-venue-template command
     venue_template_parser = subparsers.add_parser(
         "generate-venue-template",
@@ -777,6 +800,25 @@ def main() -> None:
         output_path = Path(args.output) if args.output else DATA_DIR / "schedule_output.json"
         exit_code = run_solve_schedule(input_path, output_path)
         sys.exit(exit_code)
+    elif args.command == "export-schedule":
+        so_path = Path(args.schedule_output) if args.schedule_output else DATA_DIR / "schedule_output.json"
+        si_path = Path(args.schedule_input)  if args.schedule_input  else DATA_DIR / "schedule_input.json"
+        if args.output:
+            out_path = Path(args.output)
+        else:
+            today = datetime.date.today().strftime("%Y-%m-%d")
+            out_path = Path(EXPORT_DIR) / f"VAYSF_Schedule_{today}.xlsx"
+        try:
+            so_data = json.loads(so_path.read_text(encoding="utf-8"))
+            si_data = json.loads(si_path.read_text(encoding="utf-8"))
+        except FileNotFoundError as exc:
+            logger.error(f"export-schedule: required file not found — {exc.filename}")
+            success = False
+        else:
+            out_path.parent.mkdir(parents=True, exist_ok=True)
+            ChurchTeamsExporter._write_schedule_output_report(out_path, so_data, si_data)
+            logger.info(f"Schedule Excel written to: {out_path.resolve()}")
+            success = True
     elif args.command == "generate-venue-template":
         out = Path(args.output) if args.output else None
         success = generate_venue_template(out)

--- a/middleware/main.py
+++ b/middleware/main.py
@@ -155,6 +155,22 @@ def parse_args() -> argparse.Namespace:
     reset_parser.add_argument("--probe", action="store_true",
                               help="Diagnostic: test what the PUT endpoint accepts for a single person (requires --person-id)")
 
+    # Solve-schedule command
+    solve_schedule_parser = subparsers.add_parser(
+        "solve-schedule",
+        help="Run CP-SAT scheduler: reads schedule_input.json, writes schedule_output.json",
+    )
+    solve_schedule_parser.add_argument(
+        "--input",
+        default=None,
+        help="Path to schedule_input.json (default: DATA_DIR/schedule_input.json)",
+    )
+    solve_schedule_parser.add_argument(
+        "--output",
+        default=None,
+        help="Path for schedule_output.json (default: DATA_DIR/schedule_output.json)",
+    )
+
     # Generate-venue-template command
     venue_template_parser = subparsers.add_parser(
         "generate-venue-template",
@@ -755,6 +771,12 @@ def main() -> None:
             except Exception as e:
                 logger.error(f"An exception occurred during report export: {e}", exc_info=True)
                 success = False
+    elif args.command == "solve-schedule":
+        from scheduler import run_solve_schedule
+        input_path = Path(args.input) if args.input else DATA_DIR / "schedule_input.json"
+        output_path = Path(args.output) if args.output else DATA_DIR / "schedule_output.json"
+        exit_code = run_solve_schedule(input_path, output_path)
+        sys.exit(exit_code)
     elif args.command == "generate-venue-template":
         out = Path(args.output) if args.output else None
         success = generate_venue_template(out)

--- a/middleware/run-schedule.bat
+++ b/middleware/run-schedule.bat
@@ -1,0 +1,82 @@
+@echo off
+REM ============================================================
+REM  run-schedule.bat
+REM  Step 1: solve-schedule  (CP-SAT solver)
+REM  Step 2: produce-schedule (Excel renderer)
+REM
+REM  Run from the middleware\ folder:
+REM      run-schedule.bat
+REM
+REM  Optional overrides (set before running or pass inline):
+REM      set SCHEDULE_SOLVER_TIMEOUT=60
+REM ============================================================
+
+echo.
+echo ============================================================
+echo  STEP 1 — solve-schedule
+echo ============================================================
+python main.py solve-schedule
+set SOLVE_CODE=%ERRORLEVEL%
+
+echo.
+echo  Exit code: %SOLVE_CODE%
+
+if %SOLVE_CODE% == 0 (
+    echo  [OK] All games scheduled successfully.
+    goto produce
+)
+
+if %SOLVE_CODE% == 1 (
+    echo  [WARN] Some games could not be scheduled.
+    echo         Check the log above for which games were dropped
+    echo         and verify their resource_type matches a resource
+    echo         in schedule_input.json.
+    echo         Continuing to produce-schedule so you can review
+    echo         the partial results...
+    goto produce
+)
+
+if %SOLVE_CODE% == 2 (
+    echo  [TIMEOUT] The solver ran out of time before finding a solution.
+    echo            This does NOT mean the schedule is impossible.
+    echo            Try increasing the timeout and re-running:
+    echo                set SCHEDULE_SOLVER_TIMEOUT=120
+    echo                run-schedule.bat
+    goto end
+)
+
+if %SOLVE_CODE% == 3 (
+    echo  [ERROR] A hard error occurred — bad input file, invalid JSON,
+    echo          or ortools is not installed.
+    echo          Check the log above for details.
+    goto end
+)
+
+echo  [UNKNOWN] Unexpected exit code: %SOLVE_CODE%
+goto end
+
+:produce
+echo.
+echo ============================================================
+echo  STEP 2 — produce-schedule
+echo ============================================================
+python main.py produce-schedule
+set PRODUCE_CODE=%ERRORLEVEL%
+
+echo.
+if %PRODUCE_CODE% == 0 (
+    echo  [OK] Schedule Excel written to the EXPORT_DIR.
+) else (
+    echo  [ERROR] produce-schedule failed with exit code %PRODUCE_CODE%.
+    echo          Check the log above for details.
+)
+
+:end
+echo.
+echo ============================================================
+echo  solve-schedule : exit %SOLVE_CODE%
+if defined PRODUCE_CODE (
+    echo  produce-schedule: exit %PRODUCE_CODE%
+)
+echo ============================================================
+echo.

--- a/middleware/run-schedule.bat
+++ b/middleware/run-schedule.bat
@@ -1,4 +1,5 @@
 @echo off
+setlocal
 REM ============================================================
 REM  run-schedule.bat
 REM  Step 1: solve-schedule  (CP-SAT solver)
@@ -9,15 +10,52 @@ REM      run-schedule.bat
 REM
 REM  Optional overrides (set before running or pass inline):
 REM      set SCHEDULE_SOLVER_TIMEOUT=60
+REM      set EXPORT_DIR=G:\Shared drives\...\VAYSF-data
 REM ============================================================
+
+if not defined EXPORT_DIR (
+    if exist ".env" (
+        for /f "usebackq tokens=1,* delims==" %%A in (".env") do (
+            if /I "%%A"=="EXPORT_DIR" set "EXPORT_DIR=%%B"
+        )
+    )
+)
+
+if defined EXPORT_DIR (
+    set "EXPORT_DIR=%EXPORT_DIR:"=%"
+    set "SCHEDULE_INPUT_PATH=%EXPORT_DIR%\schedule_input.json"
+    set "SCHEDULE_OUTPUT_PATH=%EXPORT_DIR%\schedule_output.json"
+) else (
+    set "SCHEDULE_INPUT_PATH=%CD%\data\schedule_input.json"
+    set "SCHEDULE_OUTPUT_PATH=%CD%\data\schedule_output.json"
+)
+
+if exist ".venv\Scripts\python.exe" (
+    set "PYTHON_EXE=.venv\Scripts\python.exe"
+) else (
+    set "PYTHON_EXE=python"
+)
 
 echo.
 echo ============================================================
-echo  STEP 1 — solve-schedule
+echo  STEP 1 - solve-schedule
 echo ============================================================
-python main.py solve-schedule
+echo  Input : %SCHEDULE_INPUT_PATH%
+echo  Output: %SCHEDULE_OUTPUT_PATH%
+echo  Python: %PYTHON_EXE%
+
+if not exist "%SCHEDULE_INPUT_PATH%" (
+    echo  [ERROR] schedule_input.json was not found at:
+    echo          %SCHEDULE_INPUT_PATH%
+    echo          Run export-church-teams first, or set EXPORT_DIR correctly.
+    set SOLVE_CODE=3
+    goto after_solve
+)
+
+%PYTHON_EXE% main.py solve-schedule --input "%SCHEDULE_INPUT_PATH%" --output "%SCHEDULE_OUTPUT_PATH%"
 set SOLVE_CODE=%ERRORLEVEL%
 
+:after_solve
 echo.
 echo  Exit code: %SOLVE_CODE%
 
@@ -46,7 +84,7 @@ if %SOLVE_CODE% == 2 (
 )
 
 if %SOLVE_CODE% == 3 (
-    echo  [ERROR] A hard error occurred — bad input file, invalid JSON,
+    echo  [ERROR] A hard error occurred - bad input file, invalid JSON,
     echo          or ortools is not installed.
     echo          Check the log above for details.
     goto end
@@ -58,9 +96,9 @@ goto end
 :produce
 echo.
 echo ============================================================
-echo  STEP 2 — produce-schedule
+echo  STEP 2 - produce-schedule
 echo ============================================================
-python main.py produce-schedule
+%PYTHON_EXE% main.py produce-schedule --input "%SCHEDULE_OUTPUT_PATH%" --constraint "%SCHEDULE_INPUT_PATH%"
 set PRODUCE_CODE=%ERRORLEVEL%
 
 echo.

--- a/middleware/scheduler.py
+++ b/middleware/scheduler.py
@@ -373,6 +373,15 @@ def _solve_one_pool(
                 if g_e in game_global_slot and g_l in game_global_slot:
                     model.Add(game_global_slot[g_l] > game_global_slot[g_e])
 
+    # C9 — finale sequence: enforce exact ordering between named game IDs
+    # Rules where one or both game IDs are absent from this pool are silently skipped
+    # (cross-resource-type finale pairs live in separate pools; handle them via C8).
+    for rule in pool_input.get("sequence", []):
+        g_e = rule.get("earlier_game_id")
+        g_l = rule.get("later_game_id")
+        if g_e in game_global_slot and g_l in game_global_slot:
+            model.Add(game_global_slot[g_l] > game_global_slot[g_e])
+
     # C6 — minimum rest: no team plays in two adjacent global slots
     team_global_assignments: dict[str, dict[int, list[Any]]] = {}
     for gid, vd in game_vars.items():
@@ -521,6 +530,21 @@ def solve(
         if rt:
             precedence_by_type.setdefault(rt, []).append(rule)
 
+    # Route each sequence rule to its pool via game_id → resource_type.
+    # Cross-pool rules (earlier and later in different pools) are sent to both
+    # pools; _solve_one_pool silently skips rules where one ID is absent.
+    game_id_to_type: dict[str, str] = {g["game_id"]: g["resource_type"] for g in games}
+    sequence: list[dict] = schedule_input.get("sequence", [])
+    sequence_by_type: dict[str, list[dict]] = {}
+    for rule in sequence:
+        types_touched: set[str] = set()
+        for key in ("earlier_game_id", "later_game_id"):
+            rt = game_id_to_type.get(rule.get(key, ""))
+            if rt:
+                types_touched.add(rt)
+        for rt in types_touched:
+            sequence_by_type.setdefault(rt, []).append(rule)
+
     if not games_by_type:
         return {
             "status":              STATUS_OPTIMAL,
@@ -540,6 +564,7 @@ def solve(
             "games":      games_by_type[resource_type],
             "resources":  resources_by_type.get(resource_type, []),
             "precedence": precedence_by_type.get(resource_type, []),
+            "sequence":   sequence_by_type.get(resource_type, []),
         }
         result = _solve_one_pool(pool_input, timeout_seconds)
         result["resource_type"] = resource_type

--- a/middleware/scheduler.py
+++ b/middleware/scheduler.py
@@ -64,7 +64,7 @@ def load_schedule_input(path: Path) -> dict[str, Any]:
     """Load schedule_input.json and validate required top-level keys."""
     with path.open(encoding="utf-8") as fh:
         data = json.load(fh)
-    for key in ("games", "resources", "precedence"):
+    for key in ("games", "resources"):
         if key not in data:
             raise ValueError(f"schedule_input.json missing required key: {key!r}")
     return data
@@ -257,9 +257,8 @@ def _solve_one_pool(
     """
     from ortools.sat.python import cp_model  # import guard
 
-    games:      list[dict] = pool_input["games"]
-    resources:  list[dict] = pool_input["resources"]
-    precedence: list[dict] = pool_input.get("precedence", [])
+    games:     list[dict] = pool_input["games"]
+    resources: list[dict] = pool_input["resources"]
 
     res_by_id:   dict[str, dict]        = {r["resource_id"]: r for r in resources}
     res_slots:   dict[str, list[str]]   = build_resource_slots(resources)
@@ -358,30 +357,6 @@ def _solve_one_pool(
             label = res_slots[rid][t]
             model.Add(gv == slot_to_global[label]).OnlyEnforceIf(var)
 
-    # C5 — stage ordering: every earlier_stage game must precede every later_stage game
-    by_event_stage: dict[tuple[str, str], list[str]] = {}
-    for game in games:
-        key = (game["event"], game["stage"])
-        by_event_stage.setdefault(key, []).append(game["game_id"])
-
-    for rule in precedence:
-        event       = rule["event"]
-        earlier_gids = by_event_stage.get((event, rule["earlier_stage"]), [])
-        later_gids   = by_event_stage.get((event, rule["later_stage"]),   [])
-        for g_e in earlier_gids:
-            for g_l in later_gids:
-                if g_e in game_global_slot and g_l in game_global_slot:
-                    model.Add(game_global_slot[g_l] > game_global_slot[g_e])
-
-    # C9 — finale sequence: enforce exact ordering between named game IDs
-    # Rules where one or both game IDs are absent from this pool are silently skipped
-    # (cross-resource-type finale pairs live in separate pools; handle them via C8).
-    for rule in pool_input.get("sequence", []):
-        g_e = rule.get("earlier_game_id")
-        g_l = rule.get("later_game_id")
-        if g_e in game_global_slot and g_l in game_global_slot:
-            model.Add(game_global_slot[g_l] > game_global_slot[g_e])
-
     # C6 — minimum rest: no team plays in two adjacent global slots
     team_global_assignments: dict[str, dict[int, list[Any]]] = {}
     for gid, vd in game_vars.items():
@@ -405,26 +380,6 @@ def _solve_one_pool(
                 for v2 in next_vars:
                     # NOT (v1 AND v2) — at most one of adjacent-slot vars can be true
                     model.AddBoolOr([v1.Not(), v2.Not()])
-
-    # C8 — per-game time windows (earliest_slot / latest_slot from schedule_input.json)
-    for game in games:
-        gid = game["game_id"]
-        if gid not in game_global_slot:
-            continue
-        lo_label = game.get("earliest_slot")
-        hi_label = game.get("latest_slot")
-        if lo_label:
-            lo = slot_to_global.get(lo_label)
-            if lo is not None:
-                model.Add(game_global_slot[gid] >= lo)
-            else:
-                logger.warning(f"Game {gid!r}: earliest_slot {lo_label!r} not in this pool's slots; ignored")
-        if hi_label:
-            hi = slot_to_global.get(hi_label)
-            if hi is not None:
-                model.Add(game_global_slot[gid] <= hi)
-            else:
-                logger.warning(f"Game {gid!r}: latest_slot {hi_label!r} not in this pool's slots; ignored")
 
     # Objective — minimize the latest occupied global slot (pack games toward start)
     if game_global_slot:
@@ -509,11 +464,10 @@ def solve(
         INFEASIBLE — every pool failed (no assignments anywhere)
         UNKNOWN    — at least one pool timed out; none solved
     """
-    games:      list[dict] = schedule_input["games"]
-    resources:  list[dict] = schedule_input["resources"]
-    precedence: list[dict] = schedule_input.get("precedence", [])
+    games:     list[dict] = schedule_input["games"]
+    resources: list[dict] = schedule_input["resources"]
 
-    # Partition games and resources by resource_type
+    # Partition games and resources by resource_type for independent pool solves
     games_by_type:     dict[str, list[dict]] = {}
     for g in games:
         games_by_type.setdefault(g["resource_type"], []).append(g)
@@ -522,34 +476,11 @@ def solve(
     for r in resources:
         resources_by_type.setdefault(r["resource_type"], []).append(r)
 
-    # Route each precedence rule to its pool via event → resource_type
-    event_to_type: dict[str, str] = {g["event"]: g["resource_type"] for g in games}
-    precedence_by_type: dict[str, list[dict]] = {}
-    for rule in precedence:
-        rt = event_to_type.get(rule["event"])
-        if rt:
-            precedence_by_type.setdefault(rt, []).append(rule)
-
-    # Route each sequence rule to its pool via game_id → resource_type.
-    # Cross-pool rules (earlier and later in different pools) are sent to both
-    # pools; _solve_one_pool silently skips rules where one ID is absent.
-    game_id_to_type: dict[str, str] = {g["game_id"]: g["resource_type"] for g in games}
-    sequence: list[dict] = schedule_input.get("sequence", [])
-    sequence_by_type: dict[str, list[dict]] = {}
-    for rule in sequence:
-        types_touched: set[str] = set()
-        for key in ("earlier_game_id", "later_game_id"):
-            rt = game_id_to_type.get(rule.get(key, ""))
-            if rt:
-                types_touched.add(rt)
-        for rt in types_touched:
-            sequence_by_type.setdefault(rt, []).append(rule)
-
     if not games_by_type:
         return {
             "status":              STATUS_OPTIMAL,
             "solver_wall_seconds": 0.0,
-            "assignments":         [],
+            "assignments":         list(schedule_input.get("playoff_slots", [])),
             "unscheduled":         [],
             "pool_results":        [],
         }
@@ -561,10 +492,8 @@ def solve(
 
     for resource_type in sorted(games_by_type.keys()):
         pool_input = {
-            "games":      games_by_type[resource_type],
-            "resources":  resources_by_type.get(resource_type, []),
-            "precedence": precedence_by_type.get(resource_type, []),
-            "sequence":   sequence_by_type.get(resource_type, []),
+            "games":     games_by_type[resource_type],
+            "resources": resources_by_type.get(resource_type, []),
         }
         result = _solve_one_pool(pool_input, timeout_seconds)
         result["resource_type"] = resource_type
@@ -591,6 +520,20 @@ def solve(
         top_status = STATUS_UNKNOWN
     else:
         top_status = STATUS_INFEASIBLE
+
+    # Merge pre-assigned playoff slots from schedule_input into assignments.
+    playoff_slots: list[dict] = schedule_input.get("playoff_slots", [])
+    if playoff_slots:
+        for ps in playoff_slots:
+            if ps.get("resource_id") and ps.get("slot"):
+                all_assignments.append({
+                    "game_id":     ps["game_id"],
+                    "resource_id": ps["resource_id"],
+                    "slot":        ps["slot"],
+                    "event":       ps.get("event", ""),
+                    "stage":       ps.get("stage", ""),
+                })
+        logger.info(f"Merged {len(playoff_slots)} pre-assigned playoff slots into output.")
 
     logger.info(
         f"Solver (all pools): status={top_status}, "

--- a/middleware/scheduler.py
+++ b/middleware/scheduler.py
@@ -6,9 +6,17 @@ CLI:
 
 Reads  : schedule_input.json (written by export-church-teams, Issue #87/#96)
 Writes : schedule_output.json to DATA_DIR (or --output path)
-Exits  : 0 = OPTIMAL or FEASIBLE, 1 = INFEASIBLE, 2 = error
+Exits  : 0 = OPTIMAL or FEASIBLE (all pools solved)
+         1 = PARTIAL (some pools failed) / INFEASIBLE (no pools solved) / UNKNOWN
+         2 = error (bad input or ortools missing)
 
-Constraints implemented:
+Architecture — pool decomposition:
+  Games are partitioned by resource_type and solved independently.
+  A Badminton slot shortage cannot cascade into an INFEASIBLE result for Tennis or
+  Gym sports.  Each pool's result lands in pool_results[]; the top-level status
+  reflects the worst outcome across all pools.
+
+Constraints implemented (per pool):
   C1  Each game assigned to exactly one (resource, start_slot).
   C2  Each (resource, slot) hosts at most one game (multi-slot aware).
   C3  No team plays two games in the same time slot.
@@ -17,9 +25,9 @@ Constraints implemented:
   C6  Minimum rest — no team plays in two adjacent global time slots.
   C7  Multi-slot games — a game whose duration > slot_minutes blocks consecutive slots.
 
-Objective: minimize the index of the latest occupied global slot (pack games early).
+Objective (per pool): minimize the index of the latest occupied global slot.
 
-Out of scope for this issue (document for future work):
+Out of scope (future work):
   - Cross-sport participant conflicts (a person in both Basketball and Badminton).
   - Church-requested blackout windows (earliest_slot / latest_slot fields are in
     the schema; wiring them up is a one-liner once they are populated upstream).
@@ -41,10 +49,11 @@ _DAY_ORDER: dict[str, int] = {"Sat-1": 0, "Sun-1": 1, "Sat-2": 2, "Sun-2": 3}
 _DEFAULT_TIMEOUT = float(os.getenv("SCHEDULE_SOLVER_TIMEOUT", "30.0"))
 _OUTPUT_FILENAME = "schedule_output.json"
 
-STATUS_OPTIMAL = "OPTIMAL"
-STATUS_FEASIBLE = "FEASIBLE"
+STATUS_OPTIMAL    = "OPTIMAL"
+STATUS_FEASIBLE   = "FEASIBLE"
+STATUS_PARTIAL    = "PARTIAL"
 STATUS_INFEASIBLE = "INFEASIBLE"
-STATUS_UNKNOWN = "UNKNOWN"
+STATUS_UNKNOWN    = "UNKNOWN"
 
 
 # ---------------------------------------------------------------------------
@@ -90,10 +99,10 @@ def build_resource_slots(resources: list[dict]) -> dict[str, list[str]]:
     """
     result: dict[str, list[str]] = {}
     for res in resources:
-        open_min = _parse_time_minutes(res["open_time"])
+        open_min  = _parse_time_minutes(res["open_time"])
         close_min = _parse_time_minutes(res["close_time"])
-        slot_min = res["slot_minutes"]
-        day = res["day"]
+        slot_min  = res["slot_minutes"]
+        day       = res["day"]
         slots: list[str] = []
         t = open_min
         while t + slot_min <= close_min:
@@ -114,7 +123,7 @@ def build_infeasibility_diagnostics(schedule_input: dict[str, Any]) -> list[dict
     This does not prove why every infeasible solve failed, but it does surface
     obvious shortages such as "Badminton Court needs 24 slots, only 20 exist".
     """
-    games: list[dict] = schedule_input["games"]
+    games: list[dict]     = schedule_input["games"]
     resources: list[dict] = schedule_input["resources"]
     res_slots = build_resource_slots(resources)
 
@@ -130,20 +139,18 @@ def build_infeasibility_diagnostics(schedule_input: dict[str, Any]) -> list[dict
         )
 
     required_by_type: dict[str, int] = defaultdict(int)
-    event_rollups: dict[tuple[str, str], dict[str, Any]] = {}
-    missing_rollups: dict[tuple[str, str], dict[str, Any]] = {}
+    event_rollups:    dict[tuple[str, str], dict[str, Any]] = {}
+    missing_rollups:  dict[tuple[str, str], dict[str, Any]] = {}
 
     for game in games:
-        event = game["event"]
+        event         = game["event"]
         resource_type = game["resource_type"]
-        compatible = resources_by_type.get(resource_type, [])
+        compatible    = resources_by_type.get(resource_type, [])
 
         if not compatible:
-            key = (event, resource_type)
+            key    = (event, resource_type)
             rollup = missing_rollups.setdefault(key, {
-                "event": event,
-                "resource_type": resource_type,
-                "game_count": 0,
+                "event": event, "resource_type": resource_type, "game_count": 0,
             })
             rollup["game_count"] += 1
             continue
@@ -152,46 +159,38 @@ def build_infeasibility_diagnostics(schedule_input: dict[str, Any]) -> list[dict
             max(1, math.ceil(game["duration_minutes"] / resource["slot_minutes"]))
             for resource in compatible
         )
-        key = (event, resource_type)
+        key    = (event, resource_type)
         rollup = event_rollups.setdefault(key, {
-            "event": event,
-            "resource_type": resource_type,
-            "game_count": 0,
-            "required_slots": 0,
+            "event": event, "resource_type": resource_type,
+            "game_count": 0, "required_slots": 0,
         })
-        rollup["game_count"] += 1
+        rollup["game_count"]    += 1
         rollup["required_slots"] += min_slots
         required_by_type[resource_type] += min_slots
 
     diagnostics: list[dict[str, Any]] = []
     resource_types = sorted({
-        *(event_resource_type for _, event_resource_type in event_rollups.keys()),
-        *(event_resource_type for _, event_resource_type in missing_rollups.keys()),
+        *(rt for _, rt in event_rollups.keys()),
+        *(rt for _, rt in missing_rollups.keys()),
     })
 
     for resource_type in resource_types:
         events = sorted(
-            (
-                rollup for rollup in event_rollups.values()
-                if rollup["resource_type"] == resource_type
-            ),
-            key=lambda rollup: (-rollup["required_slots"], rollup["event"]),
+            (r for r in event_rollups.values() if r["resource_type"] == resource_type),
+            key=lambda r: (-r["required_slots"], r["event"]),
         )
         missing_events = sorted(
-            (
-                rollup for rollup in missing_rollups.values()
-                if rollup["resource_type"] == resource_type
-            ),
-            key=lambda rollup: (-rollup["game_count"], rollup["event"]),
+            (r for r in missing_rollups.values() if r["resource_type"] == resource_type),
+            key=lambda r: (-r["game_count"], r["event"]),
         )
-        required_slots = required_by_type.get(resource_type, 0)
+        required_slots  = required_by_type.get(resource_type, 0)
         available_slots = available_by_type.get(resource_type, 0)
         diagnostics.append({
-            "resource_type": resource_type,
-            "required_slots": required_slots,
-            "available_slots": available_slots,
-            "shortage_slots": max(required_slots - available_slots, 0),
-            "events": events,
+            "resource_type":         resource_type,
+            "required_slots":        required_slots,
+            "available_slots":       available_slots,
+            "shortage_slots":        max(required_slots - available_slots, 0),
+            "events":                events,
             "missing_resource_events": missing_events,
         })
 
@@ -202,10 +201,10 @@ def format_infeasibility_diagnostics(diagnostics: list[dict[str, Any]]) -> list[
     """Render operator-friendly lower-bound diagnostics for logging/output."""
     lines: list[str] = []
     for diagnostic in diagnostics:
-        resource_type = diagnostic["resource_type"]
-        required_slots = diagnostic["required_slots"]
+        resource_type   = diagnostic["resource_type"]
+        required_slots  = diagnostic["required_slots"]
         available_slots = diagnostic["available_slots"]
-        shortage_slots = diagnostic["shortage_slots"]
+        shortage_slots  = diagnostic["shortage_slots"]
 
         for missing in diagnostic.get("missing_resource_events", []):
             lines.append(
@@ -236,31 +235,37 @@ def format_infeasibility_diagnostics(diagnostics: list[dict[str, Any]]) -> list[
 
 
 # ---------------------------------------------------------------------------
-# Solver
+# Single-pool solver (internal)
 # ---------------------------------------------------------------------------
 
-def solve(
-    schedule_input: dict[str, Any],
-    timeout_seconds: float = _DEFAULT_TIMEOUT,
+def _solve_one_pool(
+    pool_input: dict[str, Any],
+    timeout_seconds: float,
 ) -> dict[str, Any]:
-    """Build and solve the CP-SAT assignment model.
+    """Build and solve a CP-SAT model for one resource-type pool.
+
+    pool_input must contain 'games', 'resources', and 'precedence' for a single
+    resource_type.  Called by solve() once per pool.
 
     Returns a dict with keys:
         status              : 'OPTIMAL' | 'FEASIBLE' | 'INFEASIBLE' | 'UNKNOWN'
         solver_wall_seconds : float
         assignments         : list of {game_id, resource_id, slot}
         unscheduled         : list of game_ids the solver could not place
+        diagnostics         : (only present when status is not OPTIMAL/FEASIBLE)
+                              lower-bound capacity summary for this pool
     """
-    from ortools.sat.python import cp_model  # import guard — keeps module importable without ortools
+    from ortools.sat.python import cp_model  # import guard
 
-    games: list[dict] = schedule_input["games"]
-    resources: list[dict] = schedule_input["resources"]
-    precedence: list[dict] = schedule_input.get("precedence", [])
+    games:      list[dict] = pool_input["games"]
+    resources:  list[dict] = pool_input["resources"]
+    precedence: list[dict] = pool_input.get("precedence", [])
 
-    res_by_id: dict[str, dict] = {r["resource_id"]: r for r in resources}
-    res_slots: dict[str, list[str]] = build_resource_slots(resources)
+    res_by_id:   dict[str, dict]        = {r["resource_id"]: r for r in resources}
+    res_slots:   dict[str, list[str]]   = build_resource_slots(resources)
 
-    # C4 — court-type routing: group resource IDs by resource_type
+    # C4 — court-type routing (within this pool all games share one resource_type,
+    # but res_by_type keeps the structure consistent with the constraint code)
     res_by_type: dict[str, list[str]] = {}
     for r in resources:
         res_by_type.setdefault(r["resource_type"], []).append(r["resource_id"])
@@ -269,29 +274,29 @@ def solve(
     all_labels: set[str] = set()
     for slots in res_slots.values():
         all_labels.update(slots)
-    sorted_labels = sorted(all_labels, key=_slot_sort_key)
-    slot_to_global: dict[str, int] = {lbl: i for i, lbl in enumerate(sorted_labels)}
-    n_global = len(sorted_labels)
+    sorted_labels  = sorted(all_labels, key=_slot_sort_key)
+    slot_to_global = {lbl: i for i, lbl in enumerate(sorted_labels)}
+    n_global       = len(sorted_labels)
 
-    model = cp_model.CpModel()
-    game_meta: dict[str, dict] = {g["game_id"]: g for g in games}
+    model     = cp_model.CpModel()
+    game_meta = {g["game_id"]: g for g in games}
 
     # Decision variables: x[(gid, rid, t)] = BoolVar
     # True iff game gid starts on resource rid at slot index t.
     game_vars: dict[str, dict[tuple[str, int], Any]] = {}
 
     for game in games:
-        gid = game["game_id"]
+        gid           = game["game_id"]
         resource_type = game["resource_type"]
-        duration = game["duration_minutes"]
-        compatible = res_by_type.get(resource_type, [])
+        duration      = game["duration_minutes"]
+        compatible    = res_by_type.get(resource_type, [])
 
         game_vars[gid] = {}
         for rid in compatible:
-            slots = res_slots[rid]
+            slots    = res_slots[rid]
             slot_min = res_by_id[rid]["slot_minutes"]
             # C7 — multi-slot: game occupies ceil(duration/slot_min) consecutive slots
-            n_slots = max(1, math.ceil(duration / slot_min))
+            n_slots  = max(1, math.ceil(duration / slot_min))
             for t in range(len(slots) - n_slots + 1):
                 var = model.NewBoolVar(f"x_{gid}_{rid}_{t}")
                 game_vars[gid][(rid, t)] = var
@@ -310,7 +315,7 @@ def solve(
         duration = game_meta[gid]["duration_minutes"]
         for (rid, t), var in vd.items():
             slot_min = res_by_id[rid]["slot_minutes"]
-            n_slots = max(1, math.ceil(duration / slot_min))
+            n_slots  = max(1, math.ceil(duration / slot_min))
             for s in range(t, t + n_slots):
                 slot_occupancy.setdefault((rid, s), []).append(var)
 
@@ -321,13 +326,13 @@ def solve(
     # C3 — no team plays two games in the same time slot
     team_slot_vars: dict[tuple[str, str], list[Any]] = {}
     for gid, vd in game_vars.items():
-        game = game_meta[gid]
-        teams = [t for t in (game.get("team_a_id"), game.get("team_b_id")) if t]
+        game     = game_meta[gid]
+        teams    = [t for t in (game.get("team_a_id"), game.get("team_b_id")) if t]
         duration = game["duration_minutes"]
         for (rid, t), var in vd.items():
-            slots = res_slots[rid]
+            slots    = res_slots[rid]
             slot_min = res_by_id[rid]["slot_minutes"]
-            n_slots = max(1, math.ceil(duration / slot_min))
+            n_slots  = max(1, math.ceil(duration / slot_min))
             for s in range(t, t + n_slots):
                 slot_label = slots[s]
                 for team in teams:
@@ -342,7 +347,7 @@ def solve(
     for gid, vd in game_vars.items():
         if not vd:
             continue
-        gv = model.NewIntVar(0, n_global - 1, f"gslot_{gid}")
+        gv = model.NewIntVar(0, max(n_global - 1, 0), f"gslot_{gid}")
         game_global_slot[gid] = gv
         for (rid, t), var in vd.items():
             label = res_slots[rid][t]
@@ -355,9 +360,9 @@ def solve(
         by_event_stage.setdefault(key, []).append(game["game_id"])
 
     for rule in precedence:
-        event = rule["event"]
+        event       = rule["event"]
         earlier_gids = by_event_stage.get((event, rule["earlier_stage"]), [])
-        later_gids = by_event_stage.get((event, rule["later_stage"]), [])
+        later_gids   = by_event_stage.get((event, rule["later_stage"]),   [])
         for g_e in earlier_gids:
             for g_l in later_gids:
                 if g_e in game_global_slot and g_l in game_global_slot:
@@ -366,10 +371,10 @@ def solve(
     # C6 — minimum rest: no team plays in two adjacent global slots
     team_global_assignments: dict[str, dict[int, list[Any]]] = {}
     for gid, vd in game_vars.items():
-        game = game_meta[gid]
+        game  = game_meta[gid]
         teams = [t for t in (game.get("team_a_id"), game.get("team_b_id")) if t]
         for (rid, t), var in vd.items():
-            label = res_slots[rid][t]
+            label      = res_slots[rid][t]
             global_idx = slot_to_global[label]
             for team in teams:
                 team_global_assignments.setdefault(team, {}).setdefault(global_idx, []).append(var)
@@ -378,12 +383,12 @@ def solve(
         for g_idx, vars_at_g in by_idx.items():
             for v1 in vars_at_g:
                 for v2 in by_idx.get(g_idx + 1, []):
-                    # NOT (v1 AND v2) — at most one of adjacent-slot variables can be true
+                    # NOT (v1 AND v2) — at most one of adjacent-slot vars can be true
                     model.AddBoolOr([v1.Not(), v2.Not()])
 
     # Objective — minimize the latest occupied global slot (pack games toward start)
     if game_global_slot:
-        latest = model.NewIntVar(0, n_global - 1, "latest_slot")
+        latest = model.NewIntVar(0, max(n_global - 1, 0), "latest_slot")
         for gv in game_global_slot.values():
             model.Add(latest >= gv)
         model.Minimize(latest)
@@ -393,18 +398,18 @@ def solve(
     solver.parameters.max_time_in_seconds = timeout_seconds
     status_code = solver.Solve(model)
 
-    wall_time = solver.WallTime()
+    wall_time   = solver.WallTime()
     status_name = solver.StatusName(status_code)
 
     status_map = {
-        "OPTIMAL": STATUS_OPTIMAL,
-        "FEASIBLE": STATUS_FEASIBLE,
+        "OPTIMAL":    STATUS_OPTIMAL,
+        "FEASIBLE":   STATUS_FEASIBLE,
         "INFEASIBLE": STATUS_INFEASIBLE,
     }
     status = status_map.get(status_name, STATUS_UNKNOWN)
 
     assignments: list[dict] = []
-    unscheduled: list[str] = []
+    unscheduled: list[str]  = []
 
     if status in (STATUS_OPTIMAL, STATUS_FEASIBLE):
         for gid, vd in game_vars.items():
@@ -412,9 +417,9 @@ def solve(
             for (rid, t), var in vd.items():
                 if solver.Value(var):
                     assignments.append({
-                        "game_id": gid,
+                        "game_id":     gid,
                         "resource_id": rid,
-                        "slot": res_slots[rid][t],
+                        "slot":        res_slots[rid][t],
                     })
                     assigned = True
                     break
@@ -423,15 +428,127 @@ def solve(
     else:
         unscheduled = [g["game_id"] for g in games]
 
-    logger.info(
-        f"Solver: status={status}, wall_time={wall_time:.3f}s, "
-        f"assigned={len(assignments)}, unscheduled={len(unscheduled)}"
-    )
-    return {
-        "status": status,
+    result: dict[str, Any] = {
+        "status":              status,
         "solver_wall_seconds": round(wall_time, 3),
-        "assignments": assignments,
-        "unscheduled": unscheduled,
+        "assignments":         assignments,
+        "unscheduled":         unscheduled,
+    }
+    if status not in (STATUS_OPTIMAL, STATUS_FEASIBLE):
+        result["diagnostics"] = build_infeasibility_diagnostics(pool_input)
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Public solver — decomposes by resource_type pool
+# ---------------------------------------------------------------------------
+
+def solve(
+    schedule_input: dict[str, Any],
+    timeout_seconds: float = _DEFAULT_TIMEOUT,
+) -> dict[str, Any]:
+    """Partition games by resource_type and solve each pool independently.
+
+    A capacity shortage in one pool (e.g. Badminton Courts) does not cascade
+    into an INFEASIBLE result for other pools (e.g. Gym Courts or Tennis).
+
+    Returns a dict with keys:
+        status              : 'OPTIMAL' | 'FEASIBLE' | 'PARTIAL' | 'INFEASIBLE' | 'UNKNOWN'
+        solver_wall_seconds : float  (sum across all pools)
+        assignments         : list of {game_id, resource_id, slot}  (all pools merged)
+        unscheduled         : list of game_ids  (all failed pools merged)
+        pool_results        : list of per-pool result dicts, each with
+                              {resource_type, status, solver_wall_seconds,
+                               assignments, unscheduled, diagnostics?}
+
+    Status semantics:
+        OPTIMAL    — every pool solved optimally
+        FEASIBLE   — every pool solved (at least one FEASIBLE, none failed)
+        PARTIAL    — at least one pool solved AND at least one pool failed
+        INFEASIBLE — every pool failed (no assignments anywhere)
+        UNKNOWN    — at least one pool timed out; none solved
+    """
+    games:      list[dict] = schedule_input["games"]
+    resources:  list[dict] = schedule_input["resources"]
+    precedence: list[dict] = schedule_input.get("precedence", [])
+
+    # Partition games and resources by resource_type
+    games_by_type:     dict[str, list[dict]] = {}
+    for g in games:
+        games_by_type.setdefault(g["resource_type"], []).append(g)
+
+    resources_by_type: dict[str, list[dict]] = {}
+    for r in resources:
+        resources_by_type.setdefault(r["resource_type"], []).append(r)
+
+    # Route each precedence rule to its pool via event → resource_type
+    event_to_type: dict[str, str] = {g["event"]: g["resource_type"] for g in games}
+    precedence_by_type: dict[str, list[dict]] = {}
+    for rule in precedence:
+        rt = event_to_type.get(rule["event"])
+        if rt:
+            precedence_by_type.setdefault(rt, []).append(rule)
+
+    if not games_by_type:
+        return {
+            "status":              STATUS_OPTIMAL,
+            "solver_wall_seconds": 0.0,
+            "assignments":         [],
+            "unscheduled":         [],
+            "pool_results":        [],
+        }
+
+    pool_results:       list[dict[str, Any]] = []
+    all_assignments:    list[dict]           = []
+    all_unscheduled:    list[str]            = []
+    total_wall_seconds: float                = 0.0
+
+    for resource_type in sorted(games_by_type.keys()):
+        pool_input = {
+            "games":      games_by_type[resource_type],
+            "resources":  resources_by_type.get(resource_type, []),
+            "precedence": precedence_by_type.get(resource_type, []),
+        }
+        result = _solve_one_pool(pool_input, timeout_seconds)
+        result["resource_type"] = resource_type
+        pool_results.append(result)
+        all_assignments.extend(result["assignments"])
+        all_unscheduled.extend(result["unscheduled"])
+        total_wall_seconds += result["solver_wall_seconds"]
+        logger.info(
+            f"Pool {resource_type!r}: status={result['status']}, "
+            f"assigned={len(result['assignments'])}, "
+            f"unscheduled={len(result['unscheduled'])}"
+        )
+
+    # Aggregate status across pools
+    pool_statuses = {pr["status"] for pr in pool_results}
+    solved        = {STATUS_OPTIMAL, STATUS_FEASIBLE}
+    if pool_statuses == {STATUS_OPTIMAL}:
+        top_status = STATUS_OPTIMAL
+    elif pool_statuses.issubset(solved):
+        top_status = STATUS_FEASIBLE
+    elif pool_statuses & solved:
+        top_status = STATUS_PARTIAL
+    elif STATUS_UNKNOWN in pool_statuses:
+        top_status = STATUS_UNKNOWN
+    else:
+        top_status = STATUS_INFEASIBLE
+
+    logger.info(
+        f"Solver (all pools): status={top_status}, "
+        f"wall_time={total_wall_seconds:.3f}s, "
+        f"assigned={len(all_assignments)}, unscheduled={len(all_unscheduled)}, "
+        f"pools={len(pool_results)}"
+    )
+
+    return {
+        "status":              top_status,
+        "solver_wall_seconds": round(total_wall_seconds, 3),
+        "assignments":         all_assignments,
+        "unscheduled":         all_unscheduled,
+        "pool_results":        pool_results,
     }
 
 
@@ -442,7 +559,10 @@ def solve(
 def run_solve_schedule(input_path: Path, output_path: Path) -> int:
     """Load schedule_input.json, solve, write schedule_output.json.
 
-    Returns exit code: 0 = OPTIMAL/FEASIBLE, 1 = INFEASIBLE/UNKNOWN, 2 = error.
+    Returns exit code:
+        0 = OPTIMAL or FEASIBLE (every pool solved)
+        1 = PARTIAL (some pools failed) / INFEASIBLE / UNKNOWN
+        2 = error (missing input, bad JSON, ortools not installed)
     """
     try:
         schedule_input = load_schedule_input(input_path)
@@ -469,11 +589,6 @@ def run_solve_schedule(input_path: Path, output_path: Path) -> int:
         **result,
     }
 
-    diagnostics: list[dict[str, Any]] = []
-    if result["status"] == STATUS_INFEASIBLE:
-        diagnostics = build_infeasibility_diagnostics(schedule_input)
-        output["diagnostics"] = diagnostics
-
     try:
         output_path.write_text(
             json.dumps(output, indent=2, ensure_ascii=False), encoding="utf-8"
@@ -483,23 +598,40 @@ def run_solve_schedule(input_path: Path, output_path: Path) -> int:
         logger.error(f"Failed to write {output_path}: {e}")
         return 2
 
-    if result["status"] == STATUS_INFEASIBLE:
-        logger.error("INFEASIBLE: no valid schedule exists with the current constraints.")
-        diagnostic_lines = format_infeasibility_diagnostics(diagnostics)
-        if diagnostic_lines:
-            logger.error("Lower-bound capacity diagnostics:")
-            for line in diagnostic_lines:
-                logger.error(line)
-            if not any(
-                diagnostic["shortage_slots"] > 0
-                or diagnostic.get("missing_resource_events")
-                for diagnostic in diagnostics
-            ):
-                logger.warning(
-                    "No raw slot shortage was detected. The infeasibility may instead "
-                    "come from same-team conflicts, stage ordering, or min-rest spacing."
-                )
+    if result["status"] == STATUS_PARTIAL:
+        failed = [
+            pr for pr in result["pool_results"]
+            if pr["status"] not in (STATUS_OPTIMAL, STATUS_FEASIBLE)
+        ]
+        logger.warning(
+            f"PARTIAL: {len(failed)} pool(s) could not be scheduled; "
+            f"{len(result['unscheduled'])} game(s) unscheduled. "
+            f"Assignments for feasible pools have been written."
+        )
+        for pr in failed:
+            logger.error(f"  Failed pool: {pr['resource_type']!r} — {pr['status']}")
+            for line in format_infeasibility_diagnostics(pr.get("diagnostics", [])):
+                logger.error(f"    {line}")
         return 1
+
+    if result["status"] == STATUS_INFEASIBLE:
+        logger.error("INFEASIBLE: no pools could be scheduled.")
+        for pr in result["pool_results"]:
+            logger.error(f"  Pool {pr['resource_type']!r}: {pr['status']}")
+            for line in format_infeasibility_diagnostics(pr.get("diagnostics", [])):
+                logger.error(f"    {line}")
+        has_shortage = any(
+            d.get("shortage_slots", 0) > 0 or d.get("missing_resource_events")
+            for pr in result["pool_results"]
+            for d in pr.get("diagnostics", [])
+        )
+        if not has_shortage:
+            logger.warning(
+                "No raw slot shortage detected. The infeasibility may come from "
+                "same-team conflicts, stage ordering, or min-rest spacing."
+            )
+        return 1
+
     if result["status"] == STATUS_UNKNOWN:
         logger.warning("Solver timed out or reached resource limit without a solution.")
         return 1

--- a/middleware/scheduler.py
+++ b/middleware/scheduler.py
@@ -397,6 +397,26 @@ def _solve_one_pool(
                     # NOT (v1 AND v2) — at most one of adjacent-slot vars can be true
                     model.AddBoolOr([v1.Not(), v2.Not()])
 
+    # C8 — per-game time windows (earliest_slot / latest_slot from schedule_input.json)
+    for game in games:
+        gid = game["game_id"]
+        if gid not in game_global_slot:
+            continue
+        lo_label = game.get("earliest_slot")
+        hi_label = game.get("latest_slot")
+        if lo_label:
+            lo = slot_to_global.get(lo_label)
+            if lo is not None:
+                model.Add(game_global_slot[gid] >= lo)
+            else:
+                logger.warning(f"Game {gid!r}: earliest_slot {lo_label!r} not in this pool's slots; ignored")
+        if hi_label:
+            hi = slot_to_global.get(hi_label)
+            if hi is not None:
+                model.Add(game_global_slot[gid] <= hi)
+            else:
+                logger.warning(f"Game {gid!r}: latest_slot {hi_label!r} not in this pool's slots; ignored")
+
     # Objective — minimize the latest occupied global slot (pack games toward start)
     if game_global_slot:
         latest = model.NewIntVar(0, max(n_global - 1, 0), "latest_slot")

--- a/middleware/scheduler.py
+++ b/middleware/scheduler.py
@@ -21,7 +21,6 @@ Constraints implemented (per pool):
   C2  Each (resource, slot) hosts at most one game (multi-slot aware).
   C3  No team plays two games in the same time slot.
   C4  Court-type routing — each game is assigned only to matching resource_type.
-  C5  Stage ordering — earlier_stage games finish before later_stage games start.
   C6  Minimum rest — no team plays in two adjacent global time slots.
   C7  Multi-slot games — a game whose duration > slot_minutes blocks consecutive slots.
 
@@ -112,11 +111,91 @@ def build_resource_slots(resources: list[dict]) -> dict[str, list[str]]:
     return result
 
 
+def validate_playoff_slots(
+    playoff_slots: list[dict[str, Any]],
+    resources: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], dict[str, dict[str, set[str]]]]:
+    """Validate manual playoff slots and return reserved solver slots by pool.
+
+    Manual playoff rows are not re-solved, but they must still refer to real
+    resources and real slot labels so the pool-play solver can reserve those
+    exact court/time pairs.
+    """
+    if not playoff_slots:
+        return [], {}
+
+    res_by_id = {resource["resource_id"]: resource for resource in resources}
+    res_slots = build_resource_slots(resources)
+    reserved_by_type: dict[str, dict[str, set[str]]] = defaultdict(
+        lambda: defaultdict(set)
+    )
+    validated: list[dict[str, Any]] = []
+    seen_keys: dict[tuple[str, str], str] = {}
+
+    for playoff_slot in playoff_slots:
+        game_id = str(playoff_slot.get("game_id", "")).strip() or "<unknown>"
+        resource_id = str(playoff_slot.get("resource_id", "")).strip()
+        slot = str(playoff_slot.get("slot", "")).strip()
+        if not resource_id or not slot:
+            raise ValueError(
+                f"Playoff slot {game_id!r} is missing required resource_id/slot values."
+            )
+
+        resource = res_by_id.get(resource_id)
+        if resource is None:
+            raise ValueError(
+                f"Playoff slot {game_id!r} references unknown resource_id {resource_id!r}."
+            )
+
+        valid_slots = set(res_slots.get(resource_id, []))
+        if slot not in valid_slots:
+            raise ValueError(
+                f"Playoff slot {game_id!r} uses slot {slot!r}, which is not a valid slot "
+                f"for resource {resource_id!r}."
+            )
+
+        key = (resource_id, slot)
+        previous_game = seen_keys.get(key)
+        if previous_game is not None:
+            raise ValueError(
+                f"Duplicate playoff slot reservation for {resource_id!r} at {slot!r}: "
+                f"{previous_game!r} and {game_id!r}."
+            )
+        seen_keys[key] = game_id
+
+        normalized = dict(playoff_slot)
+        normalized.setdefault("resource_type", resource["resource_type"])
+        validated.append(normalized)
+        reserved_by_type[resource["resource_type"]][resource_id].add(slot)
+
+    return validated, reserved_by_type
+
+
+def ensure_unique_assignment_slots(assignments: list[dict[str, Any]]) -> None:
+    """Raise when two assignments occupy the same (resource_id, slot) pair."""
+    seen: dict[tuple[str, str], str] = {}
+    for assignment in assignments:
+        resource_id = assignment.get("resource_id")
+        slot = assignment.get("slot")
+        game_id = assignment.get("game_id", "<unknown>")
+        if not resource_id or not slot:
+            continue
+        key = (resource_id, slot)
+        previous_game = seen.get(key)
+        if previous_game is not None:
+            raise ValueError(
+                f"Assignment collision on {resource_id!r} at {slot!r}: "
+                f"{previous_game!r} and {game_id!r}."
+            )
+        seen[key] = game_id
+
+
 def build_infeasibility_diagnostics(schedule_input: dict[str, Any]) -> list[dict[str, Any]]:
     """Return lower-bound capacity diagnostics for operator-facing INFEASIBLE cases.
 
     The diagnostics intentionally stay simple:
-    - `available_slots` = total start slots available across all resources of a type
+    - `available_slots` = total unreserved start slots available across all
+      resources of a type
     - `required_slots`  = sum of the minimum slots each game would occupy on any
       compatible resource of that type
 
@@ -126,6 +205,10 @@ def build_infeasibility_diagnostics(schedule_input: dict[str, Any]) -> list[dict
     games: list[dict]     = schedule_input["games"]
     resources: list[dict] = schedule_input["resources"]
     res_slots = build_resource_slots(resources)
+    blocked_slots: dict[str, set[str]] = {
+        resource_id: set(slots)
+        for resource_id, slots in schedule_input.get("blocked_slots", {}).items()
+    }
 
     resources_by_type: dict[str, list[dict[str, Any]]] = defaultdict(list)
     for resource in resources:
@@ -134,7 +217,11 @@ def build_infeasibility_diagnostics(schedule_input: dict[str, Any]) -> list[dict
     available_by_type: dict[str, int] = {}
     for resource_type, typed_resources in resources_by_type.items():
         available_by_type[resource_type] = sum(
-            len(res_slots[resource["resource_id"]])
+            sum(
+                1
+                for slot in res_slots[resource["resource_id"]]
+                if slot not in blocked_slots.get(resource["resource_id"], set())
+            )
             for resource in typed_resources
         )
 
@@ -244,8 +331,9 @@ def _solve_one_pool(
 ) -> dict[str, Any]:
     """Build and solve a CP-SAT model for one resource-type pool.
 
-    pool_input must contain 'games', 'resources', and 'precedence' for a single
-    resource_type.  Called by solve() once per pool.
+    pool_input must contain 'games' and 'resources' for a single resource_type.
+    Optional 'blocked_slots' reserves exact (resource_id, slot) pairs for manual
+    playoff games before the pool-play solver runs. Called by solve() once per pool.
 
     Returns a dict with keys:
         status              : 'OPTIMAL' | 'FEASIBLE' | 'INFEASIBLE' | 'UNKNOWN'
@@ -260,8 +348,12 @@ def _solve_one_pool(
     games:     list[dict] = pool_input["games"]
     resources: list[dict] = pool_input["resources"]
 
-    res_by_id:   dict[str, dict]        = {r["resource_id"]: r for r in resources}
-    res_slots:   dict[str, list[str]]   = build_resource_slots(resources)
+    res_by_id:      dict[str, dict]      = {r["resource_id"]: r for r in resources}
+    res_slots:      dict[str, list[str]] = build_resource_slots(resources)
+    blocked_slots = {
+        resource_id: set(slots)
+        for resource_id, slots in pool_input.get("blocked_slots", {}).items()
+    }
 
     # C4 — court-type routing (within this pool all games share one resource_type,
     # but res_by_type keeps the structure consistent with the constraint code)
@@ -269,7 +361,7 @@ def _solve_one_pool(
     for r in resources:
         res_by_type.setdefault(r["resource_type"], []).append(r["resource_id"])
 
-    # Build global slot ordering for C5 (stage ordering) and C6 (min rest)
+    # Build global slot ordering for C6 (min rest)
     all_labels: set[str] = set()
     for slots in res_slots.values():
         all_labels.update(slots)
@@ -302,6 +394,12 @@ def _solve_one_pool(
             # C7 — multi-slot: game occupies ceil(duration/slot_min) consecutive slots
             n_slots  = max(1, math.ceil(duration / slot_min))
             for t in range(len(slots) - n_slots + 1):
+                occupied_labels = slots[t : t + n_slots]
+                if any(
+                    label in blocked_slots.get(rid, set())
+                    for label in occupied_labels
+                ):
+                    continue
                 var = model.NewBoolVar(f"x_{gid}_{rid}_{t}")
                 game_vars[gid][(rid, t)] = var
 
@@ -466,6 +564,10 @@ def solve(
     """
     games:     list[dict] = schedule_input["games"]
     resources: list[dict] = schedule_input["resources"]
+    playoff_slots, blocked_slots_by_type = validate_playoff_slots(
+        schedule_input.get("playoff_slots", []),
+        resources,
+    )
 
     # Partition games and resources by resource_type for independent pool solves
     games_by_type:     dict[str, list[dict]] = {}
@@ -480,7 +582,7 @@ def solve(
         return {
             "status":              STATUS_OPTIMAL,
             "solver_wall_seconds": 0.0,
-            "assignments":         list(schedule_input.get("playoff_slots", [])),
+            "assignments":         list(playoff_slots),
             "unscheduled":         [],
             "pool_results":        [],
         }
@@ -492,8 +594,9 @@ def solve(
 
     for resource_type in sorted(games_by_type.keys()):
         pool_input = {
-            "games":     games_by_type[resource_type],
-            "resources": resources_by_type.get(resource_type, []),
+            "games":         games_by_type[resource_type],
+            "resources":     resources_by_type.get(resource_type, []),
+            "blocked_slots": blocked_slots_by_type.get(resource_type, {}),
         }
         result = _solve_one_pool(pool_input, timeout_seconds)
         result["resource_type"] = resource_type
@@ -522,18 +625,12 @@ def solve(
         top_status = STATUS_INFEASIBLE
 
     # Merge pre-assigned playoff slots from schedule_input into assignments.
-    playoff_slots: list[dict] = schedule_input.get("playoff_slots", [])
     if playoff_slots:
         for ps in playoff_slots:
-            if ps.get("resource_id") and ps.get("slot"):
-                all_assignments.append({
-                    "game_id":     ps["game_id"],
-                    "resource_id": ps["resource_id"],
-                    "slot":        ps["slot"],
-                    "event":       ps.get("event", ""),
-                    "stage":       ps.get("stage", ""),
-                })
+            all_assignments.append(dict(ps))
         logger.info(f"Merged {len(playoff_slots)} pre-assigned playoff slots into output.")
+
+    ensure_unique_assignment_slots(all_assignments)
 
     logger.info(
         f"Solver (all pools): status={top_status}, "

--- a/middleware/scheduler.py
+++ b/middleware/scheduler.py
@@ -276,6 +276,11 @@ def _solve_one_pool(
         all_labels.update(slots)
     sorted_labels  = sorted(all_labels, key=_slot_sort_key)
     slot_to_global = {lbl: i for i, lbl in enumerate(sorted_labels)}
+    # Map global slot index → day prefix (e.g. "Sat-1") for C6 day-boundary guard
+    global_to_day: dict[int, str] = {
+        i: lbl.rsplit("-", maxsplit=1)[0]
+        for i, lbl in enumerate(sorted_labels)
+    }
     n_global       = len(sorted_labels)
 
     model     = cp_model.CpModel()
@@ -381,8 +386,14 @@ def _solve_one_pool(
 
     for team, by_idx in team_global_assignments.items():
         for g_idx, vars_at_g in by_idx.items():
+            next_vars = by_idx.get(g_idx + 1, [])
+            if not next_vars:
+                continue
+            # Skip cross-day pairs — overnight gap is not a "no-rest" violation
+            if global_to_day.get(g_idx) != global_to_day.get(g_idx + 1):
+                continue
             for v1 in vars_at_g:
-                for v2 in by_idx.get(g_idx + 1, []):
+                for v2 in next_vars:
                     # NOT (v1 AND v2) — at most one of adjacent-slot vars can be true
                     model.AddBoolOr([v1.Not(), v2.Not()])
 

--- a/middleware/scheduler.py
+++ b/middleware/scheduler.py
@@ -6,9 +6,10 @@ CLI:
 
 Reads  : schedule_input.json (written by export-church-teams, Issue #87/#96)
 Writes : schedule_output.json to DATA_DIR (or --output path)
-Exits  : 0 = OPTIMAL or FEASIBLE (all pools solved)
-         1 = PARTIAL (some pools failed) / INFEASIBLE (no pools solved) / UNKNOWN
-         2 = error (bad input or ortools missing)
+Exits  : 0 = OPTIMAL or FEASIBLE, all games scheduled
+         1 = any games unscheduled (PARTIAL / INFEASIBLE / unroutable games)
+         2 = solver timed out (UNKNOWN) — increase SCHEDULE_SOLVER_TIMEOUT
+         3 = error (bad input or ortools missing)
 
 Architecture — pool decomposition:
   Games are partitioned by resource_type and solved independently.
@@ -43,6 +44,8 @@ from pathlib import Path
 from typing import Any
 
 from loguru import logger
+
+from config import SCHEDULE_SOLVER_RANDOM_SEED
 
 _DAY_ORDER: dict[str, int] = {"Sat-1": 0, "Sun-1": 1, "Sat-2": 2, "Sun-2": 3}
 _DEFAULT_TIMEOUT = float(os.getenv("SCHEDULE_SOLVER_TIMEOUT", "30.0"))
@@ -489,6 +492,8 @@ def _solve_one_pool(
     # Solve
     solver = cp_model.CpSolver()
     solver.parameters.max_time_in_seconds = timeout_seconds
+    if SCHEDULE_SOLVER_RANDOM_SEED:
+        solver.parameters.random_seed = SCHEDULE_SOLVER_RANDOM_SEED
     status_code = solver.Solve(model)
 
     wall_time   = solver.WallTime()
@@ -656,15 +661,16 @@ def run_solve_schedule(input_path: Path, output_path: Path) -> int:
     """Load schedule_input.json, solve, write schedule_output.json.
 
     Returns exit code:
-        0 = OPTIMAL or FEASIBLE (every pool solved)
-        1 = PARTIAL (some pools failed) / INFEASIBLE / UNKNOWN
-        2 = error (missing input, bad JSON, ortools not installed)
+        0 = every pool solved, every game scheduled
+        1 = any games unscheduled (PARTIAL, INFEASIBLE, or no compatible resource)
+        2 = solver timed out (UNKNOWN) — increase SCHEDULE_SOLVER_TIMEOUT env var
+        3 = error (missing input, bad JSON, ortools not installed)
     """
     try:
         schedule_input = load_schedule_input(input_path)
     except Exception as e:
         logger.error(f"Failed to load {input_path}: {e}")
-        return 2
+        return 3
 
     logger.info(
         f"Loaded {len(schedule_input['games'])} games, "
@@ -675,10 +681,10 @@ def run_solve_schedule(input_path: Path, output_path: Path) -> int:
         result = solve(schedule_input)
     except ImportError:
         logger.error("ortools not installed. Run: pip install ortools>=9.8")
-        return 2
+        return 3
     except Exception as e:
         logger.error(f"Solver error: {e}", exc_info=True)
-        return 2
+        return 3
 
     output = {
         "solved_at": datetime.now(tz=timezone.utc).isoformat(timespec="seconds"),
@@ -692,7 +698,7 @@ def run_solve_schedule(input_path: Path, output_path: Path) -> int:
         logger.info(f"schedule_output.json written to {output_path}")
     except OSError as e:
         logger.error(f"Failed to write {output_path}: {e}")
-        return 2
+        return 3
 
     if result["status"] == STATUS_PARTIAL:
         failed = [
@@ -729,7 +735,24 @@ def run_solve_schedule(input_path: Path, output_path: Path) -> int:
         return 1
 
     if result["status"] == STATUS_UNKNOWN:
-        logger.warning("Solver timed out or reached resource limit without a solution.")
+        timeout_used = os.getenv("SCHEDULE_SOLVER_TIMEOUT", "30")
+        logger.warning(
+            f"Solver timed out after {timeout_used}s without finding a solution. "
+            "This is not proven infeasible — increase SCHEDULE_SOLVER_TIMEOUT and re-run. "
+            f"Current timeout: {timeout_used}s."
+        )
+        return 2
+
+    # A2 — OPTIMAL/FEASIBLE but some games had no compatible resource (C4 routing gap).
+    # The solver cannot schedule what it cannot see; surface this as a non-zero exit
+    # so callers don't silently consume an incomplete schedule.
+    if result["unscheduled"]:
+        logger.warning(
+            f"{len(result['unscheduled'])} game(s) could not be scheduled because "
+            "no compatible resource exists for their resource_type. "
+            "Check that every game's resource_type matches at least one resource in "
+            f"schedule_input.json. Unscheduled: {result['unscheduled']}"
+        )
         return 1
 
     return 0

--- a/middleware/scheduler.py
+++ b/middleware/scheduler.py
@@ -1,0 +1,355 @@
+"""
+scheduler.py — CP-SAT scheduler for VAY Sports Fest (Issue #93).
+
+CLI:
+    python main.py solve-schedule [--input path/to/schedule_input.json]
+
+Reads  : schedule_input.json (written by export-church-teams, Issue #87/#96)
+Writes : schedule_output.json to DATA_DIR (or --output path)
+Exits  : 0 = OPTIMAL or FEASIBLE, 1 = INFEASIBLE, 2 = error
+
+Constraints implemented:
+  C1  Each game assigned to exactly one (resource, start_slot).
+  C2  Each (resource, slot) hosts at most one game (multi-slot aware).
+  C3  No team plays two games in the same time slot.
+  C4  Court-type routing — each game is assigned only to matching resource_type.
+  C5  Stage ordering — earlier_stage games finish before later_stage games start.
+  C6  Minimum rest — no team plays in two adjacent global time slots.
+  C7  Multi-slot games — a game whose duration > slot_minutes blocks consecutive slots.
+
+Objective: minimize the index of the latest occupied global slot (pack games early).
+
+Out of scope for this issue (document for future work):
+  - Cross-sport participant conflicts (a person in both Basketball and Badminton).
+  - Church-requested blackout windows (earliest_slot / latest_slot fields are in
+    the schema; wiring them up is a one-liner once they are populated upstream).
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+
+_DAY_ORDER: dict[str, int] = {"Sat-1": 0, "Sun-1": 1, "Sat-2": 2, "Sun-2": 3}
+_DEFAULT_TIMEOUT = float(os.getenv("SCHEDULE_SOLVER_TIMEOUT", "30.0"))
+_OUTPUT_FILENAME = "schedule_output.json"
+
+STATUS_OPTIMAL = "OPTIMAL"
+STATUS_FEASIBLE = "FEASIBLE"
+STATUS_INFEASIBLE = "INFEASIBLE"
+STATUS_UNKNOWN = "UNKNOWN"
+
+
+# ---------------------------------------------------------------------------
+# Input loading
+# ---------------------------------------------------------------------------
+
+def load_schedule_input(path: Path) -> dict[str, Any]:
+    """Load schedule_input.json and validate required top-level keys."""
+    with path.open(encoding="utf-8") as fh:
+        data = json.load(fh)
+    for key in ("games", "resources", "precedence"):
+        if key not in data:
+            raise ValueError(f"schedule_input.json missing required key: {key!r}")
+    return data
+
+
+# ---------------------------------------------------------------------------
+# Slot helpers
+# ---------------------------------------------------------------------------
+
+def _parse_time_minutes(time_str: str) -> int:
+    """'HH:MM' → minutes since midnight."""
+    h, m = time_str.split(":")
+    return int(h) * 60 + int(m)
+
+
+def _slot_sort_key(label: str) -> tuple[int, int]:
+    """Sort key for slot labels: (day_order, time_in_minutes).
+
+    Label format: '{day}-{HH:MM}', e.g. 'Sat-1-08:00' or 'Day-1-09:30'.
+    Unknown day labels are placed after known weekends (order 99).
+    """
+    day, time = label.rsplit("-", maxsplit=1)
+    h, m = time.split(":")
+    return (_DAY_ORDER.get(day, 99), int(h) * 60 + int(m))
+
+
+def build_resource_slots(resources: list[dict]) -> dict[str, list[str]]:
+    """Return {resource_id: [slot_label, ...]} from each resource's time window.
+
+    Slot labels follow the '{day}-{HH:MM}' convention, e.g. 'Sat-1-08:00'.
+    The last slot starts at close_time - slot_minutes (close_time is exclusive).
+    """
+    result: dict[str, list[str]] = {}
+    for res in resources:
+        open_min = _parse_time_minutes(res["open_time"])
+        close_min = _parse_time_minutes(res["close_time"])
+        slot_min = res["slot_minutes"]
+        day = res["day"]
+        slots: list[str] = []
+        t = open_min
+        while t + slot_min <= close_min:
+            slots.append(f"{day}-{t // 60:02d}:{t % 60:02d}")
+            t += slot_min
+        result[res["resource_id"]] = slots
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Solver
+# ---------------------------------------------------------------------------
+
+def solve(
+    schedule_input: dict[str, Any],
+    timeout_seconds: float = _DEFAULT_TIMEOUT,
+) -> dict[str, Any]:
+    """Build and solve the CP-SAT assignment model.
+
+    Returns a dict with keys:
+        status              : 'OPTIMAL' | 'FEASIBLE' | 'INFEASIBLE' | 'UNKNOWN'
+        solver_wall_seconds : float
+        assignments         : list of {game_id, resource_id, slot}
+        unscheduled         : list of game_ids the solver could not place
+    """
+    from ortools.sat.python import cp_model  # import guard — keeps module importable without ortools
+
+    games: list[dict] = schedule_input["games"]
+    resources: list[dict] = schedule_input["resources"]
+    precedence: list[dict] = schedule_input.get("precedence", [])
+
+    res_by_id: dict[str, dict] = {r["resource_id"]: r for r in resources}
+    res_slots: dict[str, list[str]] = build_resource_slots(resources)
+
+    # C4 — court-type routing: group resource IDs by resource_type
+    res_by_type: dict[str, list[str]] = {}
+    for r in resources:
+        res_by_type.setdefault(r["resource_type"], []).append(r["resource_id"])
+
+    # Build global slot ordering for C5 (stage ordering) and C6 (min rest)
+    all_labels: set[str] = set()
+    for slots in res_slots.values():
+        all_labels.update(slots)
+    sorted_labels = sorted(all_labels, key=_slot_sort_key)
+    slot_to_global: dict[str, int] = {lbl: i for i, lbl in enumerate(sorted_labels)}
+    n_global = len(sorted_labels)
+
+    model = cp_model.CpModel()
+    game_meta: dict[str, dict] = {g["game_id"]: g for g in games}
+
+    # Decision variables: x[(gid, rid, t)] = BoolVar
+    # True iff game gid starts on resource rid at slot index t.
+    game_vars: dict[str, dict[tuple[str, int], Any]] = {}
+
+    for game in games:
+        gid = game["game_id"]
+        resource_type = game["resource_type"]
+        duration = game["duration_minutes"]
+        compatible = res_by_type.get(resource_type, [])
+
+        game_vars[gid] = {}
+        for rid in compatible:
+            slots = res_slots[rid]
+            slot_min = res_by_id[rid]["slot_minutes"]
+            # C7 — multi-slot: game occupies ceil(duration/slot_min) consecutive slots
+            n_slots = max(1, math.ceil(duration / slot_min))
+            for t in range(len(slots) - n_slots + 1):
+                var = model.NewBoolVar(f"x_{gid}_{rid}_{t}")
+                game_vars[gid][(rid, t)] = var
+
+        if not game_vars[gid]:
+            logger.warning(f"No compatible resources for game {gid!r}; will be unscheduled")
+
+    # C1 — each game assigned to exactly one (resource, start_slot)
+    for gid, vd in game_vars.items():
+        if vd:
+            model.AddExactlyOne(vd.values())
+
+    # C2 — each (resource, slot_idx) hosts at most one game (multi-slot aware)
+    slot_occupancy: dict[tuple[str, int], list[Any]] = {}
+    for gid, vd in game_vars.items():
+        duration = game_meta[gid]["duration_minutes"]
+        for (rid, t), var in vd.items():
+            slot_min = res_by_id[rid]["slot_minutes"]
+            n_slots = max(1, math.ceil(duration / slot_min))
+            for s in range(t, t + n_slots):
+                slot_occupancy.setdefault((rid, s), []).append(var)
+
+    for (rid, s), var_list in slot_occupancy.items():
+        if len(var_list) > 1:
+            model.AddAtMostOne(var_list)
+
+    # C3 — no team plays two games in the same time slot
+    team_slot_vars: dict[tuple[str, str], list[Any]] = {}
+    for gid, vd in game_vars.items():
+        game = game_meta[gid]
+        teams = [t for t in (game.get("team_a_id"), game.get("team_b_id")) if t]
+        duration = game["duration_minutes"]
+        for (rid, t), var in vd.items():
+            slots = res_slots[rid]
+            slot_min = res_by_id[rid]["slot_minutes"]
+            n_slots = max(1, math.ceil(duration / slot_min))
+            for s in range(t, t + n_slots):
+                slot_label = slots[s]
+                for team in teams:
+                    team_slot_vars.setdefault((team, slot_label), []).append(var)
+
+    for (team, slot_label), var_list in team_slot_vars.items():
+        if len(var_list) > 1:
+            model.AddAtMostOne(var_list)
+
+    # Global slot IntVar per game (enables C5 and C6)
+    game_global_slot: dict[str, Any] = {}
+    for gid, vd in game_vars.items():
+        if not vd:
+            continue
+        gv = model.NewIntVar(0, n_global - 1, f"gslot_{gid}")
+        game_global_slot[gid] = gv
+        for (rid, t), var in vd.items():
+            label = res_slots[rid][t]
+            model.Add(gv == slot_to_global[label]).OnlyEnforceIf(var)
+
+    # C5 — stage ordering: every earlier_stage game must precede every later_stage game
+    by_event_stage: dict[tuple[str, str], list[str]] = {}
+    for game in games:
+        key = (game["event"], game["stage"])
+        by_event_stage.setdefault(key, []).append(game["game_id"])
+
+    for rule in precedence:
+        event = rule["event"]
+        earlier_gids = by_event_stage.get((event, rule["earlier_stage"]), [])
+        later_gids = by_event_stage.get((event, rule["later_stage"]), [])
+        for g_e in earlier_gids:
+            for g_l in later_gids:
+                if g_e in game_global_slot and g_l in game_global_slot:
+                    model.Add(game_global_slot[g_l] > game_global_slot[g_e])
+
+    # C6 — minimum rest: no team plays in two adjacent global slots
+    team_global_assignments: dict[str, dict[int, list[Any]]] = {}
+    for gid, vd in game_vars.items():
+        game = game_meta[gid]
+        teams = [t for t in (game.get("team_a_id"), game.get("team_b_id")) if t]
+        for (rid, t), var in vd.items():
+            label = res_slots[rid][t]
+            global_idx = slot_to_global[label]
+            for team in teams:
+                team_global_assignments.setdefault(team, {}).setdefault(global_idx, []).append(var)
+
+    for team, by_idx in team_global_assignments.items():
+        for g_idx, vars_at_g in by_idx.items():
+            for v1 in vars_at_g:
+                for v2 in by_idx.get(g_idx + 1, []):
+                    # NOT (v1 AND v2) — at most one of adjacent-slot variables can be true
+                    model.AddBoolOr([v1.Not(), v2.Not()])
+
+    # Objective — minimize the latest occupied global slot (pack games toward start)
+    if game_global_slot:
+        latest = model.NewIntVar(0, n_global - 1, "latest_slot")
+        for gv in game_global_slot.values():
+            model.Add(latest >= gv)
+        model.Minimize(latest)
+
+    # Solve
+    solver = cp_model.CpSolver()
+    solver.parameters.max_time_in_seconds = timeout_seconds
+    status_code = solver.Solve(model)
+
+    wall_time = solver.WallTime()
+    status_name = solver.StatusName(status_code)
+
+    status_map = {
+        "OPTIMAL": STATUS_OPTIMAL,
+        "FEASIBLE": STATUS_FEASIBLE,
+        "INFEASIBLE": STATUS_INFEASIBLE,
+    }
+    status = status_map.get(status_name, STATUS_UNKNOWN)
+
+    assignments: list[dict] = []
+    unscheduled: list[str] = []
+
+    if status in (STATUS_OPTIMAL, STATUS_FEASIBLE):
+        for gid, vd in game_vars.items():
+            assigned = False
+            for (rid, t), var in vd.items():
+                if solver.Value(var):
+                    assignments.append({
+                        "game_id": gid,
+                        "resource_id": rid,
+                        "slot": res_slots[rid][t],
+                    })
+                    assigned = True
+                    break
+            if not assigned:
+                unscheduled.append(gid)
+    else:
+        unscheduled = [g["game_id"] for g in games]
+
+    logger.info(
+        f"Solver: status={status}, wall_time={wall_time:.3f}s, "
+        f"assigned={len(assignments)}, unscheduled={len(unscheduled)}"
+    )
+    return {
+        "status": status,
+        "solver_wall_seconds": round(wall_time, 3),
+        "assignments": assignments,
+        "unscheduled": unscheduled,
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+def run_solve_schedule(input_path: Path, output_path: Path) -> int:
+    """Load schedule_input.json, solve, write schedule_output.json.
+
+    Returns exit code: 0 = OPTIMAL/FEASIBLE, 1 = INFEASIBLE/UNKNOWN, 2 = error.
+    """
+    try:
+        schedule_input = load_schedule_input(input_path)
+    except Exception as e:
+        logger.error(f"Failed to load {input_path}: {e}")
+        return 2
+
+    logger.info(
+        f"Loaded {len(schedule_input['games'])} games, "
+        f"{len(schedule_input['resources'])} resources from {input_path}"
+    )
+
+    try:
+        result = solve(schedule_input)
+    except ImportError:
+        logger.error("ortools not installed. Run: pip install ortools>=9.8")
+        return 2
+    except Exception as e:
+        logger.error(f"Solver error: {e}", exc_info=True)
+        return 2
+
+    output = {
+        "solved_at": datetime.now(tz=timezone.utc).isoformat(timespec="seconds"),
+        **result,
+    }
+
+    try:
+        output_path.write_text(
+            json.dumps(output, indent=2, ensure_ascii=False), encoding="utf-8"
+        )
+        logger.info(f"schedule_output.json written to {output_path}")
+    except OSError as e:
+        logger.error(f"Failed to write {output_path}: {e}")
+        return 2
+
+    if result["status"] == STATUS_INFEASIBLE:
+        logger.error("INFEASIBLE: no valid schedule exists with the current constraints.")
+        return 1
+    if result["status"] == STATUS_UNKNOWN:
+        logger.warning("Solver timed out or reached resource limit without a solution.")
+        return 1
+
+    return 0

--- a/middleware/scheduler.py
+++ b/middleware/scheduler.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import json
 import math
 import os
+from collections import defaultdict
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -100,6 +101,138 @@ def build_resource_slots(resources: list[dict]) -> dict[str, list[str]]:
             t += slot_min
         result[res["resource_id"]] = slots
     return result
+
+
+def build_infeasibility_diagnostics(schedule_input: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return lower-bound capacity diagnostics for operator-facing INFEASIBLE cases.
+
+    The diagnostics intentionally stay simple:
+    - `available_slots` = total start slots available across all resources of a type
+    - `required_slots`  = sum of the minimum slots each game would occupy on any
+      compatible resource of that type
+
+    This does not prove why every infeasible solve failed, but it does surface
+    obvious shortages such as "Badminton Court needs 24 slots, only 20 exist".
+    """
+    games: list[dict] = schedule_input["games"]
+    resources: list[dict] = schedule_input["resources"]
+    res_slots = build_resource_slots(resources)
+
+    resources_by_type: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for resource in resources:
+        resources_by_type[resource["resource_type"]].append(resource)
+
+    available_by_type: dict[str, int] = {}
+    for resource_type, typed_resources in resources_by_type.items():
+        available_by_type[resource_type] = sum(
+            len(res_slots[resource["resource_id"]])
+            for resource in typed_resources
+        )
+
+    required_by_type: dict[str, int] = defaultdict(int)
+    event_rollups: dict[tuple[str, str], dict[str, Any]] = {}
+    missing_rollups: dict[tuple[str, str], dict[str, Any]] = {}
+
+    for game in games:
+        event = game["event"]
+        resource_type = game["resource_type"]
+        compatible = resources_by_type.get(resource_type, [])
+
+        if not compatible:
+            key = (event, resource_type)
+            rollup = missing_rollups.setdefault(key, {
+                "event": event,
+                "resource_type": resource_type,
+                "game_count": 0,
+            })
+            rollup["game_count"] += 1
+            continue
+
+        min_slots = min(
+            max(1, math.ceil(game["duration_minutes"] / resource["slot_minutes"]))
+            for resource in compatible
+        )
+        key = (event, resource_type)
+        rollup = event_rollups.setdefault(key, {
+            "event": event,
+            "resource_type": resource_type,
+            "game_count": 0,
+            "required_slots": 0,
+        })
+        rollup["game_count"] += 1
+        rollup["required_slots"] += min_slots
+        required_by_type[resource_type] += min_slots
+
+    diagnostics: list[dict[str, Any]] = []
+    resource_types = sorted({
+        *(event_resource_type for _, event_resource_type in event_rollups.keys()),
+        *(event_resource_type for _, event_resource_type in missing_rollups.keys()),
+    })
+
+    for resource_type in resource_types:
+        events = sorted(
+            (
+                rollup for rollup in event_rollups.values()
+                if rollup["resource_type"] == resource_type
+            ),
+            key=lambda rollup: (-rollup["required_slots"], rollup["event"]),
+        )
+        missing_events = sorted(
+            (
+                rollup for rollup in missing_rollups.values()
+                if rollup["resource_type"] == resource_type
+            ),
+            key=lambda rollup: (-rollup["game_count"], rollup["event"]),
+        )
+        required_slots = required_by_type.get(resource_type, 0)
+        available_slots = available_by_type.get(resource_type, 0)
+        diagnostics.append({
+            "resource_type": resource_type,
+            "required_slots": required_slots,
+            "available_slots": available_slots,
+            "shortage_slots": max(required_slots - available_slots, 0),
+            "events": events,
+            "missing_resource_events": missing_events,
+        })
+
+    return diagnostics
+
+
+def format_infeasibility_diagnostics(diagnostics: list[dict[str, Any]]) -> list[str]:
+    """Render operator-friendly lower-bound diagnostics for logging/output."""
+    lines: list[str] = []
+    for diagnostic in diagnostics:
+        resource_type = diagnostic["resource_type"]
+        required_slots = diagnostic["required_slots"]
+        available_slots = diagnostic["available_slots"]
+        shortage_slots = diagnostic["shortage_slots"]
+
+        for missing in diagnostic.get("missing_resource_events", []):
+            lines.append(
+                f"{missing['event']}: {missing['game_count']} game(s) require "
+                f"{resource_type}, but 0 compatible slots are available."
+            )
+
+        if required_slots:
+            if shortage_slots:
+                lines.append(
+                    f"{resource_type}: requires at least {required_slots} slot(s), "
+                    f"but only {available_slots} slot(s) are available "
+                    f"(short {shortage_slots})."
+                )
+            else:
+                lines.append(
+                    f"{resource_type}: requires at least {required_slots} slot(s); "
+                    f"{available_slots} slot(s) are available."
+                )
+
+        for event in diagnostic.get("events", []):
+            lines.append(
+                f"  {event['event']}: {event['game_count']} game(s) would need "
+                f"at least {event['required_slots']} slot(s)."
+            )
+
+    return lines
 
 
 # ---------------------------------------------------------------------------
@@ -336,6 +469,11 @@ def run_solve_schedule(input_path: Path, output_path: Path) -> int:
         **result,
     }
 
+    diagnostics: list[dict[str, Any]] = []
+    if result["status"] == STATUS_INFEASIBLE:
+        diagnostics = build_infeasibility_diagnostics(schedule_input)
+        output["diagnostics"] = diagnostics
+
     try:
         output_path.write_text(
             json.dumps(output, indent=2, ensure_ascii=False), encoding="utf-8"
@@ -347,6 +485,20 @@ def run_solve_schedule(input_path: Path, output_path: Path) -> int:
 
     if result["status"] == STATUS_INFEASIBLE:
         logger.error("INFEASIBLE: no valid schedule exists with the current constraints.")
+        diagnostic_lines = format_infeasibility_diagnostics(diagnostics)
+        if diagnostic_lines:
+            logger.error("Lower-bound capacity diagnostics:")
+            for line in diagnostic_lines:
+                logger.error(line)
+            if not any(
+                diagnostic["shortage_slots"] > 0
+                or diagnostic.get("missing_resource_events")
+                for diagnostic in diagnostics
+            ):
+                logger.warning(
+                    "No raw slot shortage was detected. The infeasibility may instead "
+                    "come from same-team conflicts, stage ordering, or min-rest spacing."
+                )
         return 1
     if result["status"] == STATUS_UNKNOWN:
         logger.warning("Solver timed out or reached resource limit without a solution.")

--- a/middleware/scheduler.py
+++ b/middleware/scheduler.py
@@ -526,6 +526,12 @@ def _solve_one_pool(
     else:
         unscheduled = [g["game_id"] for g in games]
 
+    # If any game in this pool had no candidate placement vars, CP-SAT can still
+    # report the reduced model as solved. Surface that as an infeasible pool so
+    # downstream JSON/report consumers do not see "OPTIMAL" beside dropped games.
+    if status in (STATUS_OPTIMAL, STATUS_FEASIBLE) and unscheduled:
+        status = STATUS_INFEASIBLE
+
     result: dict[str, Any] = {
         "status":              status,
         "solver_wall_seconds": round(wall_time, 3),
@@ -743,9 +749,8 @@ def run_solve_schedule(input_path: Path, output_path: Path) -> int:
         )
         return 2
 
-    # A2 — OPTIMAL/FEASIBLE but some games had no compatible resource (C4 routing gap).
-    # The solver cannot schedule what it cannot see; surface this as a non-zero exit
-    # so callers don't silently consume an incomplete schedule.
+    # Defensive fallback: solved statuses should not carry unscheduled games, but if
+    # they ever do, keep the CLI non-zero so callers do not silently accept it.
     if result["unscheduled"]:
         logger.warning(
             f"{len(result['unscheduled'])} game(s) could not be scheduled because "

--- a/middleware/scheduler.py
+++ b/middleware/scheduler.py
@@ -29,8 +29,6 @@ Objective (per pool): minimize the index of the latest occupied global slot.
 
 Out of scope (future work):
   - Cross-sport participant conflicts (a person in both Basketball and Badminton).
-  - Church-requested blackout windows (earliest_slot / latest_slot fields are in
-    the schema; wiring them up is a one-liner once they are populated upstream).
 """
 
 from __future__ import annotations

--- a/middleware/tests/test_church_teams_export.py
+++ b/middleware/tests/test_church_teams_export.py
@@ -1998,3 +1998,164 @@ def test_schedule_input_tab_absent_in_single_church_export(mock_connectors, tmp_
     exporter._write_excel_report(path, [], [], _make_gym_roster(2), [])
     sheets = pd.ExcelFile(path).sheet_names
     assert "Schedule-Input" not in sheets
+
+
+# ---------------------------------------------------------------------------
+# Issue #94 — _build_schedule_output_flat_rows
+# ---------------------------------------------------------------------------
+
+def _make_schedule_pair():
+    """Return (schedule_output, schedule_input) test fixtures."""
+    schedule_input = {
+        "games": [
+            {
+                "game_id": "BBM-01", "event": "Basketball - Men Team",
+                "stage": "Pool", "pool_id": "P1", "round": 1,
+                "team_a_id": "BBM-P1-T1", "team_b_id": "BBM-P1-T2",
+                "duration_minutes": 60, "resource_type": "Gym Court",
+                "earliest_slot": None, "latest_slot": None,
+            },
+            {
+                "game_id": "BBM-Final", "event": "Basketball - Men Team",
+                "stage": "Final", "pool_id": "", "round": 1,
+                "team_a_id": "WIN-BBM-Semi-1", "team_b_id": "WIN-BBM-Semi-2",
+                "duration_minutes": 60, "resource_type": "Gym Court",
+                "earliest_slot": None, "latest_slot": None,
+            },
+        ],
+        "resources": [
+            {
+                "resource_id": "GYM-Sat-1-1", "resource_type": "Gym Court",
+                "label": "Court-1", "day": "Sat-1",
+                "open_time": "08:00", "close_time": "12:00", "slot_minutes": 60,
+            }
+        ],
+        "precedence": [],
+    }
+    schedule_output = {
+        "solved_at": "2026-05-01T10:00:00",
+        "status": "OPTIMAL",
+        "solver_wall_seconds": 0.1,
+        "assignments": [
+            {"game_id": "BBM-01",    "resource_id": "GYM-Sat-1-1", "slot": "Sat-1-08:00"},
+            {"game_id": "BBM-Final", "resource_id": "GYM-Sat-1-1", "slot": "Sat-1-10:00"},
+        ],
+        "unscheduled": [],
+    }
+    return schedule_output, schedule_input
+
+
+def test_build_schedule_output_flat_rows_count():
+    """Returns one row per assignment."""
+    from church_teams_export import ChurchTeamsExporter
+    so, si = _make_schedule_pair()
+    rows = ChurchTeamsExporter._build_schedule_output_flat_rows(so, si)
+    assert len(rows) == 2
+
+
+def test_build_schedule_output_flat_rows_fields():
+    """Each row contains expected keys with non-empty event."""
+    from church_teams_export import ChurchTeamsExporter
+    so, si = _make_schedule_pair()
+    rows = ChurchTeamsExporter._build_schedule_output_flat_rows(so, si)
+    required = {"game_id", "event", "stage", "round", "team_a_id", "team_b_id",
+                "resource_label", "day", "slot", "duration_minutes"}
+    for row in rows:
+        assert required.issubset(row.keys())
+        assert row["event"] == "Basketball - Men Team"
+
+
+def test_build_schedule_output_flat_rows_sorted():
+    """Rows are sorted Pool before Final (stage order)."""
+    from church_teams_export import ChurchTeamsExporter
+    so, si = _make_schedule_pair()
+    rows = ChurchTeamsExporter._build_schedule_output_flat_rows(so, si)
+    stages = [r["stage"] for r in rows]
+    assert stages == ["Pool", "Final"]
+
+
+def test_build_schedule_output_flat_rows_time_part():
+    """The slot field extracts the HH:MM part from the full slot label."""
+    from church_teams_export import ChurchTeamsExporter
+    so, si = _make_schedule_pair()
+    rows = ChurchTeamsExporter._build_schedule_output_flat_rows(so, si)
+    pool_row = next(r for r in rows if r["game_id"] == "BBM-01")
+    assert pool_row["slot"] == "08:00"
+
+
+def test_build_schedule_output_flat_rows_day_display():
+    """Sat-1 is translated to '1st Sat'."""
+    from church_teams_export import ChurchTeamsExporter
+    so, si = _make_schedule_pair()
+    rows = ChurchTeamsExporter._build_schedule_output_flat_rows(so, si)
+    assert all(r["day"] == "1st Sat" for r in rows)
+
+
+def test_build_schedule_output_flat_rows_empty():
+    """Empty assignments list returns empty rows."""
+    from church_teams_export import ChurchTeamsExporter
+    so = {"assignments": [], "unscheduled": []}
+    si = {"games": [], "resources": [], "precedence": []}
+    rows = ChurchTeamsExporter._build_schedule_output_flat_rows(so, si)
+    assert rows == []
+
+
+# ---------------------------------------------------------------------------
+# Issue #94 — _write_schedule_output_report
+# ---------------------------------------------------------------------------
+
+def test_write_schedule_output_report_creates_file(tmp_path):
+    """_write_schedule_output_report writes an xlsx with both expected tabs."""
+    from church_teams_export import ChurchTeamsExporter
+    import openpyxl
+    so, si = _make_schedule_pair()
+    out = tmp_path / "sched.xlsx"
+    ChurchTeamsExporter._write_schedule_output_report(out, so, si)
+    assert out.exists()
+    wb = openpyxl.load_workbook(out)
+    assert "Schedule-by-Time" in wb.sheetnames
+    assert "Schedule-by-Sport" in wb.sheetnames
+
+
+def test_write_schedule_output_report_tab1_has_data(tmp_path):
+    """Schedule-by-Time tab has a title in row 1 and game text in the grid."""
+    from church_teams_export import ChurchTeamsExporter
+    import openpyxl
+    so, si = _make_schedule_pair()
+    out = tmp_path / "sched.xlsx"
+    ChurchTeamsExporter._write_schedule_output_report(out, so, si)
+    ws = openpyxl.load_workbook(out)["Schedule-by-Time"]
+    title = ws.cell(row=1, column=1).value
+    assert title and "Sports Fest" in title
+    # At least one game should appear somewhere in the grid
+    all_values = [ws.cell(row=r, column=c).value
+                  for r in range(1, ws.max_row + 1)
+                  for c in range(1, ws.max_column + 1)]
+    assert any("BBM" in str(v) for v in all_values if v)
+
+
+def test_write_schedule_output_report_tab2_flat_list(tmp_path):
+    """Schedule-by-Sport tab has a header row and one data row per assignment."""
+    from church_teams_export import ChurchTeamsExporter
+    import openpyxl
+    so, si = _make_schedule_pair()
+    out = tmp_path / "sched.xlsx"
+    ChurchTeamsExporter._write_schedule_output_report(out, so, si)
+    ws = openpyxl.load_workbook(out)["Schedule-by-Sport"]
+    assert ws.cell(row=1, column=1).value == "game_id"
+    assert ws.cell(row=2, column=1).value == "BBM-01"    # Pool comes first
+    assert ws.cell(row=3, column=1).value == "BBM-Final"
+
+
+def test_write_schedule_output_report_unscheduled_section(tmp_path):
+    """Unscheduled section appears in Schedule-by-Sport when games are unscheduled."""
+    from church_teams_export import ChurchTeamsExporter
+    import openpyxl
+    so, si = _make_schedule_pair()
+    so["unscheduled"] = ["BBM-QF-1"]
+    out = tmp_path / "sched.xlsx"
+    ChurchTeamsExporter._write_schedule_output_report(out, so, si)
+    ws = openpyxl.load_workbook(out)["Schedule-by-Sport"]
+    all_values = [ws.cell(row=r, column=1).value for r in range(1, ws.max_row + 1)]
+    assert any("Unscheduled" in str(v) for v in all_values if v)
+    assert any("BBM-QF-1" in str(v) for v in all_values if v)

--- a/middleware/tests/test_church_teams_export.py
+++ b/middleware/tests/test_church_teams_export.py
@@ -1688,7 +1688,11 @@ def test_build_gym_game_objects_structure(mock_connectors):
         assert required_fields <= g.keys(), f"Missing fields in {g}"
     from config import GYM_RESOURCE_TYPE
     assert all(g["resource_type"] == GYM_RESOURCE_TYPE for g in games)
-    assert all(g["team_a_id"] is None and g["team_b_id"] is None for g in games)
+    # team_a_id and team_b_id must be non-null strings for all games (pool + playoff)
+    assert all(
+        isinstance(g["team_a_id"], str) and isinstance(g["team_b_id"], str)
+        for g in games
+    ), "All games must have non-null team_a_id and team_b_id"
 
 
 def test_build_gym_game_objects_stages(mock_connectors):
@@ -1709,6 +1713,61 @@ def test_build_gym_game_objects_prefix_format(mock_connectors):
     assert pool_ids, "Expected Basketball pool games"
     import re
     assert all(re.match(r"BBM-\d{2}$", gid) for gid in pool_ids)
+
+
+def test_build_gym_game_objects_stable_team_ids(mock_connectors):
+    """The same placeholder team ID is reused across multiple pool games for that team."""
+    exporter = ChurchTeamsExporter()
+    games = exporter._build_gym_game_objects(_make_gym_roster(8))
+    bbm_pool = [g for g in games if g["stage"] == "Pool" and g["event"] == SPORT_TYPE["BASKETBALL"]]
+    assert bbm_pool, "Expected Basketball pool games"
+
+    # Collect all team IDs and count appearances
+    from collections import Counter
+    appearances: Counter = Counter()
+    for g in bbm_pool:
+        appearances[g["team_a_id"]] += 1
+        appearances[g["team_b_id"]] += 1
+
+    # Every team must appear in at least 2 games (gpg=2 for Basketball)
+    # Some teams in smaller edge pools may appear fewer times, but all appear at least once
+    assert all(count >= 1 for count in appearances.values()), "Each team must appear at least once"
+    # At least some teams appear in exactly 2 games (normal pool size = 3 teams)
+    assert any(count >= 2 for count in appearances.values()), "Some teams must appear in multiple games"
+
+
+def test_build_gym_game_objects_pool_id_nonempty(mock_connectors):
+    """Pool games carry a non-empty pool_id; playoff/final games have empty pool_id."""
+    exporter = ChurchTeamsExporter()
+    games = exporter._build_gym_game_objects(_make_gym_roster(8))
+    pool_games = [g for g in games if g["stage"] == "Pool"]
+    playoff_games = [g for g in games if g["stage"] not in ("Pool",)]
+
+    assert pool_games, "Expected pool games"
+    assert all(g["pool_id"] != "" for g in pool_games), "Pool games must have non-empty pool_id"
+    assert all(g["pool_id"] == "" for g in playoff_games), "Playoff/final games must have empty pool_id"
+
+
+def test_build_gym_game_objects_team_id_format(mock_connectors):
+    """Pool game team IDs follow the stable placeholder format PREFIX-Px-Ty."""
+    import re as _re
+    exporter = ChurchTeamsExporter()
+    games = exporter._build_gym_game_objects(_make_gym_roster(8))
+    bbm_pool = [g for g in games if g["stage"] == "Pool" and g["event"] == SPORT_TYPE["BASKETBALL"]]
+    for g in bbm_pool:
+        assert _re.match(r"BBM-P\d+-T\d+$", g["team_a_id"]), f"Unexpected team_a_id: {g['team_a_id']}"
+        assert _re.match(r"BBM-P\d+-T\d+$", g["team_b_id"]), f"Unexpected team_b_id: {g['team_b_id']}"
+
+
+def test_build_schedule_input_gym_court_scenario(mock_connectors, tmp_path):
+    """gym_court_scenario in schedule_input matches SCHEDULE_SOLVER_GYM_COURTS."""
+    from config import SCHEDULE_SOLVER_GYM_COURTS
+    exporter = ChurchTeamsExporter()
+    si = exporter._build_schedule_input(_make_gym_roster(), [], tmp_path / "missing.xlsx")
+    assert si["gym_court_scenario"] == SCHEDULE_SOLVER_GYM_COURTS
+    gym_resources = [r for r in si["resources"] if r["resource_type"] == "Gym Court"]
+    n_sessions = 4  # Sat-1, Sun-1, Sat-2, Sun-2
+    assert len(gym_resources) == SCHEDULE_SOLVER_GYM_COURTS * n_sessions
 
 
 def test_build_pod_game_objects_single_elimination(mock_connectors):
@@ -1876,7 +1935,8 @@ def test_build_schedule_input_keys(mock_connectors, tmp_path):
     exporter = ChurchTeamsExporter()
     si = exporter._build_schedule_input(_make_gym_roster(), [], tmp_path / "missing.xlsx")
     assert set(si.keys()) == {
-        "generated_at", "game_count", "resource_count", "games", "resources", "precedence"
+        "generated_at", "gym_court_scenario", "game_count", "resource_count",
+        "games", "resources", "precedence",
     }
     assert si["game_count"] == len(si["games"])
     assert si["resource_count"] == len(si["resources"])
@@ -1925,6 +1985,7 @@ def test_schedule_input_tab_in_consolidated_export(mock_connectors, tmp_path):
     import json as _json
     data = _json.loads(json_path.read_text(encoding="utf-8"))
     assert "games" in data and "resources" in data and "precedence" in data
+    assert "gym_court_scenario" in data
     assert data["game_count"] > 0
     assert data["resource_count"] == len(data["resources"])
     assert data["resource_count"] > 0

--- a/middleware/tests/test_church_teams_export.py
+++ b/middleware/tests/test_church_teams_export.py
@@ -923,6 +923,10 @@ def test_venue_capacity_tab_only_in_consolidated_export(mock_connectors, tmp_pat
     assert "Potential Teams/Entries" in venue_df.columns
     assert "Estimating Teams/Entries" in venue_df.columns
     assert "Teams" in venue_df.columns
+    assert "Target Pool Games/Team" in venue_df.columns
+    assert "Actual Pool Games/Team" in venue_df.columns
+    assert "Pool Composition" in venue_df.columns
+    assert "BYE Slots" in venue_df.columns
     assert "Estimated Court Hours" in venue_df.columns
     # 5 team sports + 6 racquet sports
     assert len(venue_df[venue_df["Minutes Per Game"].notna()]) == 11  # 5 team + 6 racquet sports
@@ -1729,11 +1733,9 @@ def test_build_gym_game_objects_stable_team_ids(mock_connectors):
         appearances[g["team_a_id"]] += 1
         appearances[g["team_b_id"]] += 1
 
-    # Every team must appear in at least 2 games (gpg=2 for Basketball)
-    # Some teams in smaller edge pools may appear fewer times, but all appear at least once
-    assert all(count >= 1 for count in appearances.values()), "Each team must appear at least once"
-    # At least some teams appear in exactly 2 games (normal pool size = 3 teams)
-    assert any(count >= 2 for count in appearances.values()), "Some teams must appear in multiple games"
+    # The normalized 2-game policy keeps every team at exactly 2 pool games.
+    assert appearances, "Expected stable placeholder team IDs to be reused"
+    assert all(count == 2 for count in appearances.values()), appearances
 
 
 def test_build_gym_game_objects_pool_id_nonempty(mock_connectors):
@@ -2231,49 +2233,70 @@ def test_build_schedule_output_flat_rows_empty():
 # B3 — _compute_court_slots matches _make_pool_game_pairs actual count
 # ---------------------------------------------------------------------------
 
-def test_compute_court_slots_formula_vs_actual_8teams_gpg2(mock_connectors):
-    """8 teams / gpg=2: formula gives 8 but actual round-robin (B4-balanced pools) is 12.
-
-    B4 fix: floor division gives pools [4,4] (each team plays 3 games ≥ gpg=2).
-    Old ceil division gave pools [3,3,2] where the 2-team pool played only 1 game.
-    _compute_court_slots called with actual_pool_games returns 12, not 8.
-    """
+def test_compute_court_slots_matches_normalized_policy_8teams_gpg2(mock_connectors):
+    """8 teams / gpg=2 now stays at 8 pool games under the normalized policy."""
     from church_teams_export import ChurchTeamsExporter
 
     n_teams, gpg = 8, 2
     actual = len(ChurchTeamsExporter._make_pool_game_pairs("_", n_teams, gpg))
-    assert actual == 12  # pools [4,4] → C(4,2)+C(4,2) = 6+6
+    assert actual == 8  # pools [4,4] with 4-match matrices -> 4 + 4
 
     exporter = ChurchTeamsExporter()
     s_formula = exporter._compute_court_slots(n_teams, pool_games_per_team=gpg)
     s_actual  = exporter._compute_court_slots(n_teams, pool_games_per_team=gpg,
                                               actual_pool_games=actual)
-    assert s_formula["pool_slots"] == 8    # ceil(8*2/2) formula estimate
-    assert s_actual["pool_slots"]  == 12   # correct actual count
+    assert s_formula["pool_slots"] == 8
+    assert s_actual["pool_slots"]  == 8
 
 
-def test_make_pool_game_pairs_all_teams_play_at_least_gpg(mock_connectors):
-    """B4: every team plays at least gpg games regardless of n_teams % (gpg+1)."""
+def test_make_pool_game_pairs_exact_two_games_per_team(mock_connectors):
+    """Normalized B4 policy keeps every team at the same exact pool-game count."""
     from church_teams_export import ChurchTeamsExporter
     from collections import Counter
 
     cases = [
-        (7, 2),   # old: pools [3,2,2] → min 1 game; new: [4,3] → min 2 = gpg
-        (8, 2),   # old: pools [3,3,2] → min 1 game; new: [4,4] → min 3 ≥ gpg
-        (9, 3),   # old: pools [4,3,3] → min 2 game; new: [5,4] → min 3 = gpg
-        (10, 3),  # old: pools [4,4,4] → exact; new: same, no change
-        (5, 2),   # 1 pool of 5 → each plays 4 ≥ gpg=2
+        (3, 2, 2, 3),
+        (4, 2, 2, 4),
+        (5, 2, 2, 5),
+        (7, 2, 2, 7),
+        (8, 2, 2, 8),
+        (12, 2, 2, 12),
+        (20, 2, 2, 20),
     ]
-    for n_teams, gpg in cases:
+    for n_teams, gpg, expected_games_per_team, expected_total_games in cases:
         pairs = ChurchTeamsExporter._make_pool_game_pairs("T", n_teams, gpg)
         games_per_team: Counter = Counter()
         for a, b, _ in pairs:
             games_per_team[a] += 1
             games_per_team[b] += 1
-        min_games = min(games_per_team.values()) if games_per_team else 0
-        assert min_games >= gpg, (
-            f"n_teams={n_teams}, gpg={gpg}: min games={min_games} < gpg"
+        assert len(pairs) == expected_total_games, (
+            f"n_teams={n_teams}: total pool games {len(pairs)} != {expected_total_games}"
         )
+        assert games_per_team, f"Expected generated games for n_teams={n_teams}"
+        assert all(count == expected_games_per_team for count in games_per_team.values()), (
+            f"n_teams={n_teams}, gpg={gpg}: {dict(games_per_team)}"
+        )
+
+
+def test_make_pool_game_pairs_direct_match_for_two_teams(mock_connectors):
+    """Two teams stay as a single direct match rather than an over-built pool."""
+    from church_teams_export import ChurchTeamsExporter
+
+    pairs = ChurchTeamsExporter._make_pool_game_pairs("T", 2, 2)
+    assert pairs == [("T-P1-T1", "T-P1-T2", "P1")]
+
+
+def test_make_pool_game_pairs_legacy_fallback_for_nondefault_target(mock_connectors):
+    """Non-default targets keep the legacy balanced round-robin fallback."""
+    from church_teams_export import ChurchTeamsExporter
+    from collections import Counter
+
+    pairs = ChurchTeamsExporter._make_pool_game_pairs("T", 9, 3)
+    games_per_team: Counter = Counter()
+    for a, b, _ in pairs:
+        games_per_team[a] += 1
+        games_per_team[b] += 1
+    assert min(games_per_team.values()) >= 3
 
 
 def test_compute_court_slots_consistent_with_make_pool_game_pairs(mock_connectors):
@@ -2282,7 +2305,7 @@ def test_compute_court_slots_consistent_with_make_pool_game_pairs(mock_connector
     from church_teams_export import ChurchTeamsExporter
 
     exporter = ChurchTeamsExporter()
-    cases = [(4, 3), (6, 2), (8, 2), (9, 3), (10, 2), (12, 3)]
+    cases = [(2, 2), (5, 2), (8, 2), (12, 2), (9, 3)]
     for n_teams, gpg in cases:
         actual = len(ChurchTeamsExporter._make_pool_game_pairs("_", n_teams, gpg))
         s = exporter._compute_court_slots(n_teams, pool_games_per_team=gpg,

--- a/middleware/tests/test_church_teams_export.py
+++ b/middleware/tests/test_church_teams_export.py
@@ -1924,24 +1924,13 @@ def test_load_venue_input_rows_skips_blank_resource_rows(mock_connectors, tmp_pa
     assert all(r["resource_type"] == POD_RESOURCE_TYPE_TENNIS for r in result)
 
 
-def test_build_precedence_objects_pool_before_final(mock_connectors):
-    """Pool → Semi and Semi → Final rules are generated when stages are present."""
-    exporter = ChurchTeamsExporter()
-    games = exporter._build_gym_game_objects(_make_gym_roster(8))
-    rules = ChurchTeamsExporter._build_precedence_objects(games)
-    assert rules, "Expected precedence rules for sports with playoffs"
-    bbm_rules = [r for r in rules if r["event"] == SPORT_TYPE["BASKETBALL"]]
-    stage_pairs = {(r["earlier_stage"], r["later_stage"]) for r in bbm_rules}
-    assert ("Semi", "Final") in stage_pairs
-
-
 def test_build_schedule_input_keys(mock_connectors, tmp_path):
     """_build_schedule_input returns dict with all required top-level keys."""
     exporter = ChurchTeamsExporter()
     si = exporter._build_schedule_input(_make_gym_roster(), [], tmp_path / "missing.xlsx")
     assert set(si.keys()) == {
         "generated_at", "gym_court_scenario", "game_count", "resource_count",
-        "games", "resources", "precedence",
+        "games", "resources", "playoff_slots",
     }
     assert si["game_count"] == len(si["games"])
     assert si["resource_count"] == len(si["resources"])
@@ -1989,7 +1978,7 @@ def test_schedule_input_tab_in_consolidated_export(mock_connectors, tmp_path):
 
     import json as _json
     data = _json.loads(json_path.read_text(encoding="utf-8"))
-    assert "games" in data and "resources" in data and "precedence" in data
+    assert "games" in data and "resources" in data and "playoff_slots" in data
     assert "gym_court_scenario" in data
     assert data["game_count"] > 0
     assert data["resource_count"] == len(data["resources"])

--- a/middleware/tests/test_church_teams_export.py
+++ b/middleware/tests/test_church_teams_export.py
@@ -2164,3 +2164,69 @@ def test_write_schedule_output_report_unscheduled_section(tmp_path):
     all_values = [ws.cell(row=r, column=1).value for r in range(1, ws.max_row + 1)]
     assert any("Unscheduled" in str(v) for v in all_values if v)
     assert any("BBM-QF-1" in str(v) for v in all_values if v)
+
+
+def test_write_schedule_output_report_groups_mixed_pod_windows(tmp_path):
+    """Pod resources with different slot windows render as separate time-grid sections."""
+    from church_teams_export import ChurchTeamsExporter
+    import openpyxl
+
+    schedule_input = {
+        "games": [
+            {
+                "game_id": "PCK-01", "event": "Pickleball",
+                "stage": "R1", "pool_id": "", "round": 1,
+                "team_a_id": None, "team_b_id": None,
+                "duration_minutes": 20, "resource_type": "Pickleball Court",
+                "earliest_slot": None, "latest_slot": None,
+            },
+            {
+                "game_id": "TT-01", "event": "Table Tennis",
+                "stage": "R1", "pool_id": "", "round": 1,
+                "team_a_id": None, "team_b_id": None,
+                "duration_minutes": 30, "resource_type": "Table Tennis Table",
+                "earliest_slot": None, "latest_slot": None,
+            },
+        ],
+        "resources": [
+            {
+                "resource_id": "PCK-1", "resource_type": "Pickleball Court",
+                "label": "Court-1", "day": "Day-1",
+                "open_time": "13:00", "close_time": "13:40", "slot_minutes": 20,
+            },
+            {
+                "resource_id": "TT-1", "resource_type": "Table Tennis Table",
+                "label": "Table-1", "day": "Day-1",
+                "open_time": "18:00", "close_time": "19:00", "slot_minutes": 30,
+            },
+        ],
+        "precedence": [],
+    }
+    schedule_output = {
+        "solved_at": "2026-05-15T07:07:48",
+        "status": "PARTIAL",
+        "solver_wall_seconds": 0.2,
+        "assignments": [
+            {"game_id": "PCK-01", "resource_id": "PCK-1", "slot": "Day-1-13:00"},
+            {"game_id": "TT-01", "resource_id": "TT-1", "slot": "Day-1-18:00"},
+        ],
+        "unscheduled": [],
+        "pool_results": [],
+    }
+    out = tmp_path / "sched.xlsx"
+    ChurchTeamsExporter._write_schedule_output_report(out, schedule_output, schedule_input)
+    ws = openpyxl.load_workbook(out)["Schedule-by-Time"]
+
+    all_values = [
+        ws.cell(row=r, column=c).value
+        for r in range(1, ws.max_row + 1)
+        for c in range(1, ws.max_column + 1)
+    ]
+    string_values = [str(v) for v in all_values if v is not None]
+
+    assert any("Pickleball Court" in v for v in string_values)
+    assert any("Table Tennis Table" in v for v in string_values)
+    assert "13:00" in string_values
+    assert "18:00" in string_values
+    assert any("PCK-01" in v for v in string_values)
+    assert any("TT-01" in v for v in string_values)

--- a/middleware/tests/test_church_teams_export.py
+++ b/middleware/tests/test_church_teams_export.py
@@ -1025,6 +1025,7 @@ def test_build_pod_divisions_rows_singles(mock_connectors):
     div = rows[0]
     assert div["division_id"] == "BAD-Men-Singles"
     assert div["sport_type"] == "Badminton"
+    assert div["resource_type"] == "Badminton Court"
     assert div["planning_entries"] == 3
     assert div["confirmed_entries"] == 2  # participant 2 has error
     assert div["provisional_entries"] == 1
@@ -1049,6 +1050,7 @@ def test_build_pod_divisions_rows_doubles(mock_connectors):
     assert len(rows) == 1
     div = rows[0]
     assert div["division_id"] == "TT-Men-Doubles"
+    assert div["resource_type"] == "Table Tennis Table"
     assert div["planning_entries"] == 2   # floor(4/2)
     assert div["confirmed_entries"] == 2  # no errors
     assert div["provisional_entries"] == 0
@@ -1772,6 +1774,8 @@ def test_build_schedule_input_gym_court_scenario(mock_connectors, tmp_path):
 
 def test_build_pod_game_objects_single_elimination(mock_connectors):
     """With 3 entries in a division, 2 game placeholders are generated."""
+    from config import POD_RESOURCE_EVENT_TYPE
+
     roster_rows = [
         {"Church Team": "RPC", "Participant ID (WP)": i,
          "sport_type": SPORT_TYPE["BADMINTON"], "sport_gender": "Women",
@@ -1783,6 +1787,7 @@ def test_build_pod_game_objects_single_elimination(mock_connectors):
     assert len(games) == 2, f"Expected 2 games (3-1=2), got {len(games)}"
     assert all(g["game_id"].startswith("BAD-Women-Singles-") for g in games)
     assert all(g["stage"] == "R1" for g in games)
+    assert all(g["resource_type"] == POD_RESOURCE_EVENT_TYPE[SPORT_TYPE["BADMINTON"]] for g in games)
     assert games[0]["game_id"] == "BAD-Women-Singles-01"
 
 

--- a/middleware/tests/test_church_teams_export.py
+++ b/middleware/tests/test_church_teams_export.py
@@ -2232,22 +2232,48 @@ def test_build_schedule_output_flat_rows_empty():
 # ---------------------------------------------------------------------------
 
 def test_compute_court_slots_formula_vs_actual_8teams_gpg2(mock_connectors):
-    """8 teams / gpg=2: formula over-counts (8) but actual round-robin is 7 games.
+    """8 teams / gpg=2: formula gives 8 but actual round-robin (B4-balanced pools) is 12.
 
-    _compute_court_slots called with actual_pool_games returns 7, not 8.
+    B4 fix: floor division gives pools [4,4] (each team plays 3 games ≥ gpg=2).
+    Old ceil division gave pools [3,3,2] where the 2-team pool played only 1 game.
+    _compute_court_slots called with actual_pool_games returns 12, not 8.
     """
     from church_teams_export import ChurchTeamsExporter
 
     n_teams, gpg = 8, 2
     actual = len(ChurchTeamsExporter._make_pool_game_pairs("_", n_teams, gpg))
-    assert actual == 7  # pools [3,3,2] → 3+3+1
+    assert actual == 12  # pools [4,4] → C(4,2)+C(4,2) = 6+6
 
     exporter = ChurchTeamsExporter()
     s_formula = exporter._compute_court_slots(n_teams, pool_games_per_team=gpg)
     s_actual  = exporter._compute_court_slots(n_teams, pool_games_per_team=gpg,
                                               actual_pool_games=actual)
-    assert s_formula["pool_slots"] == 8   # old over-counting formula
-    assert s_actual["pool_slots"]  == 7   # correct actual count
+    assert s_formula["pool_slots"] == 8    # ceil(8*2/2) formula estimate
+    assert s_actual["pool_slots"]  == 12   # correct actual count
+
+
+def test_make_pool_game_pairs_all_teams_play_at_least_gpg(mock_connectors):
+    """B4: every team plays at least gpg games regardless of n_teams % (gpg+1)."""
+    from church_teams_export import ChurchTeamsExporter
+    from collections import Counter
+
+    cases = [
+        (7, 2),   # old: pools [3,2,2] → min 1 game; new: [4,3] → min 2 = gpg
+        (8, 2),   # old: pools [3,3,2] → min 1 game; new: [4,4] → min 3 ≥ gpg
+        (9, 3),   # old: pools [4,3,3] → min 2 game; new: [5,4] → min 3 = gpg
+        (10, 3),  # old: pools [4,4,4] → exact; new: same, no change
+        (5, 2),   # 1 pool of 5 → each plays 4 ≥ gpg=2
+    ]
+    for n_teams, gpg in cases:
+        pairs = ChurchTeamsExporter._make_pool_game_pairs("T", n_teams, gpg)
+        games_per_team: Counter = Counter()
+        for a, b, _ in pairs:
+            games_per_team[a] += 1
+            games_per_team[b] += 1
+        min_games = min(games_per_team.values()) if games_per_team else 0
+        assert min_games >= gpg, (
+            f"n_teams={n_teams}, gpg={gpg}: min games={min_games} < gpg"
+        )
 
 
 def test_compute_court_slots_consistent_with_make_pool_game_pairs(mock_connectors):

--- a/middleware/tests/test_church_teams_export.py
+++ b/middleware/tests/test_church_teams_export.py
@@ -1922,13 +1922,125 @@ def test_load_venue_input_rows_skips_blank_resource_rows(mock_connectors, tmp_pa
     assert all(r["resource_type"] == POD_RESOURCE_TYPE_TENNIS for r in result)
 
 
+def _write_venue_input(path, headers, data_rows, gym_modes_rows=None):
+    """Write a venue_input.xlsx with a Venue-Input tab (and optional Gym-Modes)."""
+    from openpyxl import Workbook
+
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Venue-Input"
+    for c, h in enumerate(headers, start=1):
+        ws.cell(row=1, column=c, value=h)
+    for r, data in enumerate(data_rows, start=2):
+        for c, val in enumerate(data, start=1):
+            ws.cell(row=r, column=c, value=val)
+    if gym_modes_rows is not None:
+        gm = wb.create_sheet("Gym-Modes")
+        for r, data in enumerate(gym_modes_rows, start=1):
+            for c, val in enumerate(data, start=1):
+                gm.cell(row=r, column=c, value=val)
+    wb.save(path)
+
+
+def test_load_venue_input_rows_reads_exclusive_group(mock_connectors, tmp_path):
+    """Exclusive Venue Group column is attached to each emitted resource object."""
+    from config import POD_RESOURCE_TYPE_TENNIS
+
+    headers = [
+        "Pod Name", "Venue Name", "Exclusive Venue Group", "Resource Type",
+        "Quantity", "Date", "Start Time", "Last Start Time", "Slot Minutes",
+        "Available Slots", "Contact", "Cost", "Notes",
+    ]
+    rows = [
+        ["BB Pod", "Midsize Gym", "Midsize Gym", POD_RESOURCE_TYPE_TENNIS,
+         2, None, 9, 17, 30, None, None, None, None],
+    ]
+    path = tmp_path / "venue_input.xlsx"
+    _write_venue_input(path, headers, rows)
+
+    result = ChurchTeamsExporter._load_venue_input_rows(path)
+    assert len(result) == 2
+    assert all(r["exclusive_group"] == "Midsize Gym" for r in result)
+
+
+def test_load_venue_input_rows_blank_exclusive_group(mock_connectors, tmp_path):
+    """A row with no Exclusive Venue Group yields an empty-string group."""
+    from config import POD_RESOURCE_TYPE_TENNIS
+
+    headers = [
+        "Pod Name", "Venue Name", "Exclusive Venue Group", "Resource Type",
+        "Quantity", "Date", "Start Time", "Last Start Time", "Slot Minutes",
+        "Available Slots", "Contact", "Cost", "Notes",
+    ]
+    rows = [
+        ["Tennis Pod", "Chapman", None, POD_RESOURCE_TYPE_TENNIS,
+         1, None, 9, 17, 60, None, None, None, None],
+    ]
+    path = tmp_path / "venue_input.xlsx"
+    _write_venue_input(path, headers, rows)
+
+    result = ChurchTeamsExporter._load_venue_input_rows(path)
+    assert result[0]["exclusive_group"] == ""
+
+
+def test_load_gym_modes_missing_file(mock_connectors, tmp_path):
+    """Returns empty dict when venue_input.xlsx does not exist."""
+    assert ChurchTeamsExporter._load_gym_modes(tmp_path / "missing.xlsx") == {}
+
+
+def test_load_gym_modes_missing_tab(mock_connectors, tmp_path):
+    """File present but no Gym-Modes tab → empty dict (warning, no crash)."""
+    headers = ["Pod Name", "Resource Type", "Quantity"]
+    path = tmp_path / "venue_input.xlsx"
+    _write_venue_input(path, headers, [["P", "Tennis Court", 1]])
+    assert ChurchTeamsExporter._load_gym_modes(path) == {}
+
+
+def test_load_gym_modes_reads_capacities(mock_connectors, tmp_path):
+    """Gym-Modes tab is parsed into {gym: {resource_type: courts_per_block}}."""
+    headers = ["Pod Name", "Resource Type", "Quantity"]
+    gym_modes = [
+        ["Gym Name", "Basketball Courts", "Volleyball Courts",
+         "Badminton Courts", "Pickleball Courts", "Soccer Fields", "Notes"],
+        ["Midsize Gym", 1, 2, 6, 8, 1, "either-or"],
+        ["Big Gym", 2, 3, 12, 0, 0, "larger"],
+    ]
+    path = tmp_path / "venue_input.xlsx"
+    _write_venue_input(path, headers, [["P", "Tennis Court", 1]], gym_modes)
+
+    result = ChurchTeamsExporter._load_gym_modes(path)
+    assert result["Midsize Gym"] == {
+        "Basketball Court": 1, "Volleyball Court": 2,
+        "Badminton Court": 6, "Pickleball Court": 8, "Soccer Field": 1,
+    }
+    assert result["Big Gym"]["Volleyball Court"] == 3
+    assert result["Big Gym"]["Pickleball Court"] == 0
+
+
+def test_load_gym_modes_skips_note_row(mock_connectors, tmp_path):
+    """A footer row with text in Gym Name but no capacities is ignored."""
+    headers = ["Pod Name", "Resource Type", "Quantity"]
+    gym_modes = [
+        ["Gym Name", "Basketball Courts", "Volleyball Courts",
+         "Badminton Courts", "Pickleball Courts", "Soccer Fields", "Notes"],
+        ["Midsize Gym", 1, 2, 6, 8, 1, "either-or"],
+        ["Capacity-per-mode coefficients for the LP estimator.",
+         None, None, None, None, None, None],
+    ]
+    path = tmp_path / "venue_input.xlsx"
+    _write_venue_input(path, headers, [["P", "Tennis Court", 1]], gym_modes)
+
+    result = ChurchTeamsExporter._load_gym_modes(path)
+    assert list(result.keys()) == ["Midsize Gym"]
+
+
 def test_build_schedule_input_keys(mock_connectors, tmp_path):
     """_build_schedule_input returns dict with all required top-level keys."""
     exporter = ChurchTeamsExporter()
     si = exporter._build_schedule_input(_make_gym_roster(), [], tmp_path / "missing.xlsx")
     assert set(si.keys()) == {
         "generated_at", "gym_court_scenario", "game_count", "resource_count",
-        "games", "resources", "playoff_slots",
+        "games", "resources", "playoff_slots", "gym_modes",
     }
     assert si["game_count"] == len(si["games"])
     assert si["resource_count"] == len(si["resources"])

--- a/middleware/tests/test_church_teams_export.py
+++ b/middleware/tests/test_church_teams_export.py
@@ -1821,6 +1821,14 @@ def test_build_gym_resource_objects_labels(mock_connectors):
     assert "GYM-Sun-2-3" in ids
 
 
+def test_build_gym_resource_objects_include_blank_exclusive_group(mock_connectors):
+    """Gym resources carry the same exclusive_group field as venue-loaded resources."""
+    resources = ChurchTeamsExporter._build_gym_resource_objects(n_courts=2)
+    assert resources
+    assert all("exclusive_group" in r for r in resources)
+    assert all(r["exclusive_group"] == "" for r in resources)
+
+
 def test_load_venue_input_rows_missing_file(mock_connectors, tmp_path):
     """Returns empty list when venue_input.xlsx does not exist."""
     result = ChurchTeamsExporter._load_venue_input_rows(tmp_path / "missing.xlsx")
@@ -2015,6 +2023,21 @@ def test_load_gym_modes_reads_capacities(mock_connectors, tmp_path):
     }
     assert result["Big Gym"]["Volleyball Court"] == 3
     assert result["Big Gym"]["Pickleball Court"] == 0
+
+
+def test_load_gym_modes_trims_header_whitespace(mock_connectors, tmp_path):
+    """Operator-edited headers with trailing spaces are normalized before row access."""
+    headers = ["Pod Name", "Resource Type", "Quantity"]
+    gym_modes = [
+        ["Gym Name ", "Basketball Courts ", "Volleyball Courts ", "Notes "],
+        ["Midsize Gym", 1, 2, "either-or"],
+    ]
+    path = tmp_path / "venue_input.xlsx"
+    _write_venue_input(path, headers, [["P", "Tennis Court", 1]], gym_modes)
+
+    result = ChurchTeamsExporter._load_gym_modes(path)
+    assert result["Midsize Gym"]["Basketball Court"] == 1
+    assert result["Midsize Gym"]["Volleyball Court"] == 2
 
 
 def test_load_gym_modes_skips_note_row(mock_connectors, tmp_path):

--- a/middleware/tests/test_church_teams_export.py
+++ b/middleware/tests/test_church_teams_export.py
@@ -1698,13 +1698,11 @@ def test_build_gym_game_objects_structure(mock_connectors):
 
 
 def test_build_gym_game_objects_stages(mock_connectors):
-    """With 8 BBM teams, Pool + Semi + Final stages are all present."""
+    """With 8 BBM teams, only Pool stage is present (playoffs go in Playoff-Slots tab)."""
     exporter = ChurchTeamsExporter()
     games = exporter._build_gym_game_objects(_make_gym_roster(8))
     bbm_stages = {g["stage"] for g in games if g["event"] == SPORT_TYPE["BASKETBALL"]}
-    assert "Pool" in bbm_stages
-    assert "Semi" in bbm_stages or "QF" in bbm_stages
-    assert "Final" in bbm_stages
+    assert bbm_stages == {"Pool"}, f"Expected only Pool stage; got {bbm_stages}"
 
 
 def test_build_gym_game_objects_prefix_format(mock_connectors):

--- a/middleware/tests/test_church_teams_export.py
+++ b/middleware/tests/test_church_teams_export.py
@@ -935,9 +935,9 @@ def test_venue_capacity_tab_only_in_consolidated_export(mock_connectors, tmp_pat
     assert int(bball["Estimating Teams/Entries"]) == 1   # RPC's 6 basketball players qualify
     assert int(bball["Potential Teams/Entries"]) == 1    # RPC (estimating) counts in potential too
     assert str(bball["Teams"]) == "RPC"
-    assert int(bball["Pool Slots"]) == 1         # ceil(1*2/2) = 1
+    assert int(bball["Pool Slots"]) == 0         # 1 team can't play pool games (B3: actual=0)
     assert int(bball["Playoff Teams"]) == 0      # 1 team → no playoff
-    assert int(bball["Total Court Slots"]) == 1
+    assert int(bball["Total Court Slots"]) == 0
 
     vb_men = venue_df[venue_df["Event"] == "Volleyball - Men Team"].iloc[0]
     assert int(vb_men["Estimating Teams/Entries"]) == 0  # no volleyball rosters
@@ -2225,6 +2225,85 @@ def test_build_schedule_output_flat_rows_empty():
     si = {"games": [], "resources": [], "precedence": []}
     rows = ChurchTeamsExporter._build_schedule_output_flat_rows(so, si)
     assert rows == []
+
+
+# ---------------------------------------------------------------------------
+# B3 — _compute_court_slots matches _make_pool_game_pairs actual count
+# ---------------------------------------------------------------------------
+
+def test_compute_court_slots_formula_vs_actual_8teams_gpg2(mock_connectors):
+    """8 teams / gpg=2: formula over-counts (8) but actual round-robin is 7 games.
+
+    _compute_court_slots called with actual_pool_games returns 7, not 8.
+    """
+    from church_teams_export import ChurchTeamsExporter
+
+    n_teams, gpg = 8, 2
+    actual = len(ChurchTeamsExporter._make_pool_game_pairs("_", n_teams, gpg))
+    assert actual == 7  # pools [3,3,2] → 3+3+1
+
+    exporter = ChurchTeamsExporter()
+    s_formula = exporter._compute_court_slots(n_teams, pool_games_per_team=gpg)
+    s_actual  = exporter._compute_court_slots(n_teams, pool_games_per_team=gpg,
+                                              actual_pool_games=actual)
+    assert s_formula["pool_slots"] == 8   # old over-counting formula
+    assert s_actual["pool_slots"]  == 7   # correct actual count
+
+
+def test_compute_court_slots_consistent_with_make_pool_game_pairs(mock_connectors):
+    """pool_slots from _compute_court_slots equals len(_make_pool_game_pairs) for
+    several (n_teams, gpg) combinations."""
+    from church_teams_export import ChurchTeamsExporter
+
+    exporter = ChurchTeamsExporter()
+    cases = [(4, 3), (6, 2), (8, 2), (9, 3), (10, 2), (12, 3)]
+    for n_teams, gpg in cases:
+        actual = len(ChurchTeamsExporter._make_pool_game_pairs("_", n_teams, gpg))
+        s = exporter._compute_court_slots(n_teams, pool_games_per_team=gpg,
+                                          actual_pool_games=actual)
+        assert s["pool_slots"] == actual, (
+            f"n_teams={n_teams}, gpg={gpg}: pool_slots={s['pool_slots']} != actual={actual}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# B5 — _warn_if_schedules_mismatched
+# ---------------------------------------------------------------------------
+
+def test_warn_if_schedules_mismatched_clean(mock_connectors):
+    """Returns True and no warning when all assignment IDs are in schedule_input."""
+    from church_teams_export import ChurchTeamsExporter
+
+    so = {"assignments": [{"game_id": "G1", "resource_id": "R1", "slot": "Sat-1-08:00"}]}
+    si = {"games": [{"game_id": "G1"}], "playoff_slots": []}
+    assert ChurchTeamsExporter._warn_if_schedules_mismatched(so, si) is True
+
+
+def test_warn_if_schedules_mismatched_playoff_ok(mock_connectors):
+    """Returns True when assignment ID matches a playoff_slot, not a game."""
+    from church_teams_export import ChurchTeamsExporter
+
+    so = {"assignments": [{"game_id": "BBM-Final", "resource_id": "R1", "slot": "Sat-2-14:00"}]}
+    si = {"games": [], "playoff_slots": [{"game_id": "BBM-Final"}]}
+    assert ChurchTeamsExporter._warn_if_schedules_mismatched(so, si) is True
+
+
+def test_warn_if_schedules_mismatched_detects_orphan(mock_connectors):
+    """Returns False and logs a warning when an assignment game_id is unknown."""
+    from loguru import logger
+    from church_teams_export import ChurchTeamsExporter
+
+    messages = []
+    sink_id = logger.add(lambda msg: messages.append(msg), level="WARNING")
+    try:
+        so = {"assignments": [{"game_id": "STALE-99", "resource_id": "R1", "slot": "Sat-1-08:00"}]}
+        si = {"games": [{"game_id": "G1"}], "playoff_slots": []}
+        result = ChurchTeamsExporter._warn_if_schedules_mismatched(so, si)
+    finally:
+        logger.remove(sink_id)
+    assert result is False
+    assert any("STALE-99" in m for m in messages)
+    assert any("different runs" in m for m in messages)
 
 
 # ---------------------------------------------------------------------------

--- a/middleware/tests/test_main.py
+++ b/middleware/tests/test_main.py
@@ -1,0 +1,252 @@
+import argparse
+import datetime as dt
+import json
+
+import pytest
+from openpyxl import Workbook, load_workbook
+
+import main
+
+
+def _run_main_expect_exit(expected_code: int) -> None:
+    with pytest.raises(SystemExit) as exc:
+        main.main()
+    assert exc.value.code == expected_code
+
+
+def _minimal_schedule_input() -> dict:
+    return {
+        "generated_at": "2026-05-15T00:00:00",
+        "gym_court_scenario": 4,
+        "game_count": 2,
+        "resource_count": 1,
+        "games": [
+            {
+                "game_id": "BBM-01",
+                "event": "Basketball - Men Team",
+                "stage": "Pool",
+                "pool_id": "P1",
+                "round": 1,
+                "team_a_id": "BBM-P1-T1",
+                "team_b_id": "BBM-P1-T2",
+                "duration_minutes": 60,
+                "resource_type": "Gym Court",
+                "earliest_slot": None,
+                "latest_slot": None,
+            },
+            {
+                "game_id": "BBM-02",
+                "event": "Basketball - Men Team",
+                "stage": "Pool",
+                "pool_id": "P1",
+                "round": 2,
+                "team_a_id": "BBM-P1-T3",
+                "team_b_id": "BBM-P1-T4",
+                "duration_minutes": 60,
+                "resource_type": "Gym Court",
+                "earliest_slot": None,
+                "latest_slot": None,
+            },
+        ],
+        "resources": [
+            {
+                "resource_id": "GYM-Sat-1-1",
+                "resource_type": "Gym Court",
+                "label": "Court-1",
+                "day": "Sat-1",
+                "open_time": "08:00",
+                "close_time": "10:00",
+                "slot_minutes": 60,
+                "exclusive_group": "",
+            }
+        ],
+        "playoff_slots": [],
+        "gym_modes": {},
+    }
+
+
+def test_parse_args_solve_schedule_defaults(monkeypatch):
+    monkeypatch.setattr(main.sys, "argv", ["main.py", "solve-schedule"])
+    args = main.parse_args()
+    assert args.command == "solve-schedule"
+    assert args.input is None
+    assert args.output is None
+
+
+def test_parse_args_produce_schedule_aliases(monkeypatch):
+    monkeypatch.setattr(
+        main.sys,
+        "argv",
+        [
+            "main.py",
+            "produce-schedule",
+            "--input",
+            "out.json",
+            "--constraint",
+            "in.json",
+            "--output",
+            "schedule.xlsx",
+        ],
+    )
+    args = main.parse_args()
+    assert args.command == "produce-schedule"
+    assert args.schedule_output == "out.json"
+    assert args.schedule_input == "in.json"
+    assert args.output == "schedule.xlsx"
+
+
+def test_main_solve_schedule_uses_default_paths(mocker, monkeypatch, tmp_path):
+    monkeypatch.setattr(main, "DATA_DIR", tmp_path)
+    mock_run = mocker.patch("scheduler.run_solve_schedule", return_value=7)
+    monkeypatch.setattr(
+        main,
+        "parse_args",
+        lambda: argparse.Namespace(command="solve-schedule", input=None, output=None),
+    )
+
+    _run_main_expect_exit(7)
+
+    mock_run.assert_called_once_with(
+        tmp_path / "schedule_input.json",
+        tmp_path / "schedule_output.json",
+    )
+
+
+def test_main_produce_schedule_uses_default_paths(mocker, monkeypatch, tmp_path):
+    monkeypatch.setattr(main, "DATA_DIR", tmp_path)
+    monkeypatch.setattr(main, "EXPORT_DIR", tmp_path)
+
+    schedule_output_path = tmp_path / "schedule_output.json"
+    schedule_input_path = tmp_path / "schedule_input.json"
+    schedule_output_path.write_text(
+        json.dumps(
+            {
+                "solved_at": "2026-05-15T12:00:00",
+                "status": "OPTIMAL",
+                "solver_wall_seconds": 0.1,
+                "assignments": [],
+                "unscheduled": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    schedule_input_path.write_text(
+        json.dumps({"games": [], "resources": [], "playoff_slots": []}),
+        encoding="utf-8",
+    )
+
+    class FakeDate(dt.date):
+        @classmethod
+        def today(cls):
+            return cls(2026, 5, 15)
+
+    monkeypatch.setattr(main.datetime, "date", FakeDate)
+    mock_write = mocker.patch.object(main.ChurchTeamsExporter, "_write_schedule_output_report")
+    monkeypatch.setattr(
+        main,
+        "parse_args",
+        lambda: argparse.Namespace(
+            command="produce-schedule",
+            schedule_output=None,
+            schedule_input=None,
+            output=None,
+        ),
+    )
+
+    _run_main_expect_exit(0)
+
+    mock_write.assert_called_once()
+    out_path, so_data, si_data = mock_write.call_args.args
+    assert out_path == tmp_path / "VAYSF_Schedule_2026-05-15.xlsx"
+    assert so_data["status"] == "OPTIMAL"
+    assert si_data["games"] == []
+
+
+def test_schedule_pipeline_export_solve_produce_local(mocker, monkeypatch, tmp_path):
+    pytest.importorskip("ortools")
+
+    export_dir = tmp_path / "export"
+    schedule_input_path = export_dir / "schedule_input.json"
+    schedule_output_path = export_dir / "schedule_output.json"
+    workbook_path = export_dir / "VAYSF_Schedule_test.xlsx"
+    real_exporter_cls = main.ChurchTeamsExporter
+
+    class FakeExporter:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def generate_reports(
+            self,
+            target_church_code,
+            output_dir,
+            force_resend_pending,
+            force_resend_validated1,
+            force_resend_validated2,
+            dry_run,
+            target_resend_chm_id,
+        ):
+            output_dir.mkdir(parents=True, exist_ok=True)
+            wb = Workbook()
+            ws = wb.active
+            ws.title = "Summary"
+            ws["A1"] = "Fake export for CLI pipeline test"
+            wb.save(output_dir / "Church_Team_Status_ALL_2026-05-15.xlsx")
+            data = _minimal_schedule_input()
+            schedule_input = output_dir / "schedule_input.json"
+            schedule_input.write_text(json.dumps(data), encoding="utf-8")
+            return True
+
+    monkeypatch.setattr(main, "ChurchTeamsExporter", FakeExporter)
+
+    monkeypatch.setattr(
+        main,
+        "parse_args",
+        lambda: argparse.Namespace(
+            command="export-church-teams",
+            church_code=None,
+            output=str(export_dir),
+            force_resend_pending=False,
+            force_resend_validated1=False,
+            force_resend_validated2=False,
+            dry_run=False,
+            chm_id=None,
+        ),
+    )
+    _run_main_expect_exit(0)
+    assert schedule_input_path.exists()
+    monkeypatch.setattr(main, "ChurchTeamsExporter", real_exporter_cls)
+
+    monkeypatch.setattr(
+        main,
+        "parse_args",
+        lambda: argparse.Namespace(
+            command="solve-schedule",
+            input=str(schedule_input_path),
+            output=str(schedule_output_path),
+        ),
+    )
+    _run_main_expect_exit(0)
+    assert schedule_output_path.exists()
+
+    monkeypatch.setattr(
+        main,
+        "parse_args",
+        lambda: argparse.Namespace(
+            command="produce-schedule",
+            schedule_output=str(schedule_output_path),
+            schedule_input=str(schedule_input_path),
+            output=str(workbook_path),
+        ),
+    )
+    _run_main_expect_exit(0)
+
+    wb = load_workbook(workbook_path)
+    assert "Schedule-by-Time" in wb.sheetnames
+    assert "Schedule-by-Sport" in wb.sheetnames
+
+    schedule_output = json.loads(schedule_output_path.read_text(encoding="utf-8"))
+    assert schedule_output["status"] == "OPTIMAL"
+    assert len(schedule_output["assignments"]) == 2

--- a/middleware/tests/test_scheduler.py
+++ b/middleware/tests/test_scheduler.py
@@ -513,6 +513,72 @@ def test_solve_partial_exit_code(tmp_path):
     assert "diagnostics" in pools["Badminton Court"]
 
 
+def test_solve_c8_earliest_slot_respected():
+    """A game with earliest_slot is not placed before that slot."""
+    pytest.importorskip("ortools")
+    from scheduler import solve, STATUS_OPTIMAL
+    # Two slots available: Sat-1-08:00 and Sat-1-09:00.
+    # earliest_slot = Sat-1-09:00 → must land on the second slot.
+    game = _gym_game("G1", "T1", "T2")
+    game["earliest_slot"] = "Sat-1-09:00"
+    si = _minimal_schedule_input(
+        games=[game],
+        resources=[_gym_resource("GYM-Sat-1-1", open_time="08:00", close_time="10:00")],
+    )
+    result = solve(si, timeout_seconds=10.0)
+    assert result["status"] == STATUS_OPTIMAL
+    assert result["assignments"][0]["slot"] == "Sat-1-09:00"
+
+
+def test_solve_c8_latest_slot_respected():
+    """A game with latest_slot is not placed after that slot."""
+    pytest.importorskip("ortools")
+    from scheduler import solve, STATUS_OPTIMAL
+    # Two slots available: Sat-1-08:00 and Sat-1-09:00.
+    # latest_slot = Sat-1-08:00 → must land on the first slot.
+    game = _gym_game("G1", "T1", "T2")
+    game["latest_slot"] = "Sat-1-08:00"
+    si = _minimal_schedule_input(
+        games=[game],
+        resources=[_gym_resource("GYM-Sat-1-1", open_time="08:00", close_time="10:00")],
+    )
+    result = solve(si, timeout_seconds=10.0)
+    assert result["status"] == STATUS_OPTIMAL
+    assert result["assignments"][0]["slot"] == "Sat-1-08:00"
+
+
+def test_solve_c8_window_too_tight_is_infeasible():
+    """A game with an inverted window (earliest > latest) is INFEASIBLE."""
+    pytest.importorskip("ortools")
+    from scheduler import solve, STATUS_INFEASIBLE
+    # Resource has two slots: 08:00 and 09:00.
+    # earliest_slot=09:00 (gslot >= 1) AND latest_slot=08:00 (gslot <= 0) → impossible.
+    game = _gym_game("G1", "T1", "T2")
+    game["earliest_slot"] = "Sat-1-09:00"
+    game["latest_slot"]   = "Sat-1-08:00"
+    si = _minimal_schedule_input(
+        games=[game],
+        resources=[_gym_resource("GYM-Sat-1-1", open_time="08:00", close_time="10:00")],
+    )
+    result = solve(si, timeout_seconds=10.0)
+    assert result["status"] == STATUS_INFEASIBLE
+
+
+def test_solve_c8_unknown_slot_label_is_ignored():
+    """A game with an earliest_slot label not in any resource slot is scheduled normally."""
+    pytest.importorskip("ortools")
+    from scheduler import solve, STATUS_OPTIMAL
+    game = _gym_game("G1", "T1", "T2")
+    game["earliest_slot"] = "Sun-2-14:00"   # label exists in no resource → ignored
+    si = _minimal_schedule_input(
+        games=[game],
+        resources=[_gym_resource("GYM-Sat-1-1", open_time="08:00", close_time="09:00")],
+    )
+    result = solve(si, timeout_seconds=10.0)
+    assert result["status"] == STATUS_OPTIMAL
+    assert len(result["assignments"]) == 1
+
+
 def test_solve_c6_min_rest_does_not_span_day_boundary():
     """A team that plays the last slot of one day and the first of the next must be OPTIMAL.
 

--- a/middleware/tests/test_scheduler.py
+++ b/middleware/tests/test_scheduler.py
@@ -384,7 +384,10 @@ def test_solve_pool_results_always_present():
     from scheduler import solve, STATUS_OPTIMAL
     si = _minimal_schedule_input(
         games=[_gym_game("G1", "T1", "T2")],
-        resources=[_gym_resource("GYM-Sat-1-1")],
+        resources=[
+            _gym_resource("GYM-Sat-1-1"),
+            _gym_resource("GYM-Sat-2-1", day="Sat-2"),
+        ],
     )
     result = solve(si)
     assert result["status"] == STATUS_OPTIMAL
@@ -518,11 +521,14 @@ def test_solve_playoff_slots_passed_through():
     from scheduler import solve, STATUS_OPTIMAL
     si = _minimal_schedule_input(
         games=[_gym_game("G1", "T1", "T2")],
-        resources=[_gym_resource("GYM-Sat-1-1")],
+        resources=[
+            _gym_resource("GYM-Sat-1-1"),
+            _gym_resource("GYM-Sat-2-1", day="Sat-2"),
+        ],
     )
     si["playoff_slots"] = [
         {"game_id": "BBM-Final", "event": "Basketball - Men Team", "stage": "Final",
-         "resource_id": "GYM-Sat-2-1", "slot": "Sat-2-14:00"},
+         "resource_id": "GYM-Sat-2-1", "slot": "Sat-2-09:00"},
     ]
     result = solve(si, timeout_seconds=10.0)
     assert result["status"] == STATUS_OPTIMAL
@@ -530,27 +536,58 @@ def test_solve_playoff_slots_passed_through():
     assert "G1" in game_ids
     assert "BBM-Final" in game_ids
     final_asgn = next(a for a in result["assignments"] if a["game_id"] == "BBM-Final")
-    assert final_asgn["slot"] == "Sat-2-14:00"
+    assert final_asgn["slot"] == "Sat-2-09:00"
     assert final_asgn["stage"] == "Final"
 
 
-def test_solve_playoff_slots_passed_through():
-    """playoff_slots from schedule_input are merged into solver output assignments."""
+def test_solve_playoff_slots_reserve_pool_slots():
+    """Manual playoff slots reserve the same court/time from the pool-play solver."""
     pytest.importorskip("ortools")
     from scheduler import solve, STATUS_OPTIMAL
     si = _minimal_schedule_input(
         games=[_gym_game("G1", "T1", "T2")],
-        resources=[_gym_resource("GYM-Sat-1-1")],
+        resources=[_gym_resource("GYM-Sat-1-1", close_time="10:00")],
     )
     si["playoff_slots"] = [
-        {"game_id": "BBM-Final", "event": "Basketball - Men Team", "stage": "Final",
-         "resource_id": "GYM-Sat-2-1", "slot": "Sat-2-14:00"},
+        {
+            "game_id": "BBM-Final",
+            "event": "Basketball - Men Team",
+            "stage": "Final",
+            "resource_id": "GYM-Sat-1-1",
+            "slot": "Sat-1-08:00",
+        },
     ]
     result = solve(si, timeout_seconds=10.0)
     assert result["status"] == STATUS_OPTIMAL
-    game_ids = {a["game_id"] for a in result["assignments"]}
-    assert "G1" in game_ids
-    assert "BBM-Final" in game_ids
+    pool_asgn = next(a for a in result["assignments"] if a["game_id"] == "G1")
     final_asgn = next(a for a in result["assignments"] if a["game_id"] == "BBM-Final")
-    assert final_asgn["slot"] == "Sat-2-14:00"
-    assert final_asgn["stage"] == "Final"
+    assert pool_asgn["slot"] == "Sat-1-09:00"
+    assert final_asgn["slot"] == "Sat-1-08:00"
+
+
+def test_solve_duplicate_playoff_slot_raises():
+    """Duplicate manual playoff reservations fail loudly before rendering can hide them."""
+    pytest.importorskip("ortools")
+    from scheduler import solve
+    si = _minimal_schedule_input(
+        games=[_gym_game("G1", "T1", "T2")],
+        resources=[_gym_resource("GYM-Sat-1-1", close_time="10:00")],
+    )
+    si["playoff_slots"] = [
+        {
+            "game_id": "BBM-Semi-1",
+            "event": "Basketball - Men Team",
+            "stage": "Semi",
+            "resource_id": "GYM-Sat-1-1",
+            "slot": "Sat-1-08:00",
+        },
+        {
+            "game_id": "BBM-Final",
+            "event": "Basketball - Men Team",
+            "stage": "Final",
+            "resource_id": "GYM-Sat-1-1",
+            "slot": "Sat-1-08:00",
+        },
+    ]
+    with pytest.raises(ValueError, match="Duplicate playoff slot reservation"):
+        solve(si, timeout_seconds=10.0)

--- a/middleware/tests/test_scheduler.py
+++ b/middleware/tests/test_scheduler.py
@@ -600,3 +600,93 @@ def test_solve_c6_min_rest_does_not_span_day_boundary():
     result = solve(si, timeout_seconds=10.0)
     assert result["status"] == STATUS_OPTIMAL
     assert len(result["assignments"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# C9 — finale sequence ordering
+# ---------------------------------------------------------------------------
+
+def _seq_rule(earlier_id, later_id):
+    return {
+        "rule":            f"Finale: {earlier_id} before {later_id}",
+        "earlier_game_id": earlier_id,
+        "later_game_id":   later_id,
+    }
+
+
+def test_solve_c9_sequence_ordering_respected():
+    """Three finals on the same resource are assigned in the declared order."""
+    pytest.importorskip("ortools")
+    from scheduler import solve, STATUS_OPTIMAL
+
+    # Three single-court 3-slot window — solver must sequence them.
+    # Sequence rule: G1 < G2 < G3.
+    si = {
+        "games": [
+            _gym_game("G1", "T1", "T2", stage="Final"),
+            _gym_game("G2", "T3", "T4", stage="Final"),
+            _gym_game("G3", "T5", "T6", stage="Final"),
+        ],
+        "resources": [
+            _gym_resource("C1", open_time="14:00", close_time="17:00"),
+        ],
+        "precedence": [],
+        "sequence": [
+            _seq_rule("G1", "G2"),
+            _seq_rule("G2", "G3"),
+        ],
+    }
+    result = solve(si, timeout_seconds=10.0)
+    assert result["status"] == STATUS_OPTIMAL
+
+    slot_by_game = {a["game_id"]: a["slot"] for a in result["assignments"]}
+    assert slot_by_game["G1"] < slot_by_game["G2"]
+    assert slot_by_game["G2"] < slot_by_game["G3"]
+
+
+def test_solve_c9_sequence_infeasible_when_impossible():
+    """Circular sequence (G1 < G2 and G2 < G1) is INFEASIBLE."""
+    pytest.importorskip("ortools")
+    from scheduler import solve, STATUS_INFEASIBLE
+
+    si = {
+        "games": [
+            _gym_game("G1", "T1", "T2", stage="Final"),
+            _gym_game("G2", "T3", "T4", stage="Final"),
+        ],
+        "resources": [
+            _gym_resource("C1", open_time="14:00", close_time="16:00"),
+        ],
+        "precedence": [],
+        "sequence": [
+            _seq_rule("G1", "G2"),
+            _seq_rule("G2", "G1"),  # creates cycle → infeasible
+        ],
+    }
+    result = solve(si, timeout_seconds=10.0)
+    assert result["status"] == STATUS_INFEASIBLE
+
+
+def test_solve_c9_cross_pool_rule_skipped_gracefully():
+    """A sequence rule whose game IDs span different pools does not crash."""
+    pytest.importorskip("ortools")
+    from scheduler import solve, STATUS_OPTIMAL
+
+    # G1 is a Gym Court game, G2 is a Badminton Court game.
+    # The sequence rule between them cannot be enforced (different pools) but
+    # must not raise an error — each pool schedules its own game freely.
+    si = {
+        "games": [
+            _gym_game("G1", "T1", "T2", stage="Final"),
+            _bad_game("G2"),
+        ],
+        "resources": [
+            _gym_resource("GYM-1", open_time="14:00", close_time="15:00"),
+            _bad_resource("BAD-1", close_time="15:00"),
+        ],
+        "precedence": [],
+        "sequence": [_seq_rule("G1", "G2")],
+    }
+    result = solve(si, timeout_seconds=10.0)
+    assert result["status"] == STATUS_OPTIMAL
+    assert len(result["assignments"]) == 2

--- a/middleware/tests/test_scheduler.py
+++ b/middleware/tests/test_scheduler.py
@@ -1,0 +1,284 @@
+"""Tests for scheduler.py (Issue #93)."""
+import json
+import pytest
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# build_resource_slots
+# ---------------------------------------------------------------------------
+
+def test_build_resource_slots_basic():
+    """Slots are generated from open_time to close_time - slot_minutes, inclusive."""
+    from scheduler import build_resource_slots
+    resources = [{
+        "resource_id": "GYM-Sat-1-1", "resource_type": "Gym Court",
+        "label": "Court-1", "day": "Sat-1",
+        "open_time": "08:00", "close_time": "10:00", "slot_minutes": 60,
+    }]
+    slots = build_resource_slots(resources)
+    assert slots["GYM-Sat-1-1"] == ["Sat-1-08:00", "Sat-1-09:00"]
+
+
+def test_build_resource_slots_30min():
+    """30-minute slots within a 90-minute window produce 3 slots."""
+    from scheduler import build_resource_slots
+    resources = [{
+        "resource_id": "TT-1", "resource_type": "Table Tennis Table",
+        "label": "Table-1", "day": "Day-1",
+        "open_time": "09:00", "close_time": "10:30", "slot_minutes": 30,
+    }]
+    slots = build_resource_slots(resources)
+    assert slots["TT-1"] == ["Day-1-09:00", "Day-1-09:30", "Day-1-10:00"]
+
+
+def test_build_resource_slots_empty_window():
+    """A resource whose window is smaller than one slot yields no slots."""
+    from scheduler import build_resource_slots
+    resources = [{
+        "resource_id": "R1", "resource_type": "Gym Court",
+        "label": "Court-1", "day": "Sat-1",
+        "open_time": "08:00", "close_time": "08:30", "slot_minutes": 60,
+    }]
+    slots = build_resource_slots(resources)
+    assert slots["R1"] == []
+
+
+def test_build_resource_slots_multiple_resources():
+    """Each resource gets its own independent slot list."""
+    from scheduler import build_resource_slots
+    resources = [
+        {
+            "resource_id": "A", "resource_type": "Gym Court",
+            "label": "Court-1", "day": "Sat-1",
+            "open_time": "08:00", "close_time": "10:00", "slot_minutes": 60,
+        },
+        {
+            "resource_id": "B", "resource_type": "Gym Court",
+            "label": "Court-2", "day": "Sun-1",
+            "open_time": "13:00", "close_time": "15:00", "slot_minutes": 60,
+        },
+    ]
+    slots = build_resource_slots(resources)
+    assert slots["A"] == ["Sat-1-08:00", "Sat-1-09:00"]
+    assert slots["B"] == ["Sun-1-13:00", "Sun-1-14:00"]
+
+
+# ---------------------------------------------------------------------------
+# load_schedule_input
+# ---------------------------------------------------------------------------
+
+def test_load_schedule_input_valid(tmp_path):
+    """load_schedule_input returns dict when all required keys are present."""
+    from scheduler import load_schedule_input
+    data = {"games": [], "resources": [], "precedence": []}
+    path = tmp_path / "si.json"
+    path.write_text(json.dumps(data), encoding="utf-8")
+    result = load_schedule_input(path)
+    assert result["games"] == []
+    assert result["resources"] == []
+
+
+def test_load_schedule_input_missing_key(tmp_path):
+    """load_schedule_input raises ValueError when a required key is absent."""
+    from scheduler import load_schedule_input
+    path = tmp_path / "bad.json"
+    path.write_text(json.dumps({"games": [], "resources": []}), encoding="utf-8")
+    with pytest.raises(ValueError, match="precedence"):
+        load_schedule_input(path)
+
+
+def test_load_schedule_input_file_not_found(tmp_path):
+    """load_schedule_input raises an appropriate error for missing files."""
+    from scheduler import load_schedule_input
+    with pytest.raises(FileNotFoundError):
+        load_schedule_input(tmp_path / "nonexistent.json")
+
+
+# ---------------------------------------------------------------------------
+# solve() — requires ortools
+# ---------------------------------------------------------------------------
+
+def _minimal_schedule_input(games, resources, precedence=None):
+    return {
+        "games": games,
+        "resources": resources,
+        "precedence": precedence or [],
+    }
+
+
+def _gym_resource(resource_id, day="Sat-1", open_time="08:00", close_time="11:00"):
+    return {
+        "resource_id": resource_id, "resource_type": "Gym Court",
+        "label": "Court-1", "day": day,
+        "open_time": open_time, "close_time": close_time, "slot_minutes": 60,
+    }
+
+
+def _gym_game(game_id, team_a, team_b, stage="Pool", pool_id="P1"):
+    return {
+        "game_id": game_id, "event": "Basketball - Men Team",
+        "stage": stage, "pool_id": pool_id, "round": 1,
+        "team_a_id": team_a, "team_b_id": team_b,
+        "duration_minutes": 60, "resource_type": "Gym Court",
+        "earliest_slot": None, "latest_slot": None,
+    }
+
+
+@pytest.mark.skipif(
+    not pytest.importorskip("ortools", reason="ortools not installed"),
+    reason="ortools not installed",
+)
+def test_solve_two_games_no_team_overlap():
+    """Two games with disjoint teams and one court: both scheduled OPTIMAL."""
+    pytest.importorskip("ortools")
+    from scheduler import solve, STATUS_OPTIMAL
+    si = _minimal_schedule_input(
+        games=[
+            _gym_game("G1", "BBM-P1-T1", "BBM-P1-T2"),
+            _gym_game("G2", "BBM-P1-T3", "BBM-P1-T4"),
+        ],
+        resources=[_gym_resource("GYM-Sat-1-1")],
+    )
+    result = solve(si, timeout_seconds=10.0)
+    assert result["status"] == STATUS_OPTIMAL
+    assert len(result["assignments"]) == 2
+    assert result["unscheduled"] == []
+    # Both games on the same court must be in different slots
+    slots = {a["game_id"]: a["slot"] for a in result["assignments"]}
+    assert slots["G1"] != slots["G2"]
+
+
+def test_solve_team_conflict_infeasible():
+    """Two games sharing a team on a single slot/court must be INFEASIBLE."""
+    pytest.importorskip("ortools")
+    from scheduler import solve, STATUS_INFEASIBLE
+    si = _minimal_schedule_input(
+        games=[
+            _gym_game("G1", "BBM-P1-T1", "BBM-P1-T2"),
+            _gym_game("G2", "BBM-P1-T1", "BBM-P1-T3"),  # T1 in both games
+        ],
+        resources=[_gym_resource("GYM-Sat-1-1", close_time="09:00")],  # only 1 slot
+    )
+    result = solve(si, timeout_seconds=10.0)
+    assert result["status"] == STATUS_INFEASIBLE
+
+
+def test_solve_court_type_routing():
+    """A Badminton game must not be assigned to a Gym Court resource.
+
+    With no compatible resources the game lands in 'unscheduled'; the solver
+    still returns OPTIMAL (trivially — no constraints to violate for that game).
+    """
+    pytest.importorskip("ortools")
+    from scheduler import solve, STATUS_OPTIMAL
+    si = _minimal_schedule_input(
+        games=[{
+            "game_id": "G1", "event": "Badminton",
+            "stage": "R1", "pool_id": "", "round": 1,
+            "team_a_id": "A", "team_b_id": "B",
+            "duration_minutes": 25, "resource_type": "Badminton Court",
+            "earliest_slot": None, "latest_slot": None,
+        }],
+        resources=[_gym_resource("GYM-Sat-1-1")],  # only Gym Court — wrong type
+    )
+    result = solve(si, timeout_seconds=10.0)
+    assert result["status"] == STATUS_OPTIMAL
+    assert result["assignments"] == []
+    assert "G1" in result["unscheduled"]
+
+
+def test_solve_stage_ordering():
+    """A Pool game must be assigned to an earlier slot than a Final game."""
+    pytest.importorskip("ortools")
+    from scheduler import solve, STATUS_OPTIMAL, _slot_sort_key
+    si = _minimal_schedule_input(
+        games=[
+            _gym_game("BBM-01", "BBM-P1-T1", "BBM-P1-T2", stage="Pool", pool_id="P1"),
+            _gym_game("BBM-Final", "WIN-BBM-Semi-1", "WIN-BBM-Semi-2", stage="Final", pool_id=""),
+        ],
+        resources=[_gym_resource("GYM-Sat-1-1", close_time="11:00")],  # 3 slots
+        precedence=[{
+            "rule": "All Pool before Final",
+            "event": "Basketball - Men Team",
+            "earlier_stage": "Pool",
+            "later_stage": "Final",
+        }],
+    )
+    result = solve(si, timeout_seconds=10.0)
+    assert result["status"] == STATUS_OPTIMAL
+    slots = {a["game_id"]: a["slot"] for a in result["assignments"]}
+    assert _slot_sort_key(slots["BBM-01"]) < _slot_sort_key(slots["BBM-Final"])
+
+
+def test_solve_min_rest_between_games():
+    """A team with two games must not play in adjacent slots."""
+    pytest.importorskip("ortools")
+    from scheduler import solve, STATUS_OPTIMAL, _slot_sort_key
+    si = _minimal_schedule_input(
+        games=[
+            _gym_game("G1", "BBM-P1-T1", "BBM-P1-T2"),
+            _gym_game("G2", "BBM-P1-T1", "BBM-P1-T3"),  # T1 appears in both
+        ],
+        resources=[
+            _gym_resource("GYM-Sat-1-1", close_time="12:00"),  # 4 slots: 08-09-10-11
+            _gym_resource("GYM-Sat-1-2", close_time="12:00"),
+        ],
+    )
+    result = solve(si, timeout_seconds=10.0)
+    assert result["status"] == STATUS_OPTIMAL
+    slots = {a["game_id"]: a["slot"] for a in result["assignments"]}
+    key1 = _slot_sort_key(slots["G1"])
+    key2 = _slot_sort_key(slots["G2"])
+    # Slots must differ by at least 2 positions (min rest = no consecutive slots)
+    assert abs(key1[1] - key2[1]) >= 120 or key1[0] != key2[0], (
+        f"T1 played consecutive slots: {slots['G1']} and {slots['G2']}"
+    )
+
+
+def test_solve_empty_input():
+    """An input with no games produces OPTIMAL with empty assignments."""
+    pytest.importorskip("ortools")
+    from scheduler import solve, STATUS_OPTIMAL
+    si = _minimal_schedule_input(games=[], resources=[])
+    result = solve(si, timeout_seconds=10.0)
+    assert result["status"] == STATUS_OPTIMAL
+    assert result["assignments"] == []
+    assert result["unscheduled"] == []
+
+
+def test_run_solve_schedule_writes_output(tmp_path):
+    """run_solve_schedule writes a valid schedule_output.json and returns 0."""
+    pytest.importorskip("ortools")
+    from scheduler import run_solve_schedule, STATUS_OPTIMAL
+
+    si = _minimal_schedule_input(
+        games=[_gym_game("G1", "T1", "T2")],
+        resources=[_gym_resource("GYM-Sat-1-1")],
+    )
+    input_path = tmp_path / "schedule_input.json"
+    input_path.write_text(json.dumps(si), encoding="utf-8")
+    output_path = tmp_path / "schedule_output.json"
+
+    exit_code = run_solve_schedule(input_path, output_path)
+    assert exit_code == 0
+    assert output_path.exists()
+
+    data = json.loads(output_path.read_text(encoding="utf-8"))
+    assert data["status"] == STATUS_OPTIMAL
+    assert "solved_at" in data
+    assert "assignments" in data
+    assert len(data["assignments"]) == 1
+    assert data["unscheduled"] == []
+
+
+def test_run_solve_schedule_missing_input(tmp_path):
+    """run_solve_schedule returns exit code 2 when input file is missing."""
+    pytest.importorskip("ortools")
+    from scheduler import run_solve_schedule
+
+    exit_code = run_solve_schedule(
+        tmp_path / "nonexistent.json",
+        tmp_path / "out.json",
+    )
+    assert exit_code == 2

--- a/middleware/tests/test_scheduler.py
+++ b/middleware/tests/test_scheduler.py
@@ -247,6 +247,49 @@ def test_solve_empty_input():
     assert result["unscheduled"] == []
 
 
+def test_build_infeasibility_diagnostics_reports_slot_shortage():
+    """Capacity diagnostics summarize required vs available slots by resource type."""
+    from scheduler import build_infeasibility_diagnostics
+
+    si = _minimal_schedule_input(
+        games=[
+            {
+                "game_id": "BAD-01", "event": "Badminton",
+                "stage": "R1", "pool_id": "", "round": 1,
+                "team_a_id": None, "team_b_id": None,
+                "duration_minutes": 30, "resource_type": "Badminton Court",
+                "earliest_slot": None, "latest_slot": None,
+            },
+            {
+                "game_id": "BAD-02", "event": "Badminton",
+                "stage": "R1", "pool_id": "", "round": 2,
+                "team_a_id": None, "team_b_id": None,
+                "duration_minutes": 30, "resource_type": "Badminton Court",
+                "earliest_slot": None, "latest_slot": None,
+            },
+        ],
+        resources=[{
+            "resource_id": "BAD-1", "resource_type": "Badminton Court",
+            "label": "Court-1", "day": "Day-1",
+            "open_time": "09:00", "close_time": "09:30", "slot_minutes": 30,
+        }],
+    )
+
+    diagnostics = build_infeasibility_diagnostics(si)
+    assert len(diagnostics) == 1
+    diag = diagnostics[0]
+    assert diag["resource_type"] == "Badminton Court"
+    assert diag["required_slots"] == 2
+    assert diag["available_slots"] == 1
+    assert diag["shortage_slots"] == 1
+    assert diag["events"] == [{
+        "event": "Badminton",
+        "resource_type": "Badminton Court",
+        "game_count": 2,
+        "required_slots": 2,
+    }]
+
+
 def test_run_solve_schedule_writes_output(tmp_path):
     """run_solve_schedule writes a valid schedule_output.json and returns 0."""
     pytest.importorskip("ortools")
@@ -270,6 +313,55 @@ def test_run_solve_schedule_writes_output(tmp_path):
     assert "assignments" in data
     assert len(data["assignments"]) == 1
     assert data["unscheduled"] == []
+
+
+def test_run_solve_schedule_infeasible_writes_diagnostics(tmp_path):
+    """INFEASIBLE output includes lower-bound slot diagnostics for operators."""
+    pytest.importorskip("ortools")
+    from scheduler import run_solve_schedule, STATUS_INFEASIBLE
+
+    si = _minimal_schedule_input(
+        games=[
+            {
+                "game_id": "BAD-01", "event": "Badminton",
+                "stage": "R1", "pool_id": "", "round": 1,
+                "team_a_id": None, "team_b_id": None,
+                "duration_minutes": 30, "resource_type": "Badminton Court",
+                "earliest_slot": None, "latest_slot": None,
+            },
+            {
+                "game_id": "BAD-02", "event": "Badminton",
+                "stage": "R1", "pool_id": "", "round": 2,
+                "team_a_id": None, "team_b_id": None,
+                "duration_minutes": 30, "resource_type": "Badminton Court",
+                "earliest_slot": None, "latest_slot": None,
+            },
+        ],
+        resources=[{
+            "resource_id": "BAD-1", "resource_type": "Badminton Court",
+            "label": "Court-1", "day": "Day-1",
+            "open_time": "09:00", "close_time": "09:30", "slot_minutes": 30,
+        }],
+    )
+    input_path = tmp_path / "schedule_input.json"
+    input_path.write_text(json.dumps(si), encoding="utf-8")
+    output_path = tmp_path / "schedule_output.json"
+
+    exit_code = run_solve_schedule(input_path, output_path)
+    assert exit_code == 1
+    assert output_path.exists()
+
+    data = json.loads(output_path.read_text(encoding="utf-8"))
+    assert data["status"] == STATUS_INFEASIBLE
+    assert data["assignments"] == []
+    assert sorted(data["unscheduled"]) == ["BAD-01", "BAD-02"]
+    assert "diagnostics" in data
+    diag = data["diagnostics"][0]
+    assert diag["resource_type"] == "Badminton Court"
+    assert diag["required_slots"] == 2
+    assert diag["available_slots"] == 1
+    assert diag["shortage_slots"] == 1
+    assert diag["events"][0]["event"] == "Badminton"
 
 
 def test_run_solve_schedule_missing_input(tmp_path):

--- a/middleware/tests/test_scheduler.py
+++ b/middleware/tests/test_scheduler.py
@@ -511,3 +511,26 @@ def test_solve_partial_exit_code(tmp_path):
     assert any(a["game_id"] == "G1" for a in data["assignments"])
     pools = {pr["resource_type"]: pr for pr in data["pool_results"]}
     assert "diagnostics" in pools["Badminton Court"]
+
+
+def test_solve_c6_min_rest_does_not_span_day_boundary():
+    """A team that plays the last slot of one day and the first of the next must be OPTIMAL.
+
+    Before the A1 fix, contiguous global slot indices made the last slot of Sat-1 and
+    the first slot of Sun-1 appear 'adjacent', triggering a false min-rest violation.
+    """
+    pytest.importorskip("ortools")
+    from scheduler import solve, STATUS_OPTIMAL
+    si = _minimal_schedule_input(
+        games=[
+            _gym_game("G1", "T1", "T2"),   # forced onto Sat-1 (only available slot)
+            _gym_game("G2", "T1", "T3"),   # forced onto Sun-1 (only available slot)
+        ],
+        resources=[
+            _gym_resource("GYM-Sat-1-1", day="Sat-1", open_time="20:00", close_time="21:00"),
+            _gym_resource("GYM-Sun-1-1", day="Sun-1", open_time="13:00", close_time="14:00"),
+        ],
+    )
+    result = solve(si, timeout_seconds=10.0)
+    assert result["status"] == STATUS_OPTIMAL
+    assert len(result["assignments"]) == 2

--- a/middleware/tests/test_scheduler.py
+++ b/middleware/tests/test_scheduler.py
@@ -188,7 +188,11 @@ def test_solve_court_type_routing():
 
 
 def test_solve_min_rest_between_games():
-    """A team with two games must not play in adjacent slots."""
+    """A team with two games must not play in adjacent slots (C3 fix for C6 intent check).
+
+    The assertion compares global slot-index distance (>= 2 = at least one slot gap)
+    rather than minutes, so it stays valid if slot_minutes changes.
+    """
     pytest.importorskip("ortools")
     from scheduler import solve, STATUS_OPTIMAL, _slot_sort_key
     si = _minimal_schedule_input(
@@ -201,14 +205,23 @@ def test_solve_min_rest_between_games():
             _gym_resource("GYM-Sat-1-2", close_time="12:00"),
         ],
     )
+    resources = [
+        _gym_resource("GYM-Sat-1-1", close_time="12:00"),
+        _gym_resource("GYM-Sat-1-2", close_time="12:00"),
+    ]
     result = solve(si, timeout_seconds=10.0)
     assert result["status"] == STATUS_OPTIMAL
-    slots = {a["game_id"]: a["slot"] for a in result["assignments"]}
-    key1 = _slot_sort_key(slots["G1"])
-    key2 = _slot_sort_key(slots["G2"])
-    # Slots must differ by at least 2 positions (min rest = no consecutive slots)
-    assert abs(key1[1] - key2[1]) >= 120 or key1[0] != key2[0], (
-        f"T1 played consecutive slots: {slots['G1']} and {slots['G2']}"
+    assigned = {a["game_id"]: a["slot"] for a in result["assignments"]}
+    # Rebuild the same global slot ordering the solver used, then check distance.
+    # This avoids hardcoding slot_minutes (the original C3 coupling issue).
+    from scheduler import build_resource_slots
+    all_labels = sorted(
+        {s for sl in build_resource_slots(resources).values() for s in sl},
+        key=_slot_sort_key,
+    )
+    slot_idx = {s: i for i, s in enumerate(all_labels)}
+    assert abs(slot_idx[assigned["G1"]] - slot_idx[assigned["G2"]]) >= 2, (
+        f"T1 played in adjacent slots: {assigned['G1']} and {assigned['G2']}"
     )
 
 
@@ -345,7 +358,7 @@ def test_run_solve_schedule_infeasible_writes_diagnostics(tmp_path):
 
 
 def test_run_solve_schedule_missing_input(tmp_path):
-    """run_solve_schedule returns exit code 2 when input file is missing."""
+    """run_solve_schedule returns exit code 3 when input file is missing."""
     pytest.importorskip("ortools")
     from scheduler import run_solve_schedule
 
@@ -353,7 +366,61 @@ def test_run_solve_schedule_missing_input(tmp_path):
         tmp_path / "nonexistent.json",
         tmp_path / "out.json",
     )
-    assert exit_code == 2
+    assert exit_code == 3
+
+
+def test_run_solve_schedule_unroutable_game_exits_1(tmp_path):
+    """A game with no compatible resource returns exit 1 even if solver says OPTIMAL.
+
+    Before the A2 fix, run_solve_schedule returned 0 for this case, silently
+    producing an incomplete schedule that produce-schedule would render without
+    the missing game.
+    """
+    pytest.importorskip("ortools")
+    from scheduler import run_solve_schedule
+
+    si = _minimal_schedule_input(
+        games=[{
+            "game_id": "BAD-01", "event": "Badminton",
+            "stage": "R1", "pool_id": "", "round": 1,
+            "team_a_id": "A", "team_b_id": "B",
+            "duration_minutes": 30, "resource_type": "Badminton Court",
+            "earliest_slot": None, "latest_slot": None,
+        }],
+        resources=[_gym_resource("GYM-Sat-1-1")],  # Gym Court only — wrong type
+    )
+    input_path = tmp_path / "schedule_input.json"
+    input_path.write_text(__import__("json").dumps(si), encoding="utf-8")
+    output_path = tmp_path / "schedule_output.json"
+
+    exit_code = run_solve_schedule(input_path, output_path)
+    assert exit_code == 1
+
+    data = __import__("json").loads(output_path.read_text(encoding="utf-8"))
+    assert "BAD-01" in data["unscheduled"]
+
+
+def test_solver_uses_fixed_random_seed():
+    """Two identical solve() calls produce the same assignment order (B6 determinism)."""
+    pytest.importorskip("ortools")
+    from scheduler import solve, STATUS_OPTIMAL
+
+    si = _minimal_schedule_input(
+        games=[
+            _gym_game("G1", "T1", "T2"),
+            _gym_game("G2", "T3", "T4"),
+            _gym_game("G3", "T1", "T3"),
+        ],
+        resources=[_gym_resource("GYM-Sat-1-1", close_time="12:00")],
+    )
+    result_a = solve(si, timeout_seconds=10.0)
+    result_b = solve(si, timeout_seconds=10.0)
+
+    assert result_a["status"] == STATUS_OPTIMAL
+    assert result_b["status"] == STATUS_OPTIMAL
+    slots_a = {a["game_id"]: a["slot"] for a in result_a["assignments"]}
+    slots_b = {a["game_id"]: a["slot"] for a in result_b["assignments"]}
+    assert slots_a == slots_b
 
 
 # ---------------------------------------------------------------------------

--- a/middleware/tests/test_scheduler.py
+++ b/middleware/tests/test_scheduler.py
@@ -166,11 +166,11 @@ def test_solve_team_conflict_infeasible():
 def test_solve_court_type_routing():
     """A Badminton game must not be assigned to a Gym Court resource.
 
-    With no compatible resources the game lands in 'unscheduled'; the solver
-    still returns OPTIMAL (trivially — no constraints to violate for that game).
+    With no compatible resources the pool is infeasible, so downstream JSON and
+    workbook consumers do not see an OPTIMAL status beside dropped games.
     """
     pytest.importorskip("ortools")
-    from scheduler import solve, STATUS_OPTIMAL
+    from scheduler import solve, STATUS_INFEASIBLE
     si = _minimal_schedule_input(
         games=[{
             "game_id": "G1", "event": "Badminton",
@@ -182,9 +182,12 @@ def test_solve_court_type_routing():
         resources=[_gym_resource("GYM-Sat-1-1")],  # only Gym Court — wrong type
     )
     result = solve(si, timeout_seconds=10.0)
-    assert result["status"] == STATUS_OPTIMAL
+    assert result["status"] == STATUS_INFEASIBLE
     assert result["assignments"] == []
     assert "G1" in result["unscheduled"]
+    pool = result["pool_results"][0]
+    assert pool["status"] == STATUS_INFEASIBLE
+    assert "diagnostics" in pool
 
 
 def test_solve_min_rest_between_games():
@@ -370,14 +373,14 @@ def test_run_solve_schedule_missing_input(tmp_path):
 
 
 def test_run_solve_schedule_unroutable_game_exits_1(tmp_path):
-    """A game with no compatible resource returns exit 1 even if solver says OPTIMAL.
+    """A game with no compatible resource returns exit 1 and writes INFEASIBLE output.
 
     Before the A2 fix, run_solve_schedule returned 0 for this case, silently
     producing an incomplete schedule that produce-schedule would render without
     the missing game.
     """
     pytest.importorskip("ortools")
-    from scheduler import run_solve_schedule
+    from scheduler import run_solve_schedule, STATUS_INFEASIBLE
 
     si = _minimal_schedule_input(
         games=[{
@@ -397,7 +400,31 @@ def test_run_solve_schedule_unroutable_game_exits_1(tmp_path):
     assert exit_code == 1
 
     data = __import__("json").loads(output_path.read_text(encoding="utf-8"))
+    assert data["status"] == STATUS_INFEASIBLE
     assert "BAD-01" in data["unscheduled"]
+
+
+def test_solve_unroutable_pool_makes_top_level_partial():
+    """A solved pool plus an unroutable pool must aggregate to PARTIAL, not OPTIMAL."""
+    pytest.importorskip("ortools")
+    from scheduler import solve, STATUS_PARTIAL, STATUS_OPTIMAL, STATUS_INFEASIBLE
+
+    si = _minimal_schedule_input(
+        games=[
+            _gym_game("G1", "T1", "T2"),
+            _bad_game("BAD-01", "A", "B"),
+        ],
+        resources=[_gym_resource("GYM-Sat-1-1")],  # no Badminton Court resources
+    )
+    result = solve(si, timeout_seconds=10.0)
+
+    assert result["status"] == STATUS_PARTIAL
+    assert any(a["game_id"] == "G1" for a in result["assignments"])
+    assert result["unscheduled"] == ["BAD-01"]
+    pools = {pr["resource_type"]: pr for pr in result["pool_results"]}
+    assert pools["Gym Court"]["status"] == STATUS_OPTIMAL
+    assert pools["Badminton Court"]["status"] == STATUS_INFEASIBLE
+    assert "diagnostics" in pools["Badminton Court"]
 
 
 def test_solver_uses_fixed_random_seed():

--- a/middleware/tests/test_scheduler.py
+++ b/middleware/tests/test_scheduler.py
@@ -71,7 +71,7 @@ def test_build_resource_slots_multiple_resources():
 def test_load_schedule_input_valid(tmp_path):
     """load_schedule_input returns dict when all required keys are present."""
     from scheduler import load_schedule_input
-    data = {"games": [], "resources": [], "precedence": []}
+    data = {"games": [], "resources": []}
     path = tmp_path / "si.json"
     path.write_text(json.dumps(data), encoding="utf-8")
     result = load_schedule_input(path)
@@ -83,8 +83,8 @@ def test_load_schedule_input_missing_key(tmp_path):
     """load_schedule_input raises ValueError when a required key is absent."""
     from scheduler import load_schedule_input
     path = tmp_path / "bad.json"
-    path.write_text(json.dumps({"games": [], "resources": []}), encoding="utf-8")
-    with pytest.raises(ValueError, match="precedence"):
+    path.write_text(json.dumps({"games": []}), encoding="utf-8")
+    with pytest.raises(ValueError, match="resources"):
         load_schedule_input(path)
 
 
@@ -99,11 +99,10 @@ def test_load_schedule_input_file_not_found(tmp_path):
 # solve() — requires ortools
 # ---------------------------------------------------------------------------
 
-def _minimal_schedule_input(games, resources, precedence=None):
+def _minimal_schedule_input(games, resources):
     return {
         "games": games,
         "resources": resources,
-        "precedence": precedence or [],
     }
 
 
@@ -186,29 +185,6 @@ def test_solve_court_type_routing():
     assert result["status"] == STATUS_OPTIMAL
     assert result["assignments"] == []
     assert "G1" in result["unscheduled"]
-
-
-def test_solve_stage_ordering():
-    """A Pool game must be assigned to an earlier slot than a Final game."""
-    pytest.importorskip("ortools")
-    from scheduler import solve, STATUS_OPTIMAL, _slot_sort_key
-    si = _minimal_schedule_input(
-        games=[
-            _gym_game("BBM-01", "BBM-P1-T1", "BBM-P1-T2", stage="Pool", pool_id="P1"),
-            _gym_game("BBM-Final", "WIN-BBM-Semi-1", "WIN-BBM-Semi-2", stage="Final", pool_id=""),
-        ],
-        resources=[_gym_resource("GYM-Sat-1-1", close_time="11:00")],  # 3 slots
-        precedence=[{
-            "rule": "All Pool before Final",
-            "event": "Basketball - Men Team",
-            "earlier_stage": "Pool",
-            "later_stage": "Final",
-        }],
-    )
-    result = solve(si, timeout_seconds=10.0)
-    assert result["status"] == STATUS_OPTIMAL
-    slots = {a["game_id"]: a["slot"] for a in result["assignments"]}
-    assert _slot_sort_key(slots["BBM-01"]) < _slot_sort_key(slots["BBM-Final"])
 
 
 def test_solve_min_rest_between_games():
@@ -513,72 +489,6 @@ def test_solve_partial_exit_code(tmp_path):
     assert "diagnostics" in pools["Badminton Court"]
 
 
-def test_solve_c8_earliest_slot_respected():
-    """A game with earliest_slot is not placed before that slot."""
-    pytest.importorskip("ortools")
-    from scheduler import solve, STATUS_OPTIMAL
-    # Two slots available: Sat-1-08:00 and Sat-1-09:00.
-    # earliest_slot = Sat-1-09:00 → must land on the second slot.
-    game = _gym_game("G1", "T1", "T2")
-    game["earliest_slot"] = "Sat-1-09:00"
-    si = _minimal_schedule_input(
-        games=[game],
-        resources=[_gym_resource("GYM-Sat-1-1", open_time="08:00", close_time="10:00")],
-    )
-    result = solve(si, timeout_seconds=10.0)
-    assert result["status"] == STATUS_OPTIMAL
-    assert result["assignments"][0]["slot"] == "Sat-1-09:00"
-
-
-def test_solve_c8_latest_slot_respected():
-    """A game with latest_slot is not placed after that slot."""
-    pytest.importorskip("ortools")
-    from scheduler import solve, STATUS_OPTIMAL
-    # Two slots available: Sat-1-08:00 and Sat-1-09:00.
-    # latest_slot = Sat-1-08:00 → must land on the first slot.
-    game = _gym_game("G1", "T1", "T2")
-    game["latest_slot"] = "Sat-1-08:00"
-    si = _minimal_schedule_input(
-        games=[game],
-        resources=[_gym_resource("GYM-Sat-1-1", open_time="08:00", close_time="10:00")],
-    )
-    result = solve(si, timeout_seconds=10.0)
-    assert result["status"] == STATUS_OPTIMAL
-    assert result["assignments"][0]["slot"] == "Sat-1-08:00"
-
-
-def test_solve_c8_window_too_tight_is_infeasible():
-    """A game with an inverted window (earliest > latest) is INFEASIBLE."""
-    pytest.importorskip("ortools")
-    from scheduler import solve, STATUS_INFEASIBLE
-    # Resource has two slots: 08:00 and 09:00.
-    # earliest_slot=09:00 (gslot >= 1) AND latest_slot=08:00 (gslot <= 0) → impossible.
-    game = _gym_game("G1", "T1", "T2")
-    game["earliest_slot"] = "Sat-1-09:00"
-    game["latest_slot"]   = "Sat-1-08:00"
-    si = _minimal_schedule_input(
-        games=[game],
-        resources=[_gym_resource("GYM-Sat-1-1", open_time="08:00", close_time="10:00")],
-    )
-    result = solve(si, timeout_seconds=10.0)
-    assert result["status"] == STATUS_INFEASIBLE
-
-
-def test_solve_c8_unknown_slot_label_is_ignored():
-    """A game with an earliest_slot label not in any resource slot is scheduled normally."""
-    pytest.importorskip("ortools")
-    from scheduler import solve, STATUS_OPTIMAL
-    game = _gym_game("G1", "T1", "T2")
-    game["earliest_slot"] = "Sun-2-14:00"   # label exists in no resource → ignored
-    si = _minimal_schedule_input(
-        games=[game],
-        resources=[_gym_resource("GYM-Sat-1-1", open_time="08:00", close_time="09:00")],
-    )
-    result = solve(si, timeout_seconds=10.0)
-    assert result["status"] == STATUS_OPTIMAL
-    assert len(result["assignments"]) == 1
-
-
 def test_solve_c6_min_rest_does_not_span_day_boundary():
     """A team that plays the last slot of one day and the first of the next must be OPTIMAL.
 
@@ -602,91 +512,45 @@ def test_solve_c6_min_rest_does_not_span_day_boundary():
     assert len(result["assignments"]) == 2
 
 
-# ---------------------------------------------------------------------------
-# C9 — finale sequence ordering
-# ---------------------------------------------------------------------------
-
-def _seq_rule(earlier_id, later_id):
-    return {
-        "rule":            f"Finale: {earlier_id} before {later_id}",
-        "earlier_game_id": earlier_id,
-        "later_game_id":   later_id,
-    }
-
-
-def test_solve_c9_sequence_ordering_respected():
-    """Three finals on the same resource are assigned in the declared order."""
+def test_solve_playoff_slots_passed_through():
+    """Playoff slots from schedule_input are merged into the solver output assignments."""
     pytest.importorskip("ortools")
     from scheduler import solve, STATUS_OPTIMAL
-
-    # Three single-court 3-slot window — solver must sequence them.
-    # Sequence rule: G1 < G2 < G3.
-    si = {
-        "games": [
-            _gym_game("G1", "T1", "T2", stage="Final"),
-            _gym_game("G2", "T3", "T4", stage="Final"),
-            _gym_game("G3", "T5", "T6", stage="Final"),
-        ],
-        "resources": [
-            _gym_resource("C1", open_time="14:00", close_time="17:00"),
-        ],
-        "precedence": [],
-        "sequence": [
-            _seq_rule("G1", "G2"),
-            _seq_rule("G2", "G3"),
-        ],
-    }
+    si = _minimal_schedule_input(
+        games=[_gym_game("G1", "T1", "T2")],
+        resources=[_gym_resource("GYM-Sat-1-1")],
+    )
+    si["playoff_slots"] = [
+        {"game_id": "BBM-Final", "event": "Basketball - Men Team", "stage": "Final",
+         "resource_id": "GYM-Sat-2-1", "slot": "Sat-2-14:00"},
+    ]
     result = solve(si, timeout_seconds=10.0)
     assert result["status"] == STATUS_OPTIMAL
-
-    slot_by_game = {a["game_id"]: a["slot"] for a in result["assignments"]}
-    assert slot_by_game["G1"] < slot_by_game["G2"]
-    assert slot_by_game["G2"] < slot_by_game["G3"]
-
-
-def test_solve_c9_sequence_infeasible_when_impossible():
-    """Circular sequence (G1 < G2 and G2 < G1) is INFEASIBLE."""
-    pytest.importorskip("ortools")
-    from scheduler import solve, STATUS_INFEASIBLE
-
-    si = {
-        "games": [
-            _gym_game("G1", "T1", "T2", stage="Final"),
-            _gym_game("G2", "T3", "T4", stage="Final"),
-        ],
-        "resources": [
-            _gym_resource("C1", open_time="14:00", close_time="16:00"),
-        ],
-        "precedence": [],
-        "sequence": [
-            _seq_rule("G1", "G2"),
-            _seq_rule("G2", "G1"),  # creates cycle → infeasible
-        ],
-    }
-    result = solve(si, timeout_seconds=10.0)
-    assert result["status"] == STATUS_INFEASIBLE
+    game_ids = {a["game_id"] for a in result["assignments"]}
+    assert "G1" in game_ids
+    assert "BBM-Final" in game_ids
+    final_asgn = next(a for a in result["assignments"] if a["game_id"] == "BBM-Final")
+    assert final_asgn["slot"] == "Sat-2-14:00"
+    assert final_asgn["stage"] == "Final"
 
 
-def test_solve_c9_cross_pool_rule_skipped_gracefully():
-    """A sequence rule whose game IDs span different pools does not crash."""
+def test_solve_playoff_slots_passed_through():
+    """playoff_slots from schedule_input are merged into solver output assignments."""
     pytest.importorskip("ortools")
     from scheduler import solve, STATUS_OPTIMAL
-
-    # G1 is a Gym Court game, G2 is a Badminton Court game.
-    # The sequence rule between them cannot be enforced (different pools) but
-    # must not raise an error — each pool schedules its own game freely.
-    si = {
-        "games": [
-            _gym_game("G1", "T1", "T2", stage="Final"),
-            _bad_game("G2"),
-        ],
-        "resources": [
-            _gym_resource("GYM-1", open_time="14:00", close_time="15:00"),
-            _bad_resource("BAD-1", close_time="15:00"),
-        ],
-        "precedence": [],
-        "sequence": [_seq_rule("G1", "G2")],
-    }
+    si = _minimal_schedule_input(
+        games=[_gym_game("G1", "T1", "T2")],
+        resources=[_gym_resource("GYM-Sat-1-1")],
+    )
+    si["playoff_slots"] = [
+        {"game_id": "BBM-Final", "event": "Basketball - Men Team", "stage": "Final",
+         "resource_id": "GYM-Sat-2-1", "slot": "Sat-2-14:00"},
+    ]
     result = solve(si, timeout_seconds=10.0)
     assert result["status"] == STATUS_OPTIMAL
-    assert len(result["assignments"]) == 2
+    game_ids = {a["game_id"] for a in result["assignments"]}
+    assert "G1" in game_ids
+    assert "BBM-Final" in game_ids
+    final_asgn = next(a for a in result["assignments"] if a["game_id"] == "BBM-Final")
+    assert final_asgn["slot"] == "Sat-2-14:00"
+    assert final_asgn["stage"] == "Final"

--- a/middleware/tests/test_scheduler.py
+++ b/middleware/tests/test_scheduler.py
@@ -355,8 +355,12 @@ def test_run_solve_schedule_infeasible_writes_diagnostics(tmp_path):
     assert data["status"] == STATUS_INFEASIBLE
     assert data["assignments"] == []
     assert sorted(data["unscheduled"]) == ["BAD-01", "BAD-02"]
-    assert "diagnostics" in data
-    diag = data["diagnostics"][0]
+    # diagnostics now live inside pool_results, not at the top level
+    assert "pool_results" in data
+    pool = data["pool_results"][0]
+    assert pool["resource_type"] == "Badminton Court"
+    assert "diagnostics" in pool
+    diag = pool["diagnostics"][0]
     assert diag["resource_type"] == "Badminton Court"
     assert diag["required_slots"] == 2
     assert diag["available_slots"] == 1
@@ -374,3 +378,136 @@ def test_run_solve_schedule_missing_input(tmp_path):
         tmp_path / "out.json",
     )
     assert exit_code == 2
+
+
+# ---------------------------------------------------------------------------
+# Pool decomposition tests
+# ---------------------------------------------------------------------------
+
+def _bad_resource(resource_id, day="Day-1", open_time="09:00", close_time="10:30"):
+    return {
+        "resource_id": resource_id, "resource_type": "Badminton Court",
+        "label": "Court-1", "day": day,
+        "open_time": open_time, "close_time": close_time, "slot_minutes": 30,
+    }
+
+
+def _bad_game(game_id, team_a="A", team_b="B"):
+    return {
+        "game_id": game_id, "event": "Badminton",
+        "stage": "R1", "pool_id": "", "round": 1,
+        "team_a_id": team_a, "team_b_id": team_b,
+        "duration_minutes": 30, "resource_type": "Badminton Court",
+        "earliest_slot": None, "latest_slot": None,
+    }
+
+
+def test_solve_pool_results_always_present():
+    """solve() always returns pool_results even for a single resource type."""
+    pytest.importorskip("ortools")
+    from scheduler import solve, STATUS_OPTIMAL
+    si = _minimal_schedule_input(
+        games=[_gym_game("G1", "T1", "T2")],
+        resources=[_gym_resource("GYM-Sat-1-1")],
+    )
+    result = solve(si)
+    assert result["status"] == STATUS_OPTIMAL
+    assert "pool_results" in result
+    assert len(result["pool_results"]) == 1
+    pr = result["pool_results"][0]
+    assert pr["resource_type"] == "Gym Court"
+    assert pr["status"] == STATUS_OPTIMAL
+    assert len(pr["assignments"]) == 1
+
+
+def test_solve_partial_feasibility():
+    """Two independent pools: one feasible, one infeasible → PARTIAL status.
+
+    Gym Court pool has enough slots; Badminton Court pool does not.
+    The Gym Court assignments must survive even though Badminton is infeasible.
+    """
+    pytest.importorskip("ortools")
+    from scheduler import solve, STATUS_PARTIAL, STATUS_OPTIMAL, STATUS_INFEASIBLE
+
+    si = _minimal_schedule_input(
+        games=[
+            _gym_game("G1", "T1", "T2"),                    # Gym Court — feasible
+            _bad_game("BAD-01", "A", "B"),                   # Badminton Court — infeasible
+            _bad_game("BAD-02", "C", "D"),                   # Badminton Court — infeasible
+        ],
+        resources=[
+            _gym_resource("GYM-Sat-1-1"),                    # Gym Court: 3 slots
+            _bad_resource("BAD-1", close_time="09:30"),      # Badminton: only 1 slot for 2 games
+        ],
+    )
+    result = solve(si, timeout_seconds=10.0)
+
+    assert result["status"] == STATUS_PARTIAL
+
+    # Gym assignment must be preserved
+    gym_assignments = [a for a in result["assignments"] if a["game_id"] == "G1"]
+    assert len(gym_assignments) == 1
+
+    # Badminton games are unscheduled
+    assert "BAD-01" in result["unscheduled"] or "BAD-02" in result["unscheduled"]
+
+    # pool_results carries per-pool outcome
+    pools = {pr["resource_type"]: pr for pr in result["pool_results"]}
+    assert pools["Gym Court"]["status"] == STATUS_OPTIMAL
+    assert pools["Badminton Court"]["status"] == STATUS_INFEASIBLE
+    assert "diagnostics" in pools["Badminton Court"]
+
+
+def test_solve_two_independent_pools_both_optimal():
+    """Two pools with sufficient resources both solve OPTIMAL independently."""
+    pytest.importorskip("ortools")
+    from scheduler import solve, STATUS_OPTIMAL
+
+    si = _minimal_schedule_input(
+        games=[
+            _gym_game("G1", "T1", "T2"),
+            _bad_game("BAD-01", "A", "B"),
+        ],
+        resources=[
+            _gym_resource("GYM-Sat-1-1"),
+            _bad_resource("BAD-1"),                          # 3 slots — enough for 1 game
+        ],
+    )
+    result = solve(si, timeout_seconds=10.0)
+
+    assert result["status"] == STATUS_OPTIMAL
+    assert len(result["assignments"]) == 2
+    assert result["unscheduled"] == []
+    pools = {pr["resource_type"]: pr for pr in result["pool_results"]}
+    assert pools["Gym Court"]["status"] == STATUS_OPTIMAL
+    assert pools["Badminton Court"]["status"] == STATUS_OPTIMAL
+
+
+def test_solve_partial_exit_code(tmp_path):
+    """run_solve_schedule returns exit code 1 for PARTIAL and writes pool_results."""
+    pytest.importorskip("ortools")
+    from scheduler import run_solve_schedule, STATUS_PARTIAL
+
+    si = _minimal_schedule_input(
+        games=[
+            _gym_game("G1", "T1", "T2"),
+            _bad_game("BAD-01"),
+            _bad_game("BAD-02"),
+        ],
+        resources=[
+            _gym_resource("GYM-Sat-1-1"),
+            _bad_resource("BAD-1", close_time="09:30"),      # 1 slot, 2 games → infeasible
+        ],
+    )
+    input_path = tmp_path / "schedule_input.json"
+    input_path.write_text(json.dumps(si), encoding="utf-8")
+    output_path = tmp_path / "schedule_output.json"
+
+    exit_code = run_solve_schedule(input_path, output_path)
+    assert exit_code == 1
+
+    data = json.loads(output_path.read_text(encoding="utf-8"))
+    assert data["status"] == STATUS_PARTIAL
+    assert any(a["game_id"] == "G1" for a in data["assignments"])
+    pools = {pr["resource_type"]: pr for pr in data["pool_results"]}
+    assert "diagnostics" in pools["Badminton Court"]


### PR DESCRIPTION
## Summary

This branch delivers the full scheduling pipeline and all completed items from Issues #93, #94, #96, and #97.

## What's included (24 commits)

### Core pipeline — closes #93, #94, #96
- `scheduler.py` — CP-SAT solver reading `schedule_input.json`, writing `schedule_output.json`
- `produce-schedule` command — renders solved schedule as Excel timetable (`Schedule-by-Time`, `Schedule-by-Sport` tabs)
- Hardened `schedule_input.json` contract: stable placeholder team IDs, non-empty `pool_id`, explicit `SCHEDULE_SOLVER_GYM_COURTS` scenario
- Pool-play-only solver; playoff games are pre-assigned via the `Playoff-Slots` tab in `venue_input.xlsx`

### Venue input extensions
- `Exclusive Venue Group` column — tag rows sharing a physical gym
- `Gym-Modes` tab — per-gym capacity coefficients (Basketball/Volleyball/Badminton/Pickleball/Soccer)
- Both tabs warn-not-crash when absent

### Issue #97 follow-up improvements
- **A1** C6 min-rest constraint no longer spans day boundaries (spurious overnight no-rest violation fixed)
- **A2** Exit code 1 when games are dropped (no more silent OPTIMAL with unscheduled games)
- **A3** Pod-sport schedule output grouped by uniform slot-window resources
- **B3** Pool-game count aligned between Venue-Estimator and `schedule_input.json` (actual round-robin count, not formula)
- **B4** Edge-pool fairness: floor-division pool sizing guarantees every team plays ≥ gpg games; normalized Layer 1 policy (deterministic 2/3/4/5-team templates, Volleyball Women normalized to gpg=2)
- **B5** `produce-schedule` warns on file mismatch (orphaned assignment game IDs listed by name)
- **B6** Solver determinism via fixed `random_seed = 42`
- **B7** Timeout (exit 2) vs hard error (exit 3) vs unscheduled (exit 1) vs success (exit 0) — four distinct exit codes
- **C1** CLI handler tests for `solve-schedule` and `produce-schedule` argument parsing and default path wiring
- **C2** End-to-end pipeline test: export → solve → produce through `main.main()`
- **C3** Min-rest test decoupled from slot length (uses full slot-space index)
- **B1/B2/D** — B1 deferred (no upstream blackout data yet), B2 dropped (low risk at current scale), D deferred (needs participant→games mapping)

### `run-schedule.bat`
One-click Windows batch file: reads `EXPORT_DIR` from `.env`, pre-flight checks `schedule_input.json`, runs solve → produce, displays exit codes with plain-language messages.

## Test count
258 tests passing (up from 225 at branch start).

## Related issues
- Closes #93 — CP-SAT scheduler
- Closes #94 — Schedule output Excel renderer
- Closes #96 — Hardened `schedule_input.json` contract
- References #97 (follow-up items — see issue comments for closing notes)
- References #98 (next: split scheduling out of `church_teams_export.py`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nd2RJPY4FduwRnZkf3pdmL)_