### PR TITLE
Bible Challenge Phase 1: Venue-Estimator, Pool-Assignment, and conflict-edge support — refs #118

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## Unreleased
 
 ### New Features
+- Added Bible Challenge Phase-1 planning support
+  - `Venue-Estimator` now treats Bible Challenge as a sequential single-classroom Jeopardy queue instead of a normal concurrent court-hours sport
+  - `Pool-Assignment` now includes BC team rows alongside BB / VBM / VBW
+  - `Conflict-Audit` now surfaces BC shared-athlete edges as `PlanningOnly` rows in `VAYSF_Schedule_*.xlsx` until full BC game-by-game queue scheduling is implemented
+
 - Improved final `Schedule-by-Time` readability for mixed-venue gym schedules
   - `venue_input.xlsx` rows now derive logical day labels from the `Date` column when `Day` is absent, so direct venue rows no longer collapse across multiple actual dates into one fake `Day-1`
   - Direct venue resources now carry `venue_name` through to `schedule_input.json`

--- a/docs/SCHEDULING.md
+++ b/docs/SCHEDULING.md
@@ -164,8 +164,9 @@ Key constraints the pipeline must respect:
   room and games never run concurrently. The scheduling problem for BC is a
   simple queue, not a resource-allocation problem. There is no "court-hours"
   model — only total room-minutes.
-- **Round-robin phase.** Each registered BC team plays **2 games** in the
-  round-robin. Total RR games = ⌈N × 2 / 3⌉ where N is the number of teams.
+- **Round-robin phase.** Each registered BC team is planned for **2 games** in
+  the round-robin once at least 3 church teams exist. Total RR games = ⌈N × 2 / 3⌉
+  where N is the number of teams.
   Matchup pairing within the round-robin is managed by the organizer; the
   pipeline provides the pool draw and cross-sport conflict edges only.
 - **Playoff phase.** The **top 9 teams by cumulative Jeopardy score** advance
@@ -178,13 +179,15 @@ Key constraints the pipeline must respect:
 - **Per-game duration.** 60 minutes (includes buffer for late starts).
 - **Venue-Estimator model.** BC appears as a separate row in the
   Venue-Estimator showing total sequential room-hours, not concurrent
-  court-hours. Formula: `(RR games + playoff games) × 60 min`.
+  court-hours. Formula: `(RR games + playoff games) × 60 min`. If fewer than
+  3 BC teams exist, the estimator shows that the room queue is still waiting
+  for the first 3-team game.
 - **Cross-sport conflict edges.** BC teams produce pairwise shared-athlete
   edges with BB / VBM / VBW teams exactly like any other team sport. An
   athlete on a BC team who also plays Basketball still generates a
   primary-vs-secondary conflict edge in `team_conflicts`.
 
-Status as of May 21, 2026:
+Status as of May 20, 2026:
 - Partially complete
 - Implemented:
   - editable `Pool-Assignment` workflow for BB / VBM / VBW
@@ -193,12 +196,14 @@ Status as of May 21, 2026:
   - conflict-aware Gym Core solve with primary-vs-secondary weighting
   - `Conflict-Audit` output in `VAYSF_Schedule_*.xlsx`
   - Venue-Estimator rewritten for BC sequential single-classroom model
-    (issue #118, commit on `claude/review-project-status-N2Rxo`)
+  - BC teams included in `Pool-Assignment`
+  - BC shared-athlete edges included in `team_conflicts`
+  - BC cross-sport edges surface in `Conflict-Audit` as planning-only rows
+    until full BC queue scheduling is implemented
 - Next slice (issue #118):
-  - add BC teams to Pool-Assignment tab with up to 3 seeds
-  - include BC teams in cross-sport conflict edges (shared-athlete lookup)
-  - verify BC edges surface in Conflict-Audit tab
   - add Soccer as optional / config-driven sport
+  - decide whether BC should stay planning-only in Layer 2 or move into a
+    fully scheduled sequential room queue later
 
 ### Phase 2 - Racquet conflict engine
 
@@ -633,8 +638,8 @@ they are pure planning artifacts built from the roster data and
 `schedule_input.json` `resources` so an offline build stays self-consistent.
 
 The `Pool-Assignment` tab is the editable Layer-1 seeding workspace for the
-core gym sports. Operators can review the inferred team rows, set `Seed`
-values, and rerun:
+current Phase 1 team sports (`BB`, `VBM`, `VBW`, `BC`). Operators can review
+the inferred team rows, set `Seed` values, and rerun:
 
 ```bash
 python main.py assign-pools --workbook path/to/Schedule_Workbook_YYYY-MM-DD.xlsx

--- a/docs/SCHEDULING.md
+++ b/docs/SCHEDULING.md
@@ -154,7 +154,37 @@ Scope:
 - Bible Challenge - Mixed Team
 - Soccer - Coed Exhibition (optional / config-driven)
 
-Status as of May 20, 2026:
+#### Bible Challenge format (confirmed 2026)
+
+Bible Challenge runs as a **Jeopardy-style game with 3 church teams per game**.
+
+Key constraints the pipeline must respect:
+
+- **Single classroom, sequential only.** There is exactly one Bible Challenge
+  room and games never run concurrently. The scheduling problem for BC is a
+  simple queue, not a resource-allocation problem. There is no "court-hours"
+  model — only total room-minutes.
+- **Round-robin phase.** Each registered BC team plays **2 games** in the
+  round-robin. Total RR games = ⌈N × 2 / 3⌉ where N is the number of teams.
+  Matchup pairing within the round-robin is managed by the organizer; the
+  pipeline provides the pool draw and cross-sport conflict edges only.
+- **Playoff phase.** The **top 9 teams by cumulative Jeopardy score** advance
+  to the playoff. Playoff structure: **3 semi-final games** (3 pools of 3
+  teams) then **1 final game** (3 semi-final winners) = 4 total playoff games.
+  Playoff phase only runs when N ≥ 9 registered teams.
+- **Seeding.** Up to 3 seeds from prior-year winners. Remaining teams enter
+  the draw unseeded. The existing serpentine-fill `assign-pools` workflow
+  applies unchanged.
+- **Per-game duration.** 60 minutes (includes buffer for late starts).
+- **Venue-Estimator model.** BC appears as a separate row in the
+  Venue-Estimator showing total sequential room-hours, not concurrent
+  court-hours. Formula: `(RR games + playoff games) × 60 min`.
+- **Cross-sport conflict edges.** BC teams produce pairwise shared-athlete
+  edges with BB / VBM / VBW teams exactly like any other team sport. An
+  athlete on a BC team who also plays Basketball still generates a
+  primary-vs-secondary conflict edge in `team_conflicts`.
+
+Status as of May 21, 2026:
 - Partially complete
 - Implemented:
   - editable `Pool-Assignment` workflow for BB / VBM / VBW
@@ -162,10 +192,13 @@ Status as of May 20, 2026:
   - Layer 2 shared-athlete conflict edges for BB / VBM / VBW
   - conflict-aware Gym Core solve with primary-vs-secondary weighting
   - `Conflict-Audit` output in `VAYSF_Schedule_*.xlsx`
-- Next slice:
-  - extend the same conflict-aware workflow to Bible Challenge
-  - add Soccer in an optional way so the design stays flexible if Soccer does
-    not return next season
+  - Venue-Estimator rewritten for BC sequential single-classroom model
+    (issue #118, commit on `claude/review-project-status-N2Rxo`)
+- Next slice (issue #118):
+  - add BC teams to Pool-Assignment tab with up to 3 seeds
+  - include BC teams in cross-sport conflict edges (shared-athlete lookup)
+  - verify BC edges surface in Conflict-Audit tab
+  - add Soccer as optional / config-driven sport
 
 ### Phase 2 - Racquet conflict engine
 

--- a/middleware/config.py
+++ b/middleware/config.py
@@ -412,13 +412,15 @@ def is_racquet_sport(sport: str) -> bool:
 # Team sports: one row per event, counting churches with a complete roster.
 # Racquet sports: one row per sport, counting complete pairs/individuals.
 
-# Team sports included in the estimator (roster-based, min-size threshold).
+# Team sports included in the standard court-hours estimator (roster-based,
+# min-size threshold, concurrent multi-court model).
+# Bible Challenge is excluded here — it uses a sequential single-classroom
+# model and is handled separately in _build_venue_capacity_rows.
 COURT_ESTIMATE_EVENTS = [
     SPORT_TYPE["BASKETBALL"],
     SPORT_TYPE["VOLLEYBALL_MEN"],
     SPORT_TYPE["VOLLEYBALL_WOMEN"],
     SPORT_TYPE["SOCCER"],
-    SPORT_TYPE["BIBLE_CHALLENGE"],
 ]
 
 # Racquet sports included in the estimator (entry-based, doubles counted as pairs).
@@ -440,15 +442,23 @@ COURT_ESTIMATE_POOL_GAMES_BASKETBALL       = 2
 COURT_ESTIMATE_POOL_GAMES_VOLLEYBALL_MEN   = 2
 COURT_ESTIMATE_POOL_GAMES_VOLLEYBALL_WOMEN = 2
 COURT_ESTIMATE_POOL_GAMES_SOCCER           = 2
-COURT_ESTIMATE_POOL_GAMES_BIBLE_CHALLENGE  = 2
 
 COURT_ESTIMATE_POOL_GAMES_PER_TEAM = {
     SPORT_TYPE["BASKETBALL"]:       COURT_ESTIMATE_POOL_GAMES_BASKETBALL,
     SPORT_TYPE["VOLLEYBALL_MEN"]:   COURT_ESTIMATE_POOL_GAMES_VOLLEYBALL_MEN,
     SPORT_TYPE["VOLLEYBALL_WOMEN"]: COURT_ESTIMATE_POOL_GAMES_VOLLEYBALL_WOMEN,
     SPORT_TYPE["SOCCER"]:           COURT_ESTIMATE_POOL_GAMES_SOCCER,
-    SPORT_TYPE["BIBLE_CHALLENGE"]:  COURT_ESTIMATE_POOL_GAMES_BIBLE_CHALLENGE,
 }
+
+# Bible Challenge sequential-classroom estimator constants.
+# Format: Jeopardy — 3 church teams per game, games run sequentially in one
+# classroom throughout the event (never concurrent).
+# Round-robin: each team plays 2 games; total RR games = ceil(N * 2 / 3).
+# Playoff: top 9 high-score teams → 3 semi-finals + 1 final = 4 games.
+COURT_ESTIMATE_BC_TEAMS_PER_GAME          = 3
+COURT_ESTIMATE_BC_RR_GAMES_PER_TEAM      = 2
+COURT_ESTIMATE_BC_PLAYOFF_GAMES           = 4   # 3 semis + 1 final
+COURT_ESTIMATE_BC_MIN_TEAMS_FOR_PLAYOFF   = 9
 
 COURT_ESTIMATE_DEFAULT_MINUTES_PER_GAME = 60
 COURT_ESTIMATE_INCLUDE_THIRD_PLACE_GAME = False
@@ -457,7 +467,7 @@ COURT_ESTIMATE_INCLUDE_THIRD_PLACE_GAME = False
 COURT_ESTIMATE_MINUTES_BASKETBALL = 60
 COURT_ESTIMATE_MINUTES_VOLLEYBALL = 60
 COURT_ESTIMATE_MINUTES_SOCCER = 60
-COURT_ESTIMATE_MINUTES_BIBLE_CHALLENGE = 45
+COURT_ESTIMATE_MINUTES_BIBLE_CHALLENGE = 60  # 60 min per game (buffer for late starts)
 COURT_ESTIMATE_MINUTES_BADMINTON = 25
 COURT_ESTIMATE_MINUTES_PICKLEBALL = 20
 COURT_ESTIMATE_MINUTES_PICKLEBALL_35 = 20

--- a/middleware/schedule_workbook.py
+++ b/middleware/schedule_workbook.py
@@ -29,6 +29,11 @@ from config import (
     COURT_ESTIMATE_INCLUDE_THIRD_PLACE_GAME,
     COURT_ESTIMATE_MIN_TEAM_SIZE,
     COURT_ESTIMATE_MINUTES_PER_GAME,
+    COURT_ESTIMATE_MINUTES_BIBLE_CHALLENGE,
+    COURT_ESTIMATE_BC_TEAMS_PER_GAME,
+    COURT_ESTIMATE_BC_RR_GAMES_PER_TEAM,
+    COURT_ESTIMATE_BC_PLAYOFF_GAMES,
+    COURT_ESTIMATE_BC_MIN_TEAMS_FOR_PLAYOFF,
     COURT_ESTIMATE_PLAYOFF_RULES,
     POD_SPORT_ABBREV,
     SCHEDULE_SKETCH_SATURDAY_START,
@@ -929,6 +934,46 @@ class ScheduleWorkbookBuilder:
                 "Total Court Slots": s["total_slots"],
                 "Estimated Court Hours": s["court_hours"],
             })
+
+        # Bible Challenge — sequential single-classroom (Jeopardy, 3 teams/game)
+        # Games never run concurrently; "court hours" = total room hours.
+        bc_event = SPORT_TYPE["BIBLE_CHALLENGE"]
+        bc_min = self._get_min_team_size(bc_event)
+        bc_counts = self._count_estimating_teams(roster_rows, bc_event, bc_min)
+        n_bc = bc_counts["n_estimating"]
+        bc_rr_games = (
+            ceil(n_bc * COURT_ESTIMATE_BC_RR_GAMES_PER_TEAM / COURT_ESTIMATE_BC_TEAMS_PER_GAME)
+            if n_bc > 0 else 0
+        )
+        bc_has_playoff = n_bc >= COURT_ESTIMATE_BC_MIN_TEAMS_FOR_PLAYOFF
+        bc_playoff_games = COURT_ESTIMATE_BC_PLAYOFF_GAMES if bc_has_playoff else 0
+        bc_total = bc_rr_games + bc_playoff_games
+        bc_hours = round(bc_total * COURT_ESTIMATE_MINUTES_BIBLE_CHALLENGE / 60, 2)
+        bc_actual_gpg = (
+            round(bc_rr_games * COURT_ESTIMATE_BC_TEAMS_PER_GAME / n_bc, 1)
+            if n_bc > 0 else 0
+        )
+        bc_note = f"Sequential, 1 classroom — {COURT_ESTIMATE_BC_TEAMS_PER_GAME} teams/game"
+        if not bc_has_playoff:
+            bc_note += f" (< {COURT_ESTIMATE_BC_MIN_TEAMS_FOR_PLAYOFF} teams: no playoff)"
+        rows.append({
+            "Event": bc_event,
+            "Potential Teams/Entries": bc_counts["n_potential"],
+            "Estimating Teams/Entries": n_bc,
+            "Teams": bc_counts["team_codes"],
+            "Target Pool Games/Team": COURT_ESTIMATE_BC_RR_GAMES_PER_TEAM,
+            "Actual Pool Games/Team": bc_actual_gpg,
+            "Pool Composition": bc_note,
+            "BYE Slots": None,
+            "Minutes Per Game": COURT_ESTIMATE_MINUTES_BIBLE_CHALLENGE,
+            "Pool Slots": bc_rr_games,
+            "Playoff Teams": COURT_ESTIMATE_BC_MIN_TEAMS_FOR_PLAYOFF if bc_has_playoff else 0,
+            "Playoff Slots": bc_playoff_games,
+            "Third Place?": "No",
+            "Third Place Slots": 0,
+            "Total Court Slots": bc_total,
+            "Estimated Court Hours": bc_hours,
+        })
 
         # Racquet sports — count complete pairs + singles
         for sport_name in COURT_ESTIMATE_RACQUET_EVENTS:

--- a/middleware/schedule_workbook.py
+++ b/middleware/schedule_workbook.py
@@ -105,8 +105,8 @@ class ScheduleWorkbookBuilder:
     ]
     _POOL_ASSIGNMENT_HEADER_NOTES: Dict[str, str] = {
         "Event": (
-            "Canonical team-sport event this row belongs to. Version 1 focuses on the "
-            "core gym sports used for pool seeding."
+            "Canonical team-sport event this row belongs to. Current Phase 1 "
+            "pool-assignment rows cover BB / VBM / VBW / BC."
         ),
         "Church Team": (
             "Church code contributing this team row, such as RPC or TLC."
@@ -224,8 +224,10 @@ class ScheduleWorkbookBuilder:
             "Configured planning target for pool games per team."
         ),
         "Actual Pool Games/Team": (
-            "Actual average pool games per team after the current pool-normalization logic is "
-            "applied. May differ slightly from the target."
+            "Actual pool-game planning assumption for this event. For the standard team-sport "
+            "model this is the average implied by the normalized pool layout; for Bible "
+            "Challenge it reflects the organizer-facing 2-games-per-team target once enough "
+            "teams exist to run the Jeopardy format."
         ),
         "Pool Composition": (
             "Pool sizes used by the current planning policy, such as 4 + 3 + 3."
@@ -942,20 +944,23 @@ class ScheduleWorkbookBuilder:
         bc_min = self._get_min_team_size(bc_event)
         bc_counts = self._count_estimating_teams(roster_rows, bc_event, bc_min)
         n_bc = bc_counts["n_estimating"]
+        bc_can_run_rr = n_bc >= COURT_ESTIMATE_BC_TEAMS_PER_GAME
         bc_rr_games = (
             ceil(n_bc * COURT_ESTIMATE_BC_RR_GAMES_PER_TEAM / COURT_ESTIMATE_BC_TEAMS_PER_GAME)
-            if n_bc > 0 else 0
+            if bc_can_run_rr else 0
         )
-        bc_has_playoff = n_bc >= COURT_ESTIMATE_BC_MIN_TEAMS_FOR_PLAYOFF
+        bc_has_playoff = bc_can_run_rr and n_bc >= COURT_ESTIMATE_BC_MIN_TEAMS_FOR_PLAYOFF
         bc_playoff_games = COURT_ESTIMATE_BC_PLAYOFF_GAMES if bc_has_playoff else 0
         bc_total = bc_rr_games + bc_playoff_games
         bc_hours = round(bc_total * COURT_ESTIMATE_MINUTES_BIBLE_CHALLENGE / 60, 2)
-        bc_actual_gpg = (
-            round(bc_rr_games * COURT_ESTIMATE_BC_TEAMS_PER_GAME / n_bc, 1)
-            if n_bc > 0 else 0
-        )
+        bc_actual_gpg = COURT_ESTIMATE_BC_RR_GAMES_PER_TEAM if bc_can_run_rr else 0
         bc_note = f"Sequential, 1 classroom — {COURT_ESTIMATE_BC_TEAMS_PER_GAME} teams/game"
-        if not bc_has_playoff:
+        if not bc_can_run_rr and n_bc > 0:
+            bc_note += (
+                f" (waiting for at least {COURT_ESTIMATE_BC_TEAMS_PER_GAME} teams to open "
+                "the round-robin queue)"
+            )
+        elif not bc_has_playoff:
             bc_note += f" (< {COURT_ESTIMATE_BC_MIN_TEAMS_FOR_PLAYOFF} teams: no playoff)"
         rows.append({
             "Event": bc_event,
@@ -1511,7 +1516,7 @@ class ScheduleWorkbookBuilder:
         roster_rows: List[Dict[str, Any]],
         pool_assignment_rows: List[Dict[str, Any]],
     ) -> List[Dict[str, Any]]:
-        """Return cross-sport shared-athlete edges for the core gym sports."""
+        """Return cross-sport shared-athlete edges for the current Phase 1 team sports."""
         team_lookup = cls._build_core_gym_team_lookup(roster_rows)
         if not team_lookup:
             return []
@@ -2276,7 +2281,7 @@ class ScheduleWorkbookBuilder:
                 "   If omitted, the command tries to auto-detect the newest ALL workbook "
                 "beside schedule_input.json or in EXPORT_DIR.\n"
                 "4. Review the planning tabs in this workbook.\n"
-                "5. Edit the Pool-Assignment tab if you want to seed BB/VBM/VBW teams, then run:\n"
+                "5. Edit the Pool-Assignment tab if you want to seed BB/VBM/VBW/BC teams, then run:\n"
                 "   python main.py assign-pools --workbook \"...\\Schedule_Workbook_YYYY-MM-DD.xlsx\"\n"
                 "6. Repeat until venue capacity, seeding, pod planning, and resource IDs look right.",
             ),
@@ -2292,7 +2297,7 @@ class ScheduleWorkbookBuilder:
                 "Tabs In This Workbook",
                 "Summary: operator guide and command cheat sheet.\n"
                 "Venue-Estimator: rough demand estimate for team/racquet sports.\n"
-                "Pool-Assignment: editable BB/VBM/VBW seed and pool-draw workspace.\n"
+                "Pool-Assignment: editable BB/VBM/VBW/BC seed and pool-draw workspace.\n"
                 "Pod-Divisions: planned pod divisions for racquet/pod events.\n"
                 "Pod-Entries-Review: detailed entry review for pod sports.\n"
                 "Court-Schedule-Sketch: quick planning sketch using Layer 1 assumptions.\n"
@@ -4077,6 +4082,7 @@ class ScheduleWorkbookBuilder:
                     f"Edges: {conflict_summary.get('total_edges', 0)}  |  "
                     f"Separated: {conflict_summary.get('separated_edges', 0)}  |  "
                     f"Remaining: {conflict_summary.get('overlapping_edges', 0)}  |  "
+                    f"Planning-only: {conflict_summary.get('planning_only_edges', 0)}  |  "
                     f"Incomplete: {conflict_summary.get('incomplete_edges', 0)}"
                 ),
             ),
@@ -4122,6 +4128,8 @@ class ScheduleWorkbookBuilder:
                 )
                 if row.get("status") == "IncompleteSchedule":
                     row_fill = PatternFill(fgColor="FFF2CC", fill_type="solid")
+                elif row.get("status") == "PlanningOnly":
+                    row_fill = PatternFill(fgColor="DDEBF7", fill_type="solid")
                 for ci, (col, _width) in enumerate(audit_headers, start=1):
                     cell = ws3.cell(row=ri3, column=ci, value=row.get(col, ""))
                     cell.fill = row_fill

--- a/middleware/schedule_workbook.py
+++ b/middleware/schedule_workbook.py
@@ -101,6 +101,7 @@ class ScheduleWorkbookBuilder:
         (SPORT_TYPE["BASKETBALL"], "BBM"),
         (SPORT_TYPE["VOLLEYBALL_MEN"], "VBM"),
         (SPORT_TYPE["VOLLEYBALL_WOMEN"], "VBW"),
+        (SPORT_TYPE["BIBLE_CHALLENGE"], "BC"),
     ]
     _POOL_ASSIGNMENT_HEADER_NOTES: Dict[str, str] = {
         "Event": (

--- a/middleware/scheduler.py
+++ b/middleware/scheduler.py
@@ -176,12 +176,18 @@ def build_conflict_audit(
             "total_edges": 0,
             "separated_edges": 0,
             "overlapping_edges": 0,
+            "planning_only_edges": 0,
             "incomplete_edges": 0,
             "remaining_primary_overlap_penalty": 0,
             "remaining_secondary_overlap_penalty": 0,
         }, []
 
     game_meta = {game["game_id"]: game for game in schedule_input.get("games", [])}
+    events_with_games = {
+        str(game.get("event") or "").strip()
+        for game in schedule_input.get("games", [])
+        if str(game.get("event") or "").strip()
+    }
     games_by_team: dict[str, list[dict[str, Any]]] = defaultdict(list)
     for assignment in assignments:
         game = game_meta.get(assignment.get("game_id"), {})
@@ -198,6 +204,7 @@ def build_conflict_audit(
     rows: list[dict[str, Any]] = []
     separated_edges = 0
     overlapping_edges = 0
+    planning_only_edges = 0
     incomplete_edges = 0
     remaining_primary_overlap_penalty = 0
     remaining_secondary_overlap_penalty = 0
@@ -206,6 +213,8 @@ def build_conflict_audit(
         counts = _normalize_conflict_edge_counts(edge)
         team_a_id = str(edge.get("team_a_id") or "").strip()
         team_b_id = str(edge.get("team_b_id") or "").strip()
+        event_a = str(edge.get("event_a") or "").strip()
+        event_b = str(edge.get("event_b") or "").strip()
         team_a_games = games_by_team.get(team_a_id, [])
         team_b_games = games_by_team.get(team_b_id, [])
         overlap_pairs: list[str] = []
@@ -216,7 +225,10 @@ def build_conflict_audit(
                         f"{game_a['game_id']} vs {game_b['game_id']} @ {game_a['slot']}"
                     )
 
-        if not team_a_games or not team_b_games:
+        if event_a not in events_with_games or event_b not in events_with_games:
+            status = "PlanningOnly"
+            planning_only_edges += 1
+        elif not team_a_games or not team_b_games:
             status = "IncompleteSchedule"
             incomplete_edges += 1
         elif overlap_pairs:
@@ -230,9 +242,9 @@ def build_conflict_audit(
 
         rows.append({
             "team_a_label": str(edge.get("team_a_label") or team_a_id),
-            "event_a": str(edge.get("event_a") or ""),
+            "event_a": event_a,
             "team_b_label": str(edge.get("team_b_label") or team_b_id),
-            "event_b": str(edge.get("event_b") or ""),
+            "event_b": event_b,
             "shared_count": counts["shared_count"],
             "primary_overlap_count": counts["primary"],
             "secondary_only_count": counts["secondary"],
@@ -248,6 +260,7 @@ def build_conflict_audit(
         "total_edges": len(rows),
         "separated_edges": separated_edges,
         "overlapping_edges": overlapping_edges,
+        "planning_only_edges": planning_only_edges,
         "incomplete_edges": incomplete_edges,
         "remaining_primary_overlap_penalty": remaining_primary_overlap_penalty,
         "remaining_secondary_overlap_penalty": remaining_secondary_overlap_penalty,

--- a/middleware/tests/test_schedule_workbook.py
+++ b/middleware/tests/test_schedule_workbook.py
@@ -2321,3 +2321,117 @@ def test_bc_minutes_per_game_is_60():
     """Confirm COURT_ESTIMATE_MINUTES_BIBLE_CHALLENGE was updated to 60."""
     from config import COURT_ESTIMATE_MINUTES_BIBLE_CHALLENGE
     assert COURT_ESTIMATE_MINUTES_BIBLE_CHALLENGE == 60
+
+
+# ---------------------------------------------------------------------------
+# Bible Challenge Pool-Assignment & conflict-edge tests (Issue #118)
+# ---------------------------------------------------------------------------
+
+def test_bc_appears_in_pool_assignment_base_rows():
+    """BC teams meeting min_team_size=3 should produce Pool-Assignment rows."""
+    builder = ScheduleWorkbookBuilder()
+    churches = ["RPC", "OCB", "ANH"]
+    rows = _bc_roster(churches, n_per_church=3)
+    base_rows = builder._build_pool_assignment_base_rows(rows)
+    bc_rows = [r for r in base_rows if r["Event"] == SPORT_TYPE["BIBLE_CHALLENGE"]]
+    assert {r["Team ID"] for r in bc_rows} == set(churches)
+    for r in bc_rows:
+        assert r["Min Team Size"] == 3
+        assert r["Roster Count"] == 3
+
+
+def test_bc_pool_assignment_below_min_team_size_excluded():
+    """BC team with fewer than 3 roster members is excluded from Pool-Assignment."""
+    builder = ScheduleWorkbookBuilder()
+    rows = (
+        _bc_roster(["RPC"], n_per_church=3)
+        + _bc_roster(["OCB"], n_per_church=2)  # below min
+    )
+    base_rows = builder._build_pool_assignment_base_rows(rows)
+    bc_rows = [r for r in base_rows if r["Event"] == SPORT_TYPE["BIBLE_CHALLENGE"]]
+    assert {r["Team ID"] for r in bc_rows} == {"RPC"}
+
+
+def test_bc_cross_sport_conflict_edge_with_basketball(tmp_path):
+    """BC and BB teams sharing an athlete must produce a team_conflicts edge."""
+    builder = ScheduleWorkbookBuilder()
+    shared_id = 42
+    # Need ≥ 2 BB teams and ≥ 2 BC teams so the pool-assignment logic
+    # doesn't fall into the "WaitingForMoreTeams" branch.
+    bb_rpc = [
+        {
+            "Church Team": "RPC",
+            "sport_type": SPORT_TYPE["BASKETBALL"],
+            "sport_gender": "Men",
+            "sport_format": "Team",
+            "Participant ID (WP)": pid,
+            "participant_primary_sport": SPORT_TYPE["BASKETBALL"],
+        }
+        for pid in range(40, 45)  # includes shared_id=42
+    ]
+    bb_anh = [
+        {
+            "Church Team": "ANH",
+            "sport_type": SPORT_TYPE["BASKETBALL"],
+            "sport_gender": "Men",
+            "sport_format": "Team",
+            "Participant ID (WP)": pid,
+            "participant_primary_sport": SPORT_TYPE["BASKETBALL"],
+        }
+        for pid in range(50, 55)
+    ]
+    bc_ocb = [
+        {
+            "Church Team": "OCB",
+            "sport_type": SPORT_TYPE["BIBLE_CHALLENGE"],
+            "sport_gender": "Mixed",
+            "sport_format": "Team",
+            "Participant ID (WP)": pid,
+            "participant_primary_sport": SPORT_TYPE["BASKETBALL"],  # primary is BB
+        }
+        for pid in (shared_id, 90, 91)  # #42 is shared with RPC's BB team
+    ]
+    bc_tlc = [
+        {
+            "Church Team": "TLC",
+            "sport_type": SPORT_TYPE["BIBLE_CHALLENGE"],
+            "sport_gender": "Mixed",
+            "sport_format": "Team",
+            "Participant ID (WP)": pid,
+            "participant_primary_sport": SPORT_TYPE["BIBLE_CHALLENGE"],
+        }
+        for pid in (95, 96, 97)
+    ]
+    roster_rows = bb_rpc + bb_anh + bc_ocb + bc_tlc
+
+    si = builder._build_schedule_input(roster_rows, [], tmp_path / "no_venue.xlsx")
+
+    bc_bb_edges = [
+        edge for edge in si["team_conflicts"]
+        if {edge.get("event_a"), edge.get("event_b")}
+           == {SPORT_TYPE["BASKETBALL"], SPORT_TYPE["BIBLE_CHALLENGE"]}
+    ]
+    assert len(bc_bb_edges) == 1
+    edge = bc_bb_edges[0]
+    assert edge["shared_count"] == 1
+    assert edge["primary_overlap_count"] == 1  # athlete's primary is BB
+    assert edge["secondary_only_count"] == 0
+
+
+def test_bc_pool_assignment_does_not_create_gym_games(tmp_path):
+    """BC pool-assignment rows must NOT generate Gym Core games (BC is not a gym sport)."""
+    builder = ScheduleWorkbookBuilder()
+    bc_rows = _bc_roster(["RPC", "OCB", "ANH"], n_per_church=3)
+
+    si = builder._build_schedule_input(bc_rows, [], tmp_path / "no_venue.xlsx")
+    bc_games = [g for g in si.get("games", []) if g.get("event") == SPORT_TYPE["BIBLE_CHALLENGE"]]
+    assert bc_games == []
+
+
+def test_bc_event_in_pool_assignment_defs():
+    """BC must be the 4th entry in _POOL_ASSIGNMENT_EVENT_DEFS with prefix 'BC'."""
+    defs = ScheduleWorkbookBuilder._POOL_ASSIGNMENT_EVENT_DEFS
+    assert (SPORT_TYPE["BIBLE_CHALLENGE"], "BC") in defs
+    # Sort index makes BC the last (4th) event
+    idx = ScheduleWorkbookBuilder._event_sort_index(SPORT_TYPE["BIBLE_CHALLENGE"])
+    assert idx == 3

--- a/middleware/tests/test_schedule_workbook.py
+++ b/middleware/tests/test_schedule_workbook.py
@@ -218,6 +218,7 @@ def test_write_schedule_workbook_creates_planning_tabs(tmp_path):
     assert "Church_Team_Status_ALL" in summary_text
     assert "run-schedule.bat" in summary_text
     assert "assign-pools" in summary_text
+    assert "BB/VBM/VBW/BC" in summary_text
     venue_ws = wb["Venue-Estimator"]
     assert venue_ws["A1"].comment is not None
     assert "Canonical event name" in venue_ws["A1"].comment.text
@@ -2065,6 +2066,24 @@ def test_write_schedule_output_report_tab3_conflict_audit(tmp_path):
     assert ws.cell(row=7, column=8).value == "SeparatedInSchedule"
 
 
+def test_write_schedule_output_report_tab3_planning_only_conflict_audit(tmp_path):
+    """Conflict-Audit should render planning-only rows distinctly."""
+    import openpyxl
+
+    so, si = _make_schedule_pair()
+    so["conflict_audit_summary"]["planning_only_edges"] = 1
+    so["conflict_audit_summary"]["separated_edges"] = 0
+    so["conflict_audit"][0]["event_b"] = SPORT_TYPE["BIBLE_CHALLENGE"]
+    so["conflict_audit"][0]["status"] = "PlanningOnly"
+    so["conflict_audit"][0]["scheduled_team_b_games"] = 0
+
+    out = tmp_path / "sched.xlsx"
+    ScheduleWorkbookBuilder._write_schedule_output_report(out, so, si)
+    ws = openpyxl.load_workbook(out)["Conflict-Audit"]
+    assert "Planning-only" in str(ws.cell(row=3, column=2).value)
+    assert ws.cell(row=7, column=8).value == "PlanningOnly"
+
+
 def test_write_schedule_output_report_unscheduled_section(tmp_path):
     """Unscheduled section appears in Schedule-by-Sport when games are unscheduled."""
     import openpyxl
@@ -2271,6 +2290,7 @@ def test_bc_venue_estimator_rr_game_count_12_teams():
 
     assert bc_row["Estimating Teams/Entries"] == 12
     assert bc_row["Pool Slots"] == 8                        # ceil(12*2/3)
+    assert bc_row["Actual Pool Games/Team"] == 2
     assert bc_row["Playoff Teams"] == COURT_ESTIMATE_BC_MIN_TEAMS_FOR_PLAYOFF
     assert bc_row["Playoff Slots"] == COURT_ESTIMATE_BC_PLAYOFF_GAMES  # 4
     assert bc_row["Total Court Slots"] == 12                # 8 RR + 4 playoff
@@ -2292,6 +2312,7 @@ def test_bc_venue_estimator_no_playoff_when_fewer_than_9_teams():
 
     assert bc_row["Estimating Teams/Entries"] == 8
     assert bc_row["Pool Slots"] == 6                        # ceil(8*2/3) = ceil(5.33) = 6
+    assert bc_row["Actual Pool Games/Team"] == 2
     assert bc_row["Playoff Teams"] == 0
     assert bc_row["Playoff Slots"] == 0
     assert bc_row["Total Court Slots"] == 6
@@ -2305,6 +2326,7 @@ def test_bc_venue_estimator_zero_teams():
     bc_row = next(r for r in capacity_rows if r["Event"] == SPORT_TYPE["BIBLE_CHALLENGE"])
 
     assert bc_row["Estimating Teams/Entries"] == 0
+    assert bc_row["Actual Pool Games/Team"] == 0
     assert bc_row["Pool Slots"] == 0
     assert bc_row["Playoff Slots"] == 0
     assert bc_row["Total Court Slots"] == 0
@@ -2315,6 +2337,20 @@ def test_bc_venue_estimator_not_in_court_hours_model():
     """BC must NOT appear via the standard concurrent court-hours COURT_ESTIMATE_EVENTS path."""
     from config import COURT_ESTIMATE_EVENTS
     assert SPORT_TYPE["BIBLE_CHALLENGE"] not in COURT_ESTIMATE_EVENTS
+
+
+def test_bc_venue_estimator_waits_for_first_three_team_game():
+    """With only 2 BC teams, the sequential queue should remain in waiting mode."""
+    builder = ScheduleWorkbookBuilder()
+    rows = _bc_roster(["RPC", "OCB"])
+    capacity_rows = builder._build_venue_capacity_rows(rows)
+    bc_row = next(r for r in capacity_rows if r["Event"] == SPORT_TYPE["BIBLE_CHALLENGE"])
+
+    assert bc_row["Estimating Teams/Entries"] == 2
+    assert bc_row["Actual Pool Games/Team"] == 0
+    assert bc_row["Pool Slots"] == 0
+    assert bc_row["Total Court Slots"] == 0
+    assert "waiting for at least 3 teams" in bc_row["Pool Composition"]
 
 
 def test_bc_minutes_per_game_is_60():

--- a/middleware/tests/test_schedule_workbook.py
+++ b/middleware/tests/test_schedule_workbook.py
@@ -2239,3 +2239,85 @@ def test_write_schedule_output_report_merges_gym_core_day_sections(tmp_path):
     assert any("VBM-01" in v for v in string_values)
     assert any("VBM-02" in v for v in string_values)
     assert any("VBW-01" in v for v in string_values)
+
+
+# ---------------------------------------------------------------------------
+# Bible Challenge Venue-Estimator tests (Issue #118)
+# ---------------------------------------------------------------------------
+
+def _bc_roster(church_codes, n_per_church=3):
+    """Build minimal BC roster rows — enough to meet min_team_size=3."""
+    rows = []
+    for code in church_codes:
+        for _ in range(n_per_church):
+            rows.append({"Church Team": code, "sport_type": SPORT_TYPE["BIBLE_CHALLENGE"], "sport_gender": "Mixed"})
+    return rows
+
+
+def test_bc_venue_estimator_rr_game_count_12_teams():
+    """12 BC teams × 2 games/team ÷ 3 teams/game = 8 RR games."""
+    from config import (
+        COURT_ESTIMATE_BC_TEAMS_PER_GAME,
+        COURT_ESTIMATE_BC_RR_GAMES_PER_TEAM,
+        COURT_ESTIMATE_BC_PLAYOFF_GAMES,
+        COURT_ESTIMATE_BC_MIN_TEAMS_FOR_PLAYOFF,
+        COURT_ESTIMATE_MINUTES_BIBLE_CHALLENGE,
+    )
+    builder = ScheduleWorkbookBuilder()
+    churches = [f"C{i:02d}" for i in range(1, 13)]  # 12 teams
+    rows = _bc_roster(churches)
+    capacity_rows = builder._build_venue_capacity_rows(rows)
+    bc_row = next(r for r in capacity_rows if r["Event"] == SPORT_TYPE["BIBLE_CHALLENGE"])
+
+    assert bc_row["Estimating Teams/Entries"] == 12
+    assert bc_row["Pool Slots"] == 8                        # ceil(12*2/3)
+    assert bc_row["Playoff Teams"] == COURT_ESTIMATE_BC_MIN_TEAMS_FOR_PLAYOFF
+    assert bc_row["Playoff Slots"] == COURT_ESTIMATE_BC_PLAYOFF_GAMES  # 4
+    assert bc_row["Total Court Slots"] == 12                # 8 RR + 4 playoff
+    assert bc_row["Minutes Per Game"] == COURT_ESTIMATE_MINUTES_BIBLE_CHALLENGE  # 60
+    assert bc_row["Estimated Court Hours"] == 12.0          # 12 games × 60 min / 60
+    assert bc_row["Third Place?"] == "No"
+    assert "Sequential" in bc_row["Pool Composition"]
+    assert "1 classroom" in bc_row["Pool Composition"]
+
+
+def test_bc_venue_estimator_no_playoff_when_fewer_than_9_teams():
+    """8 BC teams → no playoff (need ≥ 9). Pool Slots = ceil(8*2/3) = 6."""
+    from config import COURT_ESTIMATE_BC_MIN_TEAMS_FOR_PLAYOFF
+    builder = ScheduleWorkbookBuilder()
+    churches = [f"C{i:02d}" for i in range(1, 9)]  # 8 teams
+    rows = _bc_roster(churches)
+    capacity_rows = builder._build_venue_capacity_rows(rows)
+    bc_row = next(r for r in capacity_rows if r["Event"] == SPORT_TYPE["BIBLE_CHALLENGE"])
+
+    assert bc_row["Estimating Teams/Entries"] == 8
+    assert bc_row["Pool Slots"] == 6                        # ceil(8*2/3) = ceil(5.33) = 6
+    assert bc_row["Playoff Teams"] == 0
+    assert bc_row["Playoff Slots"] == 0
+    assert bc_row["Total Court Slots"] == 6
+    assert f"< {COURT_ESTIMATE_BC_MIN_TEAMS_FOR_PLAYOFF}" in bc_row["Pool Composition"]
+
+
+def test_bc_venue_estimator_zero_teams():
+    """0 BC teams → all zeros, no crash."""
+    builder = ScheduleWorkbookBuilder()
+    capacity_rows = builder._build_venue_capacity_rows([])
+    bc_row = next(r for r in capacity_rows if r["Event"] == SPORT_TYPE["BIBLE_CHALLENGE"])
+
+    assert bc_row["Estimating Teams/Entries"] == 0
+    assert bc_row["Pool Slots"] == 0
+    assert bc_row["Playoff Slots"] == 0
+    assert bc_row["Total Court Slots"] == 0
+    assert bc_row["Estimated Court Hours"] == 0.0
+
+
+def test_bc_venue_estimator_not_in_court_hours_model():
+    """BC must NOT appear via the standard concurrent court-hours COURT_ESTIMATE_EVENTS path."""
+    from config import COURT_ESTIMATE_EVENTS
+    assert SPORT_TYPE["BIBLE_CHALLENGE"] not in COURT_ESTIMATE_EVENTS
+
+
+def test_bc_minutes_per_game_is_60():
+    """Confirm COURT_ESTIMATE_MINUTES_BIBLE_CHALLENGE was updated to 60."""
+    from config import COURT_ESTIMATE_MINUTES_BIBLE_CHALLENGE
+    assert COURT_ESTIMATE_MINUTES_BIBLE_CHALLENGE == 60

--- a/middleware/tests/test_scheduler.py
+++ b/middleware/tests/test_scheduler.py
@@ -90,6 +90,51 @@ def test_normalize_conflict_edge_counts_derives_secondary_only():
     }
 
 
+def test_build_conflict_audit_marks_unscheduled_event_as_planning_only():
+    """Edges touching an event with no Layer-2 games should be planning-only, not incomplete."""
+    from scheduler import build_conflict_audit
+
+    schedule_input = {
+        "games": [
+            {
+                "game_id": "BBM-01",
+                "event": "Basketball - Men Team",
+                "stage": "Pool",
+                "pool_id": "P1",
+                "round": 1,
+                "team_a_id": "BBM::RPC",
+                "team_b_id": "BBM::ANH",
+                "duration_minutes": 60,
+                "resource_type": "Basketball Court",
+            }
+        ],
+        "resources": [],
+        "team_conflicts": [
+            {
+                "team_a_id": "BBM::RPC",
+                "team_a_label": "RPC",
+                "event_a": "Basketball - Men Team",
+                "team_b_id": "BC::OCB",
+                "team_b_label": "OCB",
+                "event_b": "Bible Challenge - Mixed Team",
+                "shared_count": 1,
+                "primary_overlap_count": 1,
+                "secondary_only_count": 0,
+                "shared_participant_names": ["An"],
+            }
+        ],
+    }
+    assignments = [
+        {"game_id": "BBM-01", "resource_id": "BB-1", "slot": "Sat-1-08:00"}
+    ]
+
+    summary, rows = build_conflict_audit(schedule_input, assignments)
+
+    assert summary["planning_only_edges"] == 1
+    assert summary["incomplete_edges"] == 0
+    assert rows[0]["status"] == "PlanningOnly"
+
+
 # ---------------------------------------------------------------------------
 # load_schedule_input
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Phase 1 extension for Bible Challenge. Implements issue #118.

This is the same content as #119 (closed due to merge conflicts caused by the squash-merge of #117) cherry-picked onto a clean branch off `main`.

Three commits:

- **Rewrite Venue-Estimator for BC's sequential single-classroom Jeopardy model.** Removes BC from `COURT_ESTIMATE_EVENTS` (concurrent court-hours path) and adds dedicated BC logic: `⌈N × 2 / 3⌉` RR games + 4 playoff games (only when N ≥ 9), 60 min/game. Adds 4 new BC config constants.
- **Include BC teams in Pool-Assignment and cross-sport conflict edges** by adding `(SPORT_TYPE["BIBLE_CHALLENGE"], "BC")` to `_POOL_ASSIGNMENT_EVENT_DEFS`. BC seeding, serpentine fill, and BC↔BB/VBM/VBW shared-athlete edges all flow from the existing generic code.
- **Live-testing fixes by Bumble:**
  - New `PlanningOnly` status in `build_conflict_audit` for edges whose event has no Layer-2 games (cleaner semantics than `IncompleteSchedule`).
  - `bc_can_run_rr` guard fixes a bug where the estimator computed RR games for fewer than 3 BC teams.
  - Light-blue cell fill for `PlanningOnly` rows in the Conflict-Audit tab.
  - Tooltip / summary / changelog updates.

## Confirmed 2026 Bible Challenge format (documented in `docs/SCHEDULING.md`)

- Jeopardy-style, **3 church teams per game**, single classroom, **always sequential**.
- Round-robin: each team plays **2 games**; total = ⌈N × 2 / 3⌉.
- Playoff: top 9 by cumulative score → 3 semis + 1 final = 4 games (only when N ≥ 9).
- Per-game duration: **60 min** (buffer for late starts).
- Up to 3 seeds from prior-year winners.

## Test plan

- [x] `python3 -m pytest tests/ -q` — **363 passed** (up from 350 on main).
- [x] Live data run by Bumble (`export-church-teams` → `build-schedule-workbook` → `assign-pools` → `solve-schedule` → `produce-schedule`); resulting fixes captured in the third commit.

## Out of scope (future work for #118 follow-ups)

- Soccer optional / config-driven sport.
- 3-team game schema (`team_ids: [a,b,c]`) — only needed if the pipeline eventually publishes the BC matchup slate. Cross-sport conflict math is pairwise and works without it.
- BC matchup-slate generation and playoff bracket — organizer-managed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EHEhRFWLFoXEpBDNuE5s4g)_