### PR TITLE
middleware: scope targeted resend and log prior approval metadata

### DIFF
--- a/middleware/church_teams_export.py
+++ b/middleware/church_teams_export.py
@@ -714,6 +714,33 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
             logger.error("ChMeetings authentication failed. Cannot generate reports.")
             return False
 
+        if (
+            target_resend_chm_id
+            and not target_church_code
+            and (force_resend_pending or force_resend_validated1 or force_resend_validated2)
+        ):
+            wp_participants = self.wp_connector.get_participants(
+                {"chmeetings_id": str(target_resend_chm_id).strip()}
+            )
+            if wp_participants:
+                inferred_church_code = str(wp_participants[0].get("church_code", "")).strip().upper()
+                if inferred_church_code:
+                    target_church_code = inferred_church_code
+                    logger.info(
+                        f"Inferred target church '{target_church_code}' for resend ChMeetings ID "
+                        f"{target_resend_chm_id}. Limiting report generation to that church."
+                    )
+                else:
+                    logger.warning(
+                        f"Target resend ChMeetings ID {target_resend_chm_id} has no church_code in WordPress. "
+                        "Falling back to all churches."
+                    )
+            else:
+                logger.warning(
+                    f"Could not find WordPress participant for resend ChMeetings ID {target_resend_chm_id}. "
+                    "Falling back to all churches."
+                )
+
         deadline_date = datetime.strptime(REGISTRATION_DEADLINE, "%Y-%m-%d").date()
         today = datetime.now().date()
         if today >= deadline_date:
@@ -3104,6 +3131,17 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
             if not pastor_email:
                 logger.error(f"No pastor email for church {church_code}")
                 return False
+
+            existing_approvals = sync_manager.wordpress_connector.get_approvals(
+                params={"participant_id": wp_participant_id}
+            )
+            existing_approval = next(
+                (
+                    approval for approval in existing_approvals
+                    if str(approval.get("church_id")) == str(church.get("church_id"))
+                ),
+                None,
+            )
             
             # Generate new token and expiry
             from uuid import uuid4
@@ -3155,6 +3193,16 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
             )
             
             if success:
+                if existing_approval:
+                    logger.info(
+                        "Existing approval record before resend for "
+                        f"{participant_name} (WP ID: {wp_participant_id}): "
+                        f"approval_id={existing_approval.get('approval_id')}, "
+                        f"created_at={existing_approval.get('created_at', 'N/A')}, "
+                        f"status={existing_approval.get('approval_status', 'N/A')}, "
+                        f"token_expiry={existing_approval.get('token_expiry', 'N/A')}, "
+                        f"pastor_email={existing_approval.get('pastor_email', 'N/A')}"
+                    )
                 logger.info(f"Successfully resent approval email for {participant_name} (ID: {wp_participant_id})")
                 return True
             else:

--- a/middleware/tests/test_church_teams_export.py
+++ b/middleware/tests/test_church_teams_export.py
@@ -118,20 +118,20 @@ def test_resend_logs_existing_approval_metadata(mock_connectors, mocker):
 
     fake_sync_manager = MagicMock()
     fake_sync_manager.churches_cache = {
-        "WSD": {
-            "church_code": "WSD",
-            "church_id": 9,
-            "pastor_email": "cuongmanhnguyen@hotmail.com",
+        "TST": {
+            "church_code": "TST",
+            "church_id": 99,
+            "pastor_email": "pastor@example.com",
         }
     }
     fake_sync_manager.wordpress_connector.get_approvals.return_value = [
         {
             "approval_id": "76",
-            "participant_id": "350",
-            "church_id": "9",
+            "participant_id": "999",
+            "church_id": "99",
             "approval_status": "pending",
             "token_expiry": "2026-06-09 20:58:02",
-            "pastor_email": "cuongmanhnguyen@hotmail.com",
+            "pastor_email": "pastor@example.com",
             "created_at": "2026-05-11 03:58:03",
         }
     ]
@@ -142,12 +142,12 @@ def test_resend_logs_existing_approval_metadata(mock_connectors, mocker):
 
     exporter = ChurchTeamsExporter()
     participant_contact = {
-        "Participant ID (WP)": "350",
-        "First Name": "Dora",
-        "Last Name": "Phan",
-        "Church Team": "WSD",
-        "ChMeetings ID": "3630125",
-        "Email": "doraphan2009@gmail.com",
+        "Participant ID (WP)": "999",
+        "First Name": "Test",
+        "Last Name": "Participant",
+        "Church Team": "TST",
+        "ChMeetings ID": "1111111",
+        "Email": "participant@example.com",
         "Is_Member_ChM": "Yes",
         "Photo URL (WP)": "https://example.com/photo.jpg",
     }
@@ -156,7 +156,7 @@ def test_resend_logs_existing_approval_metadata(mock_connectors, mocker):
 
     assert success is True
     assert any(
-        "Existing approval record before resend for Dora Phan" in call.args[0]
+        "Existing approval record before resend for Test Participant" in call.args[0]
         and "created_at=2026-05-11 03:58:03" in call.args[0]
         for call in info_logger.call_args_list
     )
@@ -166,7 +166,7 @@ def test_generate_reports_infers_target_church_for_targeted_resend(mock_connecto
     chm_connector, wp_connector = mock_connectors
     chm_connector.authenticate.return_value = True
     wp_connector.get_participants.return_value = [
-        {"participant_id": 350, "chmeetings_id": "3630125", "church_code": "WSD"}
+        {"participant_id": 999, "chmeetings_id": "1111111", "church_code": "TST"}
     ]
 
     exporter = ChurchTeamsExporter()
@@ -177,12 +177,12 @@ def test_generate_reports_infers_target_church_for_targeted_resend(mock_connecto
         output_dir=tmp_path,
         force_resend_pending=True,
         dry_run=True,
-        target_resend_chm_id="3630125",
+        target_resend_chm_id="1111111",
     )
 
     assert success is True
-    wp_connector.get_participants.assert_called_once_with({"chmeetings_id": "3630125"})
-    fetch_chm.assert_called_once_with("WSD")
+    wp_connector.get_participants.assert_called_once_with({"chmeetings_id": "1111111"})
+    fetch_chm.assert_called_once_with("TST")
 
 
 def test_generate_reports_surfaces_open_validation_issues(mock_connectors, mocker, tmp_path):

--- a/middleware/tests/test_church_teams_export.py
+++ b/middleware/tests/test_church_teams_export.py
@@ -113,6 +113,78 @@ def test_handle_force_resend_filters_to_one_chm_id(mock_connectors, mocker):
     assert resend_count == 1
 
 
+def test_resend_logs_existing_approval_metadata(mock_connectors, mocker):
+    _, wp_connector = mock_connectors
+
+    fake_sync_manager = MagicMock()
+    fake_sync_manager.churches_cache = {
+        "WSD": {
+            "church_code": "WSD",
+            "church_id": 9,
+            "pastor_email": "cuongmanhnguyen@hotmail.com",
+        }
+    }
+    fake_sync_manager.wordpress_connector.get_approvals.return_value = [
+        {
+            "approval_id": "76",
+            "participant_id": "350",
+            "church_id": "9",
+            "approval_status": "pending",
+            "token_expiry": "2026-06-09 20:58:02",
+            "pastor_email": "cuongmanhnguyen@hotmail.com",
+            "created_at": "2026-05-11 03:58:03",
+        }
+    ]
+    fake_sync_manager.wordpress_connector.create_approval.return_value = {"approval_id": 76}
+    fake_sync_manager.send_pastor_approval_email.return_value = True
+
+    info_logger = mocker.patch("church_teams_export.logger.info")
+
+    exporter = ChurchTeamsExporter()
+    participant_contact = {
+        "Participant ID (WP)": "350",
+        "First Name": "Dora",
+        "Last Name": "Phan",
+        "Church Team": "WSD",
+        "ChMeetings ID": "3630125",
+        "Email": "doraphan2009@gmail.com",
+        "Is_Member_ChM": "Yes",
+        "Photo URL (WP)": "https://example.com/photo.jpg",
+    }
+
+    success = exporter._resend_approval_for_participant(fake_sync_manager, participant_contact)
+
+    assert success is True
+    assert any(
+        "Existing approval record before resend for Dora Phan" in call.args[0]
+        and "created_at=2026-05-11 03:58:03" in call.args[0]
+        for call in info_logger.call_args_list
+    )
+
+
+def test_generate_reports_infers_target_church_for_targeted_resend(mock_connectors, mocker, tmp_path):
+    chm_connector, wp_connector = mock_connectors
+    chm_connector.authenticate.return_value = True
+    wp_connector.get_participants.return_value = [
+        {"participant_id": 350, "chmeetings_id": "3630125", "church_code": "WSD"}
+    ]
+
+    exporter = ChurchTeamsExporter()
+    fetch_chm = mocker.patch.object(exporter, "_fetch_chm_church_team_data", return_value={})
+
+    success = exporter.generate_reports(
+        target_church_code=None,
+        output_dir=tmp_path,
+        force_resend_pending=True,
+        dry_run=True,
+        target_resend_chm_id="3630125",
+    )
+
+    assert success is True
+    wp_connector.get_participants.assert_called_once_with({"chmeetings_id": "3630125"})
+    fetch_chm.assert_called_once_with("WSD")
+
+
 def test_generate_reports_surfaces_open_validation_issues(mock_connectors, mocker, tmp_path):
     chm_connector, wp_connector = mock_connectors
     chm_connector.authenticate.return_value = True


### PR DESCRIPTION
## Summary

Cherry-pick of Bumble's commit from `codex/targeted-resend-logging` onto current main.

- Scopes targeted resend logic in `church_teams_export.py`
- Logs prior approval metadata
- Adds corresponding tests in `test_church_teams_export.py`

+120 lines across 2 files. Applied cleanly with no conflicts.

## Test plan

- [ ] `pytest tests/test_church_teams_export.py` passes in mock mode

---
_Generated by [Claude Code](https://claude.ai/code/session_0177LXrM5jJK9FNLxGhzobVX)_