### PR TITLE
Soccer Phase 1: optional / config-driven Coed Exhibition support — closes #118

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 ## Unreleased
 
 ### New Features
+- Added Soccer (Coed Exhibition) Phase-1 planning support
+  - New `SOCCER_ENABLED` config flag (default `True` for 2026); set to `False` to fully remove Soccer from Pool-Assignment, Venue-Estimator, and conflict edges
+  - `Pool-Assignment` now includes Soccer team rows (prefix `SOC`) alongside BB / VBM / VBW / BC, with up-to-3 seeds
+  - Soccer shared-athlete edges with BB / VBM / VBW / BC included in `team_conflicts`; surface in `Conflict-Audit` as `PlanningOnly` rows since Soccer fields are organizer-scheduled rather than solved by Gym Core
+  - Completes Phase 1 of the scheduling roadmap for the 2026 season
+
 - Added Bible Challenge Phase-1 planning support
   - `Venue-Estimator` now treats Bible Challenge as a sequential single-classroom Jeopardy queue instead of a normal concurrent court-hours sport
   - `Pool-Assignment` now includes BC team rows alongside BB / VBM / VBW

--- a/docs/SCHEDULING.md
+++ b/docs/SCHEDULING.md
@@ -187,8 +187,8 @@ Key constraints the pipeline must respect:
   athlete on a BC team who also plays Basketball still generates a
   primary-vs-secondary conflict edge in `team_conflicts`.
 
-Status as of May 20, 2026:
-- Partially complete
+Status as of May 21, 2026:
+- Phase 1 complete (for the 2026 season)
 - Implemented:
   - editable `Pool-Assignment` workflow for BB / VBM / VBW
   - persisted seeded pool draw via `pool_assignments.json`
@@ -200,10 +200,29 @@ Status as of May 20, 2026:
   - BC shared-athlete edges included in `team_conflicts`
   - BC cross-sport edges surface in `Conflict-Audit` as planning-only rows
     until full BC queue scheduling is implemented
-- Next slice (issue #118):
-  - add Soccer as optional / config-driven sport
-  - decide whether BC should stay planning-only in Layer 2 or move into a
-    fully scheduled sequential room queue later
+  - Soccer included in `Pool-Assignment` and cross-sport conflict edges via
+    the `SOCCER_ENABLED` config flag (default `True`). When set to `False`,
+    Soccer is fully removed from outputs so the design stays flexible if the
+    Coed Exhibition does not return in future seasons.
+
+#### Soccer (optional, config-driven)
+
+Soccer - Coed Exhibition is gated on `SOCCER_ENABLED` in `config.py`:
+
+- **`SOCCER_ENABLED = True`** (current 2026 default): Soccer appears in
+  `Venue-Estimator` (standard concurrent court-hours model on Soccer Fields),
+  in `Pool-Assignment` with up to-3 seeds, and produces shared-athlete
+  conflict edges with BB / VBM / VBW / BC in `team_conflicts`. Soccer games
+  are not generated for the Gym Core solver (Soccer uses dedicated fields,
+  not gym courts) — the organizer manages the Soccer field schedule.
+- **`SOCCER_ENABLED = False`**: Soccer is removed from `COURT_ESTIMATE_EVENTS`
+  and from `_POOL_ASSIGNMENT_EVENT_DEFS`. The pipeline produces no Soccer
+  rows even if stray Soccer registrations exist (which would be a
+  registration-form error in that case).
+
+Future enhancement (out of scope for #118): tie Soccer scheduling into a
+dedicated sequential Soccer-fields queue, similar to BC's planning-only
+treatment today.
 
 ### Phase 2 - Racquet conflict engine
 
@@ -638,7 +657,8 @@ they are pure planning artifacts built from the roster data and
 `schedule_input.json` `resources` so an offline build stays self-consistent.
 
 The `Pool-Assignment` tab is the editable Layer-1 seeding workspace for the
-current Phase 1 team sports (`BB`, `VBM`, `VBW`, `BC`). Operators can review
+current Phase 1 team sports (`BB`, `VBM`, `VBW`, `BC`, and `SOC` when
+`SOCCER_ENABLED`). Operators can review
 the inferred team rows, set `Seed` values, and rerun:
 
 ```bash

--- a/middleware/config.py
+++ b/middleware/config.py
@@ -111,6 +111,14 @@ SPORT_TYPE = {
 SPORT_UNSELECTED = "Unselected/NA"
 DEFAULT_SPORT = "default"
 
+# Soccer - Coed Exhibition is an optional team sport that may not run every
+# season. Toggle this flag to remove Soccer from the planning pipeline:
+#   - True: Soccer appears in Pool-Assignment, Venue-Estimator, and cross-sport
+#     conflict edges with BB / VBM / VBW / BC.
+#   - False: Soccer is fully excluded from outputs even if there are stray
+#     Soccer registrations (treated as registration error in that case).
+SOCCER_ENABLED = True
+
 # Sport Category Classification
 SPORT_CATEGORY = {
     "TEAM": "Team",
@@ -416,12 +424,15 @@ def is_racquet_sport(sport: str) -> bool:
 # min-size threshold, concurrent multi-court model).
 # Bible Challenge is excluded here — it uses a sequential single-classroom
 # model and is handled separately in _build_venue_capacity_rows.
+# Soccer is included only when SOCCER_ENABLED is True (Coed Exhibition is
+# optional and may not return every season).
 COURT_ESTIMATE_EVENTS = [
     SPORT_TYPE["BASKETBALL"],
     SPORT_TYPE["VOLLEYBALL_MEN"],
     SPORT_TYPE["VOLLEYBALL_WOMEN"],
-    SPORT_TYPE["SOCCER"],
 ]
+if SOCCER_ENABLED:
+    COURT_ESTIMATE_EVENTS.append(SPORT_TYPE["SOCCER"])
 
 # Racquet sports included in the estimator (entry-based, doubles counted as pairs).
 COURT_ESTIMATE_RACQUET_EVENTS = [

--- a/middleware/schedule_workbook.py
+++ b/middleware/schedule_workbook.py
@@ -19,6 +19,7 @@ from math import ceil
 from config import (
     SPORT_TYPE,
     SPORT_FORMAT,
+    SOCCER_ENABLED,
     RACQUET_SPORTS,
     is_racquet_sport,
     COURT_ESTIMATE_EVENTS,
@@ -102,7 +103,9 @@ class ScheduleWorkbookBuilder:
         (SPORT_TYPE["VOLLEYBALL_MEN"], "VBM"),
         (SPORT_TYPE["VOLLEYBALL_WOMEN"], "VBW"),
         (SPORT_TYPE["BIBLE_CHALLENGE"], "BC"),
-    ]
+    ] + (
+        [(SPORT_TYPE["SOCCER"], "SOC")] if SOCCER_ENABLED else []
+    )
     _POOL_ASSIGNMENT_HEADER_NOTES: Dict[str, str] = {
         "Event": (
             "Canonical team-sport event this row belongs to. Current Phase 1 "
@@ -2281,7 +2284,7 @@ class ScheduleWorkbookBuilder:
                 "   If omitted, the command tries to auto-detect the newest ALL workbook "
                 "beside schedule_input.json or in EXPORT_DIR.\n"
                 "4. Review the planning tabs in this workbook.\n"
-                "5. Edit the Pool-Assignment tab if you want to seed BB/VBM/VBW/BC teams, then run:\n"
+                "5. Edit the Pool-Assignment tab if you want to seed BB/VBM/VBW/BC/SOC teams, then run:\n"
                 "   python main.py assign-pools --workbook \"...\\Schedule_Workbook_YYYY-MM-DD.xlsx\"\n"
                 "6. Repeat until venue capacity, seeding, pod planning, and resource IDs look right.",
             ),
@@ -2297,7 +2300,7 @@ class ScheduleWorkbookBuilder:
                 "Tabs In This Workbook",
                 "Summary: operator guide and command cheat sheet.\n"
                 "Venue-Estimator: rough demand estimate for team/racquet sports.\n"
-                "Pool-Assignment: editable BB/VBM/VBW/BC seed and pool-draw workspace.\n"
+                "Pool-Assignment: editable BB/VBM/VBW/BC/SOC seed and pool-draw workspace.\n"
                 "Pod-Divisions: planned pod divisions for racquet/pod events.\n"
                 "Pod-Entries-Review: detailed entry review for pod sports.\n"
                 "Court-Schedule-Sketch: quick planning sketch using Layer 1 assumptions.\n"

--- a/middleware/tests/test_schedule_workbook.py
+++ b/middleware/tests/test_schedule_workbook.py
@@ -218,7 +218,7 @@ def test_write_schedule_workbook_creates_planning_tabs(tmp_path):
     assert "Church_Team_Status_ALL" in summary_text
     assert "run-schedule.bat" in summary_text
     assert "assign-pools" in summary_text
-    assert "BB/VBM/VBW/BC" in summary_text
+    assert "BB/VBM/VBW/BC/SOC" in summary_text
     venue_ws = wb["Venue-Estimator"]
     assert venue_ws["A1"].comment is not None
     assert "Canonical event name" in venue_ws["A1"].comment.text
@@ -2471,3 +2471,151 @@ def test_bc_event_in_pool_assignment_defs():
     # Sort index makes BC the last (4th) event
     idx = ScheduleWorkbookBuilder._event_sort_index(SPORT_TYPE["BIBLE_CHALLENGE"])
     assert idx == 3
+
+
+# ---------------------------------------------------------------------------
+# Soccer (optional / config-driven) tests — Issue #118
+# ---------------------------------------------------------------------------
+
+def _soccer_roster(church_codes, n_per_church=4):
+    """Build minimal Soccer roster rows — enough to meet min_team_size=4."""
+    rows = []
+    for code in church_codes:
+        for _ in range(n_per_church):
+            rows.append({"Church Team": code, "sport_type": SPORT_TYPE["SOCCER"], "sport_gender": "Mixed"})
+    return rows
+
+
+def test_soccer_in_pool_assignment_defs_when_enabled():
+    """When SOCCER_ENABLED is True (default), Soccer is included in pool defs as 5th entry."""
+    from config import SOCCER_ENABLED
+    assert SOCCER_ENABLED is True
+    defs = ScheduleWorkbookBuilder._POOL_ASSIGNMENT_EVENT_DEFS
+    assert (SPORT_TYPE["SOCCER"], "SOC") in defs
+    idx = ScheduleWorkbookBuilder._event_sort_index(SPORT_TYPE["SOCCER"])
+    assert idx == 4  # after BB(0), VBM(1), VBW(2), BC(3)
+
+
+def test_soccer_in_court_estimate_events_when_enabled():
+    """Soccer should appear in the standard court-hours estimator when enabled."""
+    from config import COURT_ESTIMATE_EVENTS, SOCCER_ENABLED
+    assert SOCCER_ENABLED is True
+    assert SPORT_TYPE["SOCCER"] in COURT_ESTIMATE_EVENTS
+
+
+def test_soccer_appears_in_pool_assignment_base_rows():
+    """Soccer teams meeting min_team_size=4 should produce Pool-Assignment rows."""
+    builder = ScheduleWorkbookBuilder()
+    churches = ["RPC", "OCB", "ANH"]
+    rows = _soccer_roster(churches, n_per_church=4)
+    base_rows = builder._build_pool_assignment_base_rows(rows)
+    soccer_rows = [r for r in base_rows if r["Event"] == SPORT_TYPE["SOCCER"]]
+    assert {r["Team ID"] for r in soccer_rows} == set(churches)
+    for r in soccer_rows:
+        assert r["Min Team Size"] == 4
+
+
+def test_soccer_pool_assignment_below_min_team_size_excluded():
+    """Soccer team with fewer than 4 roster members is excluded from Pool-Assignment."""
+    builder = ScheduleWorkbookBuilder()
+    rows = (
+        _soccer_roster(["RPC"], n_per_church=4)
+        + _soccer_roster(["OCB"], n_per_church=3)  # below min
+    )
+    base_rows = builder._build_pool_assignment_base_rows(rows)
+    soccer_rows = [r for r in base_rows if r["Event"] == SPORT_TYPE["SOCCER"]]
+    assert {r["Team ID"] for r in soccer_rows} == {"RPC"}
+
+
+def test_soccer_cross_sport_conflict_edge_with_basketball(tmp_path):
+    """Soccer and BB teams sharing an athlete must produce a team_conflicts edge."""
+    builder = ScheduleWorkbookBuilder()
+    shared_id = 42
+    bb_rpc = [
+        {
+            "Church Team": "RPC",
+            "sport_type": SPORT_TYPE["BASKETBALL"],
+            "sport_gender": "Men",
+            "sport_format": "Team",
+            "Participant ID (WP)": pid,
+            "participant_primary_sport": SPORT_TYPE["BASKETBALL"],
+        }
+        for pid in range(40, 45)  # includes shared_id=42
+    ]
+    bb_anh = [
+        {
+            "Church Team": "ANH",
+            "sport_type": SPORT_TYPE["BASKETBALL"],
+            "sport_gender": "Men",
+            "sport_format": "Team",
+            "Participant ID (WP)": pid,
+            "participant_primary_sport": SPORT_TYPE["BASKETBALL"],
+        }
+        for pid in range(50, 55)
+    ]
+    soccer_ocb = [
+        {
+            "Church Team": "OCB",
+            "sport_type": SPORT_TYPE["SOCCER"],
+            "sport_gender": "Mixed",
+            "sport_format": "Team",
+            "Participant ID (WP)": pid,
+            "participant_primary_sport": SPORT_TYPE["SOCCER"],  # primary is Soccer
+        }
+        for pid in (shared_id, 90, 91, 92)
+    ]
+    soccer_tlc = [
+        {
+            "Church Team": "TLC",
+            "sport_type": SPORT_TYPE["SOCCER"],
+            "sport_gender": "Mixed",
+            "sport_format": "Team",
+            "Participant ID (WP)": pid,
+            "participant_primary_sport": SPORT_TYPE["SOCCER"],
+        }
+        for pid in (95, 96, 97, 98)
+    ]
+    roster_rows = bb_rpc + bb_anh + soccer_ocb + soccer_tlc
+
+    si = builder._build_schedule_input(roster_rows, [], tmp_path / "no_venue.xlsx")
+
+    bb_soccer_edges = [
+        edge for edge in si["team_conflicts"]
+        if {edge.get("event_a"), edge.get("event_b")}
+           == {SPORT_TYPE["BASKETBALL"], SPORT_TYPE["SOCCER"]}
+    ]
+    assert len(bb_soccer_edges) == 1
+    edge = bb_soccer_edges[0]
+    assert edge["shared_count"] == 1
+    # Athlete's primary is Soccer, which is one of the events on this edge.
+    assert edge["primary_overlap_count"] == 1
+
+
+def test_soccer_pool_assignment_does_not_create_gym_games(tmp_path):
+    """Soccer pool-assignment rows must NOT generate Gym Core games (uses Soccer fields)."""
+    builder = ScheduleWorkbookBuilder()
+    rows = _soccer_roster(["RPC", "OCB", "ANH"], n_per_church=4)
+    si = builder._build_schedule_input(rows, [], tmp_path / "no_venue.xlsx")
+    soccer_games = [g for g in si.get("games", []) if g.get("event") == SPORT_TYPE["SOCCER"]]
+    assert soccer_games == []
+
+
+def test_soccer_disabled_removes_from_pool_assignment(monkeypatch):
+    """When SOCCER_ENABLED=False, Soccer is excluded from Pool-Assignment outputs."""
+    # Simulate disabled mode by patching the class attribute to the without-Soccer list.
+    defs_without_soccer = [
+        (event, prefix)
+        for event, prefix in ScheduleWorkbookBuilder._POOL_ASSIGNMENT_EVENT_DEFS
+        if event != SPORT_TYPE["SOCCER"]
+    ]
+    monkeypatch.setattr(
+        ScheduleWorkbookBuilder,
+        "_POOL_ASSIGNMENT_EVENT_DEFS",
+        defs_without_soccer,
+    )
+
+    builder = ScheduleWorkbookBuilder()
+    rows = _soccer_roster(["RPC", "OCB"], n_per_church=4)
+    base_rows = builder._build_pool_assignment_base_rows(rows)
+    soccer_rows = [r for r in base_rows if r["Event"] == SPORT_TYPE["SOCCER"]]
+    assert soccer_rows == []


### PR DESCRIPTION
## Summary

Adds Soccer (Coed Exhibition) Phase-1 planning support, **completing Phase 1** of the scheduling roadmap for the 2026 season.

## Changes

- **`config.py`** — new `SOCCER_ENABLED` flag (default `True`). `COURT_ESTIMATE_EVENTS` now appends Soccer only when enabled.
- **`schedule_workbook.py`** — `_POOL_ASSIGNMENT_EVENT_DEFS` conditionally includes `(Soccer, "SOC")` as the 5th entry when `SOCCER_ENABLED` is True. Summary/tooltip text updated `BB/VBM/VBW/BC` → `BB/VBM/VBW/BC/SOC`.
- Soccer cross-sport conflict edges with BB/VBM/VBW/BC flow automatically through the existing pairwise builder.
- Soccer games are **not** generated for the Gym Core solver (Soccer uses dedicated fields, not gym courts) — organizer manages the Soccer field schedule. Edges surface in `Conflict-Audit` as `PlanningOnly` rows.
- **`docs/SCHEDULING.md`** — Phase 1 marked complete; new Soccer section explaining flag semantics.

## Why a flag?

The Coed Exhibition may not return in future seasons. With `SOCCER_ENABLED = False`, Soccer is fully removed from `COURT_ESTIMATE_EVENTS` and `_POOL_ASSIGNMENT_EVENT_DEFS` — no Soccer rows, no Soccer conflict edges, no surprise Soccer references in outputs. Default is `True` for 2026.

## Test plan

- [x] `python3 -m pytest tests/ -q` — **370 passed** (up from 363).
- [x] New tests cover both enabled and disabled modes.

## What this closes

Closes #118 (Phase 1 extension to Bible Challenge and optional Soccer — both halves now landed).

## Out of scope (future work)

- Soccer field-scheduled queue (currently Soccer is `PlanningOnly` like BC). A future enhancement could tie Soccer into a dedicated sequential field queue similar to a venue solver.
- Phase 2: racquet conflict engine.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EHEhRFWLFoXEpBDNuE5s4g)_