### PR TITLE
docs: scheduling how-to guide, Layer 1/2 model, and moving parts map

### DIFF
--- a/docs/SCHEDULE-HOW-TO.md
+++ b/docs/SCHEDULE-HOW-TO.md
@@ -1,0 +1,184 @@
+# How to Create the Sports Fest Competition Schedule
+
+This guide walks you through the four-step scheduling pipeline from venue setup to a
+printed Excel timetable.  For the full technical reference, see `docs/SCHEDULING.md`.
+
+---
+
+## Prerequisites
+
+- `pip install -r requirements.txt` done (includes `ortools`)
+- `.env` configured with working API credentials
+- Approved rosters in WordPress (run a full sync first if unsure)
+
+---
+
+## Step 1 — Fill out `venue_input.xlsx`
+
+Copy the template into the data folder and rename it:
+
+```
+middleware/data/SportsFest_2026_Venue_Input_Template.xlsx
+→ middleware/data/venue_input.xlsx
+```
+
+The file is gitignored — do not commit it.  It has three tabs:
+
+### `Venue-Input` tab
+
+One row per physical court or table resource.  Required columns:
+
+| Column | Example | Notes |
+|--------|---------|-------|
+| Sport / Resource Type | `Gym Court` | Must match a `POD_RESOURCE_TYPE_*` or `GYM_RESOURCE_TYPE` constant in `config.py` |
+| Day | `Sat-1` | `Sat-1`, `Sat-2`, or `Sun` |
+| Open Time | `08:00` | 24-hour format |
+| Close Time | `21:00` | Last slot starts before this time |
+| Slot Minutes | `60` | Game duration for this resource |
+| Quantity | `4` | Number of identical courts on this day |
+| Exclusive Venue Group | `Main Gym` | Fill this in when one physical gym can be configured as BB courts **or** VB courts but not both simultaneously.  Tag every row for the same gym with the same label.  Leave blank for standalone courts. |
+
+### `Gym-Modes` tab
+
+One row per physical gym.  Records how many courts each gym yields per sport mode.
+Use `0` for modes the gym cannot host.
+
+| Column | Example |
+|--------|---------|
+| Gym Name | `Main Gym` |
+| Basketball Courts | `1` |
+| Volleyball Courts | `2` |
+| Badminton Courts | `0` |
+| Pickleball Courts | `0` |
+| Soccer Fields | `0` |
+
+### `Playoff-Slots` tab
+
+One row per knockout game (QF, Semi, Final, 3rd place).  The solver does **not**
+assign playoff timing — you control it exactly here.
+
+| Column | Example | Notes |
+|--------|---------|-------|
+| `game_id` | `BBM-Final` | Unique; used in the schedule output |
+| `event` | `Basketball - Men Team` | Must match the event name exactly |
+| `stage` | `Final` | `QF`, `Semi`, `Final`, or `3rd` |
+| `resource_id` | `GYM-Sat-2-1` | Must match a resource_id from the Venue-Input rows |
+| `slot` | `Sat-2-14:00` | `Day-HH:MM` format |
+
+To lock in a finale order (e.g. VB Women → VB Men → Basketball back-to-back),
+put those rows in that order with consecutive slot values.
+
+---
+
+## Step 2 — (Optional) Adjust config constants
+
+Open `middleware/config.py` and check these values match your new venue:
+
+| Constant | Default | What it controls |
+|----------|---------|-----------------|
+| `SCHEDULE_SOLVER_GYM_COURTS` | `4` | Number of gym courts for the solver scenario |
+| `SCHEDULE_SKETCH_SATURDAY_START` | `8` | First game hour on Saturday (24h) |
+| `SCHEDULE_SKETCH_SATURDAY_LAST_GAME` | `20` | Last game start hour on Saturday |
+| `SCHEDULE_SKETCH_SUNDAY_START` | `13` | First game hour on Sunday |
+| `SCHEDULE_SKETCH_SUNDAY_LAST_GAME` | `20` | Last game start hour on Sunday |
+
+---
+
+## Step 3 — Pull registrations and generate `schedule_input.json`
+
+```bash
+cd middleware
+python main.py export-church-teams
+```
+
+Because `venue_input.xlsx` is present, this also writes a **Schedule-Input** tab in
+the output workbook and a `schedule_input.json` alongside it.  That JSON file is the
+machine contract the solver reads in the next step.
+
+**Check the output:** open `Church_Team_Status_ALL_*.xlsx` and look at the
+`Schedule-Input` tab to verify game counts and resource rows look right before solving.
+
+### Optional — offline planning workbook
+
+Before solving you can iterate on venue layout without hitting the live APIs:
+
+```bash
+python main.py build-schedule-workbook
+```
+
+This produces a 6-tab planning Excel (`Venue-Estimator`, `Pod-Divisions`,
+`Court-Schedule-Sketch`, etc.) so coordinators can verify court counts and time
+estimates.
+
+---
+
+## Step 4 — Run the CP-SAT solver
+
+**On Windows (recommended):**
+
+```bat
+run-schedule.bat
+```
+
+This runs both the solver and the Excel renderer in one shot and prints a clear
+pass/fail summary.
+
+**Or run each step individually:**
+
+```bash
+python main.py solve-schedule
+```
+
+Exit codes:
+
+| Code | Meaning | What to do |
+|------|---------|-----------|
+| `0` | All games scheduled (OPTIMAL or FEASIBLE) | Proceed to Step 5 |
+| `1` | Partial — some games unscheduled | Check the log; add courts or expand time window, then re-run |
+| `2` | Timeout — no solution found | Set `SCHEDULE_SOLVER_TIMEOUT=120` and retry |
+| `3+` | Hard error (bad input, ortools not installed) | Check the log for details |
+
+**If you get exit code `1` (partial):** the log prints a diagnostics table showing
+required slots vs. available slots per resource type.  The usual fix is increasing
+`Quantity` in `venue_input.xlsx` for the over-subscribed resource type, or widening
+the time window in `config.py`.
+
+---
+
+## Step 5 — Render the Excel timetable
+
+```bash
+python main.py produce-schedule
+```
+
+Writes `VAYSF_Schedule_YYYY-MM-DD.xlsx` to `EXPORT_DIR`.  Two tabs:
+
+- **Schedule-by-Time** — color-coded grid view for floor coordinators
+- **Schedule-by-Sport** — flat list with auto-filter for sport directors
+
+Playoff games from your `Playoff-Slots` tab appear alongside pool play.
+
+---
+
+## Last-minute playoff changes
+
+If a playoff game time or court needs to change during the tournament:
+
+1. Edit the `Playoff-Slots` tab in `venue_input.xlsx`.
+2. Re-run `produce-schedule` only — no solver re-run needed:
+
+```bash
+python main.py produce-schedule --input data/schedule_output.json --constraint data/schedule_input.json
+```
+
+---
+
+## Quick checklist
+
+- [ ] `venue_input.xlsx` filled out (Venue-Input, Gym-Modes, Playoff-Slots tabs)
+- [ ] `SCHEDULE_SOLVER_GYM_COURTS` in `config.py` matches your gym court count
+- [ ] Time window constants updated if venue hours changed
+- [ ] `export-church-teams` run successfully → `schedule_input.json` produced
+- [ ] `solve-schedule` exits `0` (or `1` with acceptable partial result)
+- [ ] `produce-schedule` writes `VAYSF_Schedule_*.xlsx` to `EXPORT_DIR`
+- [ ] Coordinators review both tabs before printing

--- a/docs/SCHEDULE-HOW-TO.md
+++ b/docs/SCHEDULE-HOW-TO.md
@@ -62,11 +62,35 @@ assign playoff timing — you control it exactly here.
 | `game_id` | `BBM-Final` | Unique; used in the schedule output |
 | `event` | `Basketball - Men Team` | Must match the event name exactly |
 | `stage` | `Final` | `QF`, `Semi`, `Final`, or `3rd` |
-| `resource_id` | `GYM-Sat-2-1` | Must match a `resource_id` from the `resources` array in `schedule_input.json` (run `export-church-teams` first, then copy IDs from that file) |
+| `resource_id` | `GYM-Sat-2-1` | Must match a generated resource ID — see **Finding resource IDs** below |
 | `slot` | `Sat-2-14:00` | `Day-HH:MM` format |
 
 To lock in a finale order (e.g. VB Women → VB Men → Basketball back-to-back),
 put those rows in that order with consecutive slot values.
+
+### Finding resource IDs
+
+Resource IDs are auto-generated from your `Venue-Input` rows.  The easiest way to
+look them up is in **Excel, not JSON**:
+
+1. Run `export-church-teams` (Step 3 below).
+2. Open `Church_Team_Status_ALL_*.xlsx` and go to the **`Schedule-Input`** tab.
+3. The `Resources` section of that tab lists every court and table with its
+   `resource_id` in a readable table.  Copy IDs from there into `Playoff-Slots`.
+
+If you want to predict the IDs without running the export first, they follow
+these patterns:
+
+| Resource type | ID pattern | Example |
+|---------------|-----------|---------|
+| Gym Court (Basketball / Volleyball) | `GYM-{day}-{n}` | `GYM-Sat-1-1`, `GYM-Sat-2-3` |
+| Badminton Court | `BAD-{n}` | `BAD-1`, `BAD-2` |
+| Pickleball Court | `PIC-{n}` | `PIC-1` |
+| Table Tennis Table | `TAB-{n}` | `TAB-1` |
+| Tennis Court | `TEN-{n}` | `TEN-1` |
+
+Day labels for gym courts: `Sat-1`, `Sat-2`, `Sun-1`, `Sun-2`.
+`{n}` is sequential across all rows of the same resource type in `Venue-Input`.
 
 ---
 

--- a/docs/SCHEDULE-HOW-TO.md
+++ b/docs/SCHEDULE-HOW-TO.md
@@ -62,7 +62,7 @@ assign playoff timing — you control it exactly here.
 | `game_id` | `BBM-Final` | Unique; used in the schedule output |
 | `event` | `Basketball - Men Team` | Must match the event name exactly |
 | `stage` | `Final` | `QF`, `Semi`, `Final`, or `3rd` |
-| `resource_id` | `GYM-Sat-2-1` | Must match a resource_id from the Venue-Input rows |
+| `resource_id` | `GYM-Sat-2-1` | Must match a `resource_id` from the `resources` array in `schedule_input.json` (run `export-church-teams` first, then copy IDs from that file) |
 | `slot` | `Sat-2-14:00` | `Day-HH:MM` format |
 
 To lock in a finale order (e.g. VB Women → VB Men → Basketball back-to-back),

--- a/docs/SCHEDULING.md
+++ b/docs/SCHEDULING.md
@@ -40,6 +40,94 @@ rather than the Layer-2 booked inventory — Issues #102 (Stage A allocator) and
 
 ---
 
+## Moving Parts Map
+
+### Data flow by layer
+
+```
+LAYER 1 — STRATEGIC (pre-booking): estimate the minimum venue to book
+──────────────────────────────────────────────────────────────────────────────
+  ChMeetings + WordPress
+       │
+       │  export-church-teams  (run-me.bat includes this)
+       ▼
+  Church_Team_Status_ALL_*.xlsx          schedule_input.json  ◄─ venue_input.xlsx
+  ├─ Summary                             [BRIDGE: Layer 1 → 2]   (manual, booked
+  ├─ Contacts-Status                      currently built from    venue goes here)
+  ├─ Roster                               Layer-1 estimate;
+  ├─ Validation-Issues                    fixed by #102 + #103
+  └─ {Sport} tabs                                │
+       │                                         │  build-schedule-workbook
+       │  (human review / approvals)             ▼
+       │                               Schedule_Workbook_*.xlsx
+       │                               ├─ Venue-Estimator       ← demand estimate
+       │                               ├─ Court-Schedule-Sketch ← 3/4/5-court sketch
+       │                               ├─ Pod-Divisions         ← division planning
+       │                               ├─ Pod-Entries-Review    ← entry checklist
+       │                               ├─ Pod-Resource-Estimate ← capacity vs demand
+       │                               └─ Schedule-Input        ← JSON echo (bridge)
+       │
+       │  ── VENUE CONTRACT SIGNED ──────────────────────────────────────────
+       │
+LAYER 2 — TACTICAL (post-booking): maximize use of the booked venue
+──────────────────────────────────────────────────────────────────────────────
+  venue_input.xlsx
+       │
+       │  Stage A: gym mode allocator  [NOT YET BUILT — Issue #102]
+       │    Greedy priority allocation of gym time-ranges to sport modes.
+       │    Structural exclusivity: no gym block handed to two modes.
+       ▼
+  schedule_input.json  (now carrying real Layer-2 gym resources)
+       │
+       │  solve-schedule  (Stage B: CP-SAT solver — run-schedule.bat Step 1)
+       ▼
+  schedule_output.json
+       │
+       │  produce-schedule  (run-schedule.bat Step 2)
+       ▼
+  VAYSF_Schedule_*.xlsx
+  ├─ Schedule-by-Time   ← color-coded grid for floor coordinators
+  └─ Schedule-by-Sport  ← flat list with auto-filter for sport directors
+```
+
+### Source files (scheduling-related)
+
+| File | Role | Layer |
+|------|------|-------|
+| `main.py` | CLI entry — all commands | — |
+| `church_teams_export.py` | Live ChMeetings + WP export; delegates scheduling tabs to `schedule_workbook.py` | Layer 1 + bridge |
+| `schedule_workbook.py` | `ScheduleWorkbookBuilder` — all scheduling tabs, both workbooks, schedule output renderer | Layer 1 + bridge + Layer 2 output |
+| `scheduler.py` | CP-SAT solver (Stage B) | Layer 2 |
+| `config.py` | All configuration constants; `SCHEDULE_SKETCH_*` and `SCHEDULE_SOLVER_GYM_COURTS` are Layer-1 stand-ins | — |
+| `gym_allocator.py` | Stage A greedy mode allocator | **Not built** — Issue #102 |
+
+### Batch scripts (Windows operator shortcuts)
+
+| Script | Runs | Layer |
+|--------|------|-------|
+| `run-me.bat` | `sync --type full` → `sync --type validation` → `export-church-teams` | Non-scheduling + Layer 1 |
+| `run-schedule.bat` | `solve-schedule` → `produce-schedule` | Layer 2 |
+
+### Input files
+
+| File | Location | Role | Layer |
+|------|----------|------|-------|
+| `venue_input.xlsx` | `middleware/data/` (gitignored) | Booked venue: courts, times, gym modes, playoff slots | Layer 2 input |
+| `SportsFest_2026_Venue_Input_Template.xlsx` | `middleware/data/` (committed) | Operator template for `venue_input.xlsx` | — |
+
+### Generated artifacts
+
+| Artifact | Produced by | Consumed by | Layer |
+|----------|-------------|-------------|-------|
+| `Church_Team_Status_ALL_*.xlsx` | `export-church-teams` | Human review, approvals | Non-scheduling |
+| `Church_Team_Status_{CODE}.xlsx` | `export-church-teams` | Pastor / church coordinator | Non-scheduling |
+| `schedule_input.json` | `export-church-teams` | `solve-schedule`, `build-schedule-workbook` | Bridge (Layer 1 data today; Layer 2 after #103) |
+| `Schedule_Workbook_*.xlsx` | `build-schedule-workbook` | Coordinator planning / venue contract decision | **Layer 1** |
+| `schedule_output.json` | `solve-schedule` | `produce-schedule` | Layer 2 |
+| `VAYSF_Schedule_*.xlsx` | `produce-schedule` | Floor coordinators, sport directors | Layer 2 |
+
+---
+
 ## Four-Step Pipeline
 
 ```

--- a/docs/SCHEDULING.md
+++ b/docs/SCHEDULING.md
@@ -6,6 +6,40 @@ and Claude sessions do not need to reverse-engineer the design from code.
 
 ---
 
+## Strategic vs Tactical: Layer 1 and Layer 2
+
+VAY Sports Fest scheduling spans two layers, divided by the moment the venue
+contract is signed.
+
+**Layer 1 — strategic (pre-booking).** Before any gym is contracted, the
+question is *estimation*: what is the minimum venue capacity we need to book?
+The output informs the venue contract negotiation. This layer is **not yet
+built** — `SCHEDULE_SOLVER_GYM_COURTS` and `SCHEDULE_SKETCH_N_COURTS` in
+`config.py` are crude scenario stand-ins for it, and the `Venue-Estimator` tab
+covers part of the demand estimate. A dedicated gym-capacity estimator is
+future work.
+
+**Layer 2 — tactical (post-booking).** The venue contract is signed; the
+question becomes *maximization*: how do we get the most out of the courts and
+hours already paid for? Layer 2 reads the real booked venue from
+`venue_input.xlsx` and runs in two stages:
+
+- **Stage A — gym mode allocation.** Each gym can be configured in one of
+  several mutually-exclusive modes per time block (e.g. 1 basketball court
+  *or* 2 volleyball courts). Stage A decides each gym's mode per time range —
+  greedily, most-populous-sport-first. Inputs: the `Gym-Modes` and
+  `Venue-Input` tabs plus per-sport demand. See Issue #102.
+- **Stage B — per-sport game scheduling.** The CP-SAT solver (`scheduler.py`)
+  packs each sport's games into the courts Stage A allocated, one sport at a
+  time.
+
+The four-step pipeline below is the Layer-2 runtime path. Today the scheduler
+still builds gym courts from the Layer-1 estimate (`SCHEDULE_SOLVER_GYM_COURTS`)
+rather than the Layer-2 booked inventory — Issues #102 (Stage A allocator) and
+#103 (integration) close that gap.
+
+---
+
 ## Four-Step Pipeline
 
 ```


### PR DESCRIPTION
## Summary

- Adds `docs/SCHEDULE-HOW-TO.md` — operator step-by-step guide for creating the competition schedule with a booked venue
- Adds a **Layer 1 (strategic) vs Layer 2 (tactical)** section to `docs/SCHEDULING.md`, explaining the pre-booking estimation vs post-booking maximization split
- Adds a **Moving Parts Map** to `docs/SCHEDULING.md` — data flow diagram, source files, batch scripts, input files, and generated artifacts with Layer attribution

## Related issues

- Context for Issues #101, #102, #103 (scheduling architecture cleanup)

## Test plan

- [ ] Docs render correctly on GitHub
- [ ] No code changes — docs only

---
_Generated by [Claude Code](https://claude.ai/code/session_0177LXrM5jJK9FNLxGhzobVX)_