### PR TITLE
scheduler: six-tier objective, C3x cross-pool avoidance, C4p pinned-playoff precedence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,14 @@
 ## Unreleased
 
 ### New Features
+- Auto-generate gym playoff game objects (QF/Semi/Final/3rd) for Basketball, VB Men, VB Women — closes [#132](https://github.com/i12know/vaysf/issues/132)
+  - `_build_assigned_gym_game_objects()` now returns pool games AND auto-generated single-elimination playoff games sized to the estimating-team count (4-team → Semi/Final/3rd; 8-team → QF/Semi/Final/3rd), matching the existing Soccer pattern
+  - Playoff games carry standard seed/winner/loser references (`BBM-Seed-1`, `WIN-BBM-QF-1`, `LOS-BBM-Semi-2`, etc.) so they appear in `schedule_input.json` without requiring any `Playoff-Slots` entries
+  - Precedence rules are auto-wired: Pool → QF → Semi → Final / 3rd with a one-slot gap between rounds
+  - Operators who still want to pin a specific game to a court/time can continue to do so via the `Playoff-Slots` tab in `venue_input.xlsx` — those rows override the solver assignment via `merge_playoff_slot_assignments()`
+  - New shared helper `_build_single_elim_playoff()` centralizes the bracket-generation logic so future sports can reuse it
+
+
 - Added first-class 2-game / 3-game team-sport pool policies
   - Core gym team sports no longer rely on the vague legacy fallback when `Target Pool Games/Team` is set to `3`
   - `Venue-Estimator`, `Pool-Assignment`, `Court-Schedule-Sketch`, and `schedule_input.json` now all share the same explicit policy for `2` and `3`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # CHANGELOG
 
+## Unreleased
+
+### Solver improvements — day spread + cross-pool conflict elimination
+
+- **Six-tier lexicographic objective** (scheduler.py) — upgraded from five tiers
+  - New **Tier 3 — Max-per-day spread**: when cross-pool avoidance is active, minimize the maximum number of games on any single day, distributing pool-play games evenly across both weekends instead of packing everything into the first Saturday/Sunday
+  - **Tier 5 — VB gender switches** promoted above **Tier 6 — sum of slot indices**: net-height changes between Men's VB and Women's VB now outrank the pack-early preference, reducing the "VBW game right after VBM on the same court" placement that previously occurred
+  - Sum-of-slot-indices demoted to Tier 6 (tiebreaker only)
+  - Updated weight construction in `scheduler.py` and objective table in `docs/SCHEDULING.md`
+
+- **C3x — cross-pool conflict constraint** (scheduler.py): pools are now solved in priority order (BC Station → Soccer Field → Tennis/Badminton/Pickleball/Table Tennis → Gym Core). After each pool is solved, team slot occupancies are collected. Cross-sport conflict edges in `team_conflicts` are used to identify gym-sport partner teams; those teams are forbidden from being assigned to any slot already claimed by their BC/Soccer counterpart in the same time window. This hard constraint eliminates the cross-sport pink rows (BBM/VBM/VBW vs BC, BBM/VBM/VBW vs Soccer) that the within-pool penalty alone could not fix. `max_games_per_day` is reported per pool in solver logs.
+
 ## Version 1.11 (2026-05-23)
 
 ### New Features

--- a/docs/SCHEDULING.md
+++ b/docs/SCHEDULING.md
@@ -604,9 +604,9 @@ games.
 
 Configurable timeout via `SCHEDULE_SOLVER_TIMEOUT` env var (default: 30 s).
 
-#### Solver objectives (five-tier lexicographic)
+#### Solver objectives (six-tier lexicographic)
 
-The solver minimizes a single combined integer that encodes five goals in strict
+The solver minimizes a single combined integer that encodes six goals in strict
 priority order.  Because each tier's weight exceeds the maximum possible total of
 all lower tiers combined, improving a higher-tier goal is **always** worth more
 than any improvement at lower tiers — the hierarchy is enforced by arithmetic,
@@ -614,25 +614,36 @@ not policy.
 
 | Tier | Goal | What it means in practice |
 |------|------|--------------------------|
-| 1 | **Primary conflict penalty** | Two teams share an athlete whose *primary* sport is one of the two events. Example: a player whose primary sport is Basketball also registers for Bible Challenge — a BB vs BC same-slot collision is a primary conflict. The solver treats this as a near-hard constraint and will sacrifice any Tier 2–5 improvement to eliminate it. |
+| 1 | **Primary conflict penalty** | Two teams share an athlete whose *primary* sport is one of the two events. Example: a player whose primary sport is Basketball also registers for Bible Challenge — a BB vs BC same-slot collision is a primary conflict. The solver treats this as a near-hard constraint and will sacrifice any Tier 2–6 improvement to eliminate it. |
 | 2 | **Secondary conflict penalty** | Same shared-athlete collision, but the athlete's primary sport is a *third* event. Example: a Soccer-primary player who also plays Basketball and Bible Challenge. A BB vs BC clash is now a secondary conflict — still penalised, but slightly below Tier 1. |
-| 3 | **Latest slot index** (makespan) | After conflicts are settled, minimize the index of the *last occupied slot* across all games. This shrinks the right edge of the schedule: if all games fit in slots 0–20, the solver will not stretch to slot 30 even when those slots are available. |
-| 4 | **Sum of slot indices** (packing) | Even after Tier 3 fixes the horizon, games could scatter anywhere within that window at no extra cost. Tier 4 minimizes `sum(slot_index for each game)`, so a game in slot 2 contributes 2 and a game in slot 8 contributes 8. The solver now actively prefers filling slot 3 before slot 7, which keeps each sport concentrated on its designated day rather than drifting across the weekend. |
-| 5 | **Volleyball court switches** | On a court that alternates between Men's VB and Women's VB, each gender flip requires a net-height change and disrupts spectators. The solver counts back-to-back gender changes per court and minimizes that total — but only after all four higher-tier goals are already optimal. |
+| 3 | **Max-per-day spread** | When cross-pool avoidance is active (another sport has already claimed certain time slots), minimize the *maximum number of games on any single day*. This distributes pool-play games evenly across all available days rather than packing everything into the first available weekend. Activated only when C3x (cross-pool) constraints are present; otherwise skipped so single-sport pools (e.g. Table Tennis) still concentrate on their designated day. |
+| 4 | **Latest slot index** (makespan) | After conflicts and spread are settled, minimize the index of the *last occupied slot* across all games. This shrinks the right edge of the schedule. |
+| 5 | **Volleyball court switches** | On a court that alternates between Men's VB and Women's VB, each gender flip requires a net-height change. The solver minimizes back-to-back gender changes per court. This is prioritized **above** packing (Tier 6) to reduce net-adjustment disruptions. |
+| 6 | **Sum of slot indices** (packing) | Within the constraints set by Tiers 1–5, minimize `sum(slot_index for each game)` as a tiebreaker. Prefers filling slot 3 before slot 7, keeping games front-loaded within each day. |
 
 Weight construction (from `scheduler.py`):
 
 ```python
-vb_weight        = 1
-sum_slots_weight = vb_switch_max + 1                                   # beats any VB saving
-latest_weight    = sum_slots_max * sum_slots_weight + vb_switch_max + 1  # beats Tiers 4+5
-secondary_weight = latest_max * latest_weight + …                        # beats Tiers 3–5
-primary_weight   = secondary_penalty_max * secondary_weight + …          # beats Tiers 2–5
+sum_slots_weight = 1
+vb_weight        = sum_slots_max + 1                                    # beats any packing saving
+latest_weight    = vb_switch_max * vb_weight + sum_slots_max + 1       # beats Tiers 5+6
+spread_weight    = latest_max * latest_weight + … + 1                  # beats Tiers 4+5+6
+secondary_weight = spread_max * spread_weight + …                      # beats Tiers 3–6
+primary_weight   = secondary_penalty_max * secondary_weight + …        # beats Tiers 2–6
 ```
 
+**Cross-pool conflict avoidance (C3x):** Pools are solved in priority order — BC
+Station first, then Soccer Field, then Tennis/Badminton/Pickleball/Table Tennis,
+and finally Gym Core (BB + VB) last.  After each pool is solved, every team's
+assigned slots are recorded.  Conflict edges in `team_conflicts` are used to
+identify cross-sport partner teams: if ANH-BC occupies Sat-1-13:00, the solver
+forbids ANH-BBM from starting any game that spans Sat-1-13:00.  This hard
+constraint (C3x) eliminates the cross-sport pink rows in the Conflict-Audit that
+the within-pool penalty alone could not fix.
+
 Day ordering for global slot indices follows weekday-then-cycle chronology
-(Fri-1 < Sat-1 < Sun-1 < Fri-2 < …), so the Tier 3/4 packing naturally
-prefers earlier dates in the weekend without any extra constraint.
+(Fri-1 < Sat-1 < Sun-1 < Fri-2 < …), so Tier 4/6 packing naturally prefers
+earlier dates in the weekend without any extra constraint.
 
 **Pool decomposition:** games are partitioned by `resource_type` and solved in
 independent CP-SAT models. A capacity shortage in one pool (e.g. Badminton Court)

--- a/middleware/church_teams_export.py
+++ b/middleware/church_teams_export.py
@@ -3649,6 +3649,7 @@ _SCHEDULE_WORKBOOK_METHOD_NAMES = (
     "_bc_no_repeat_triplets",
     "_build_assigned_bc_game_objects",
     "_build_assigned_soccer_game_objects",
+    "_build_single_elim_playoff",
     "_build_gym_game_objects",
     "_build_assigned_gym_game_objects",
     "_build_gym_team_conflicts",

--- a/middleware/schedule_workbook.py
+++ b/middleware/schedule_workbook.py
@@ -2207,13 +2207,151 @@ class ScheduleWorkbookBuilder:
             )
 
     @classmethod
+    def _build_single_elim_playoff(
+        cls,
+        event_name: str,
+        prefix: str,
+        playoff_teams: int,
+        pool_game_ids: List[str],
+        extra_fields: Dict[str, Any],
+        include_third: bool,
+    ) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+        """Build single-elimination playoff games + precedence for a 4- or 8-team bracket.
+
+        Seed pairings (highest seed plays lowest):
+          4 teams: Semi-1 = Seed 1 vs Seed 4; Semi-2 = Seed 2 vs Seed 3
+          8 teams: QF-1=S1vS8, QF-2=S4vS5, QF-3=S2vS7, QF-4=S3vS6;
+                   Semi-1 = WIN-QF-1 vs WIN-QF-2; Semi-2 = WIN-QF-3 vs WIN-QF-4
+        Final = WIN-Semi-1 vs WIN-Semi-2; 3rd = LOS-Semi-1 vs LOS-Semi-2 (when
+        include_third).  Precedence wires Pool→QF (if any)→Semi→Final/3rd with a
+        one-slot gap between rounds.  Returns ([], []) for unsupported sizes.
+
+        ``extra_fields`` is merged into each generated game dict so callers can
+        attach sport-specific fields (resource_type, duration_minutes, solver_pool).
+        """
+        if playoff_teams not in (4, 8):
+            return [], []
+
+        games: List[Dict[str, Any]] = []
+        precedence: List[Dict[str, Any]] = []
+
+        semi_ids = [f"{prefix}-Semi-1", f"{prefix}-Semi-2"]
+
+        if playoff_teams == 8:
+            qf_ids = [f"{prefix}-QF-{i}" for i in range(1, 5)]
+            qf_seeds = [(1, 8), (4, 5), (2, 7), (3, 6)]
+            for qf_idx, (qf_id, (seed_a, seed_b)) in enumerate(
+                zip(qf_ids, qf_seeds), start=1
+            ):
+                qf_game = {
+                    "game_id": qf_id,
+                    "event": event_name,
+                    "stage": "QF",
+                    "pool_id": "",
+                    "round": qf_idx,
+                    "team_a_id": f"{prefix}-Seed-{seed_a}",
+                    "team_b_id": f"{prefix}-Seed-{seed_b}",
+                    "team_a_label": f"Seed {seed_a}",
+                    "team_b_label": f"Seed {seed_b}",
+                }
+                qf_game.update(extra_fields)
+                games.append(qf_game)
+            precedence.extend(
+                {"before_game_id": pid, "after_game_id": qid, "min_gap_slots": 1}
+                for pid in pool_game_ids for qid in qf_ids
+            )
+            precedence.extend(
+                {"before_game_id": qid, "after_game_id": sid, "min_gap_slots": 1}
+                for qid in qf_ids for sid in semi_ids
+            )
+            semi_team_pairs = [
+                (f"WIN-{qf_ids[0]}", f"WIN-{qf_ids[1]}", "Winner QF-1", "Winner QF-2"),
+                (f"WIN-{qf_ids[2]}", f"WIN-{qf_ids[3]}", "Winner QF-3", "Winner QF-4"),
+            ]
+        else:
+            semi_team_pairs = [
+                (f"{prefix}-Seed-1", f"{prefix}-Seed-4", "Seed 1", "Seed 4"),
+                (f"{prefix}-Seed-2", f"{prefix}-Seed-3", "Seed 2", "Seed 3"),
+            ]
+            precedence.extend(
+                {"before_game_id": pid, "after_game_id": sid, "min_gap_slots": 1}
+                for pid in pool_game_ids for sid in semi_ids
+            )
+
+        for semi_idx, (semi_id, (team_a, team_b, label_a, label_b)) in enumerate(
+            zip(semi_ids, semi_team_pairs), start=1
+        ):
+            semi_game = {
+                "game_id": semi_id,
+                "event": event_name,
+                "stage": "Semi",
+                "pool_id": "",
+                "round": semi_idx,
+                "team_a_id": team_a,
+                "team_b_id": team_b,
+                "team_a_label": label_a,
+                "team_b_label": label_b,
+            }
+            semi_game.update(extra_fields)
+            games.append(semi_game)
+
+        final_id = f"{prefix}-Final"
+        final_game = {
+            "game_id": final_id,
+            "event": event_name,
+            "stage": "Final",
+            "pool_id": "",
+            "round": 1,
+            "team_a_id": f"WIN-{semi_ids[0]}",
+            "team_b_id": f"WIN-{semi_ids[1]}",
+            "team_a_label": "Winner Semi 1",
+            "team_b_label": "Winner Semi 2",
+        }
+        final_game.update(extra_fields)
+        games.append(final_game)
+        precedence.extend(
+            {"before_game_id": sid, "after_game_id": final_id, "min_gap_slots": 1}
+            for sid in semi_ids
+        )
+
+        if include_third:
+            third_id = f"{prefix}-3rd"
+            third_game = {
+                "game_id": third_id,
+                "event": event_name,
+                "stage": "3rd",
+                "pool_id": "",
+                "round": 1,
+                "team_a_id": f"LOS-{semi_ids[0]}",
+                "team_b_id": f"LOS-{semi_ids[1]}",
+                "team_a_label": "Loser Semi 1",
+                "team_b_label": "Loser Semi 2",
+            }
+            third_game.update(extra_fields)
+            games.append(third_game)
+            precedence.extend(
+                {"before_game_id": sid, "after_game_id": third_id, "min_gap_slots": 1}
+                for sid in semi_ids
+            )
+
+        return games, precedence
+
+    @classmethod
     def _build_assigned_gym_game_objects(
         cls,
         roster_rows: List[Dict[str, Any]],
         pool_assignment_rows: List[Dict[str, Any]],
         allow_placeholder_fallback: bool = True,
-    ) -> List[Dict[str, Any]]:
-        """Return gym games using assigned real teams when pool assignments exist."""
+    ) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+        """Return gym games (pool + auto-generated playoffs) plus precedence.
+
+        Pool games come from the seeded draw in ``pool_assignment_rows``.  Playoff
+        games (QF/Semi/Final/3rd) are auto-generated based on the playoff-team count
+        and wired into precedence so the solver can place them in any open slot.
+        Operators who want a specific game pinned to a court/time still do that
+        via the Playoff-Slots tab in venue_input.xlsx — those rows override the
+        auto-generated assignments via merge_playoff_slot_assignments.
+        """
         sport_defs = [
             (SPORT_TYPE["BASKETBALL"], "BBM", GYM_RESOURCE_TYPE_BASKETBALL),
             (SPORT_TYPE["VOLLEYBALL_MEN"], "VBM", GYM_RESOURCE_TYPE_VOLLEYBALL),
@@ -2221,6 +2359,7 @@ class ScheduleWorkbookBuilder:
         ]
         mpg = COURT_ESTIMATE_DEFAULT_MINUTES_PER_GAME
         games: List[Dict[str, Any]] = []
+        precedence: List[Dict[str, Any]] = []
         placeholder_map_by_event = cls._pool_assignment_placeholder_map(pool_assignment_rows)
 
         for event_name, prefix, resource_type in sport_defs:
@@ -2240,6 +2379,7 @@ class ScheduleWorkbookBuilder:
                 event_name, COURT_ESTIMATE_DEFAULT_POOL_GAMES_PER_TEAM
             )
             pool_pairs = cls._make_pool_game_pairs(prefix, n_teams, gpg)
+            sport_pool_game_ids: List[str] = []
             for pair_idx, (team_a_id, team_b_id, pool_id) in enumerate(pool_pairs, start=1):
                 team_a_meta = slot_map.get(team_a_id)
                 team_b_meta = slot_map.get(team_b_id)
@@ -2248,8 +2388,10 @@ class ScheduleWorkbookBuilder:
                         f"Pool-assignment map for event '{event_name}' is missing "
                         f"{team_a_id!r} or {team_b_id!r}; falling back to placeholders."
                     )
+                pool_game_id = f"{prefix}-{pair_idx:02d}"
+                sport_pool_game_ids.append(pool_game_id)
                 games.append({
-                    "game_id": f"{prefix}-{pair_idx:02d}",
+                    "game_id": pool_game_id,
                     "event": event_name,
                     "stage": "Pool",
                     "pool_id": pool_id,
@@ -2273,7 +2415,26 @@ class ScheduleWorkbookBuilder:
                     "latest_slot": None,
                 })
 
-        return games
+            playoff_teams = cls._get_playoff_teams_for_event(event_name, n_teams)
+            if playoff_teams >= 4:
+                playoff_games, playoff_precedence = cls._build_single_elim_playoff(
+                    event_name=event_name,
+                    prefix=prefix,
+                    playoff_teams=playoff_teams,
+                    pool_game_ids=sport_pool_game_ids,
+                    extra_fields={
+                        "duration_minutes": mpg,
+                        "resource_type": resource_type,
+                        "solver_pool": cls._GYM_CORE_SOLVER_POOL,
+                        "earliest_slot": None,
+                        "latest_slot": None,
+                    },
+                    include_third=COURT_ESTIMATE_INCLUDE_THIRD_PLACE_GAME,
+                )
+                games.extend(playoff_games)
+                precedence.extend(playoff_precedence)
+
+        return games, precedence
 
     # ── Schedule-Input JSON builders ─────────────────────────────────────────
 
@@ -2854,7 +3015,7 @@ class ScheduleWorkbookBuilder:
             roster_rows,
             pool_assignment_path,
         )
-        gym_games = self._build_assigned_gym_game_objects(
+        gym_games, gym_precedence = self._build_assigned_gym_game_objects(
             roster_rows,
             pool_assignment_rows,
             allow_placeholder_fallback=(gym_resource_strategy == "fallback"),
@@ -2867,6 +3028,7 @@ class ScheduleWorkbookBuilder:
         pod_games = self._build_pod_game_objects(roster_rows, validation_rows)
         all_games = gym_games + bc_games + soccer_games + pod_games
         team_conflicts = self._build_gym_team_conflicts(roster_rows, pool_assignment_rows)
+        precedence.extend(gym_precedence)
         precedence.extend(soccer_precedence)
 
         gym_allocation: Optional[Dict[str, Any]] = None

--- a/middleware/schedule_workbook.py
+++ b/middleware/schedule_workbook.py
@@ -5433,12 +5433,38 @@ class ScheduleWorkbookBuilder:
             rid = str(res.get("resource_id") or "").strip()
             return str(res.get("label") or rid).strip()
 
-        # Sort by venue group then label for column ordering.
+        # Sort venue groups by the priority of their dominant resource type so
+        # the column layout follows the sport order (Soccer → BC → Basketball →
+        # Volleyball → Tennis → Pickleball → Badminton → Table Tennis) rather
+        # than alphabetical venue names.  When a venue hosts multiple resource
+        # types (e.g. 4 Tennis + 4 Pickleball at EHS Tennis Court), it sorts by
+        # the lowest-numbered (highest priority) type it contains.
+        _resource_type_rank = {
+            "Soccer Field":        0,
+            "BC Station":          1,
+            "Basketball Court":    2,
+            "Volleyball Court":    3,
+            "Tennis Court":        4,
+            "Pickleball Court":    5,
+            "Badminton Court":     6,
+            "Table Tennis Table":  7,
+        }
+        _UNRANKED = 99
+
+        vg_to_min_rank: Dict[str, int] = {}
+        for res in all_resources:
+            vg = _venue_group(res)
+            rt = str(res.get("resource_type") or "").strip()
+            rank = _resource_type_rank.get(rt, _UNRANKED)
+            if vg not in vg_to_min_rank or rank < vg_to_min_rank[vg]:
+                vg_to_min_rank[vg] = rank
+
         # "Other" (fallback when venue_name is blank) sorts between EHS venues
-        # and any Orange/external venues by mapping it to "EHS~" which is
-        # lexicographically after all "EHS …" names but before "Orange …".
-        def _vg_sort_key(vg: str) -> str:
-            return "EHS~" if vg == "Other" else vg
+        # and any Orange/external venues by mapping its name component to
+        # "EHS~" which is lexicographically after all "EHS …" names.
+        def _vg_sort_key(vg: str) -> Tuple[int, str]:
+            name_key = "EHS~" if vg == "Other" else vg
+            return (vg_to_min_rank.get(vg, _UNRANKED), name_key)
 
         def _label_sort_key(label: str) -> Tuple[str, int, str]:
             # Natural sort: split on the last run of digits so "Court-2" < "Court-10".

--- a/middleware/schedule_workbook.py
+++ b/middleware/schedule_workbook.py
@@ -5459,12 +5459,14 @@ class ScheduleWorkbookBuilder:
             if vg not in vg_to_min_rank or rank < vg_to_min_rank[vg]:
                 vg_to_min_rank[vg] = rank
 
-        # "Other" (fallback when venue_name is blank) sorts between EHS venues
-        # and any Orange/external venues by mapping its name component to
-        # "EHS~" which is lexicographically after all "EHS …" names.
+        # "Other" (fallback when venue_name is blank) sorts after all named
+        # venues regardless of its resource types, so it never splits two
+        # sport-related venue groups that should be adjacent (e.g. Tennis and
+        # Pickleball).  Named venues still sort by sport-type priority.
         def _vg_sort_key(vg: str) -> Tuple[int, str]:
-            name_key = "EHS~" if vg == "Other" else vg
-            return (vg_to_min_rank.get(vg, _UNRANKED), name_key)
+            if vg == "Other":
+                return (_UNRANKED, "Other")
+            return (vg_to_min_rank.get(vg, _UNRANKED), vg)
 
         def _label_sort_key(label: str) -> Tuple[str, int, str]:
             # Natural sort: split on the last run of digits so "Court-2" < "Court-10".

--- a/middleware/scheduler.py
+++ b/middleware/scheduler.py
@@ -776,18 +776,35 @@ def _solve_one_pool(
                 team_global_assignments.setdefault(team, {}).setdefault(global_idx, []).append(var)
 
     precedence_rules = pool_input.get("precedence", []) or []
+    # pinned_game_global: {game_id: global_slot_index} for manually pinned playoff games.
+    # Used below so precedence rules whose "after" side is pinned still constrain the
+    # solver-assigned "before" pool game to finish early enough.
+    pinned_game_global: dict[str, int] = {
+        gid: slot_to_global[slot]
+        for gid, slot in (pool_input.get("pinned_game_slots") or {}).items()
+        if slot in slot_to_global
+    }
     for rule in precedence_rules:
         before_game_id = str(rule.get("before_game_id") or "").strip()
         after_game_id = str(rule.get("after_game_id") or "").strip()
         if not before_game_id or not after_game_id:
             continue
-        if before_game_id not in game_global_slot or after_game_id not in game_global_slot:
-            continue
         min_gap_slots = max(int(rule.get("min_gap_slots") or 1), 1)
-        model.Add(
-            game_global_slot[after_game_id]
-            >= game_global_slot[before_game_id] + min_gap_slots
-        )
+        if before_game_id in game_global_slot and after_game_id in game_global_slot:
+            # Both games are solver-assigned: standard ordering constraint.
+            model.Add(
+                game_global_slot[after_game_id]
+                >= game_global_slot[before_game_id] + min_gap_slots
+            )
+        elif before_game_id in game_global_slot and after_game_id in pinned_game_global:
+            # "Before" is solver-assigned; "after" is a manually pinned playoff game.
+            # Translate to an upper-bound on the pool game's slot so it must finish
+            # before the pinned playoff starts.
+            pinned_idx = pinned_game_global[after_game_id]
+            model.Add(
+                game_global_slot[before_game_id] <= pinned_idx - min_gap_slots
+            )
+        # Skip if "before" is pinned (can't constrain a pinned game) or both unknown.
 
     for team, by_idx in team_global_assignments.items():
         for g_idx, vars_at_g in by_idx.items():
@@ -1181,6 +1198,20 @@ def solve(
             pool_key = resource_pool_by_id.get(resource_id, resource_type)
             blocked_slots_by_pool.setdefault(pool_key, {})[resource_id] = set(slots)
 
+    # pinned_game_slots_by_pool: {pool_key: {game_id: slot_label}} for manually
+    # pinned playoff games. Passed to _solve_one_pool so precedence rules whose
+    # "after" side is pinned can still constrain pool games (fix for the bug
+    # where VBM pool games spilled past VBM-QF-1 start time on 2nd Saturday).
+    pinned_game_slots_by_pool: dict[str, dict[str, str]] = defaultdict(dict)
+    for _ps in playoff_slots:
+        _gid = str(_ps.get("game_id") or "").strip()
+        _slot = str(_ps.get("slot") or "").strip()
+        _rid  = str(_ps.get("resource_id") or "").strip()
+        if _gid and _slot and _rid:
+            _pk = resource_pool_by_id.get(_rid, "")
+            if _pk:
+                pinned_game_slots_by_pool[_pk][_gid] = _slot
+
     team_conflicts = schedule_input.get("team_conflicts", []) or []
     team_conflicts_by_pool: dict[str, list[dict[str, Any]]] = defaultdict(list)
     precedence_by_pool: dict[str, list[dict[str, Any]]] = defaultdict(list)
@@ -1301,6 +1332,7 @@ def solve(
             "precedence":          precedence_by_pool.get(pool_key, []),
             "day_order":           day_order,
             "cross_pool_avoidance": cross_pool_avoidance,
+            "pinned_game_slots":   pinned_game_slots_by_pool.get(pool_key, {}),
         }
         result = _solve_one_pool(pool_input, timeout_seconds)
         result["resource_type"] = pool_key

--- a/middleware/scheduler.py
+++ b/middleware/scheduler.py
@@ -25,17 +25,19 @@ Constraints implemented (per pool):
   C6  Minimum rest — no team plays in two adjacent global time slots.
   C7  Multi-slot games — a game whose duration > slot_minutes blocks consecutive slots.
 
-Objective (per pool, five-tier lexicographic via integer dominance):
+Objective (per pool, six-tier lexicographic via integer dominance):
   1. Minimize primary shared-athlete conflicts — two teams share an athlete
      whose primary sport is one of the two events (near-hard constraint).
   2. Minimize secondary shared-athlete conflicts — same collision but the
      athlete's primary sport is a third event (soft penalty).
-  3. Minimize the index of the latest occupied global slot (makespan).
-  4. Minimize the sum of all games' global slot indices — packs games into
-     the earliest available slots so each sport stays concentrated on its
-     designated day rather than drifting across the weekend.
+  3. Minimize the maximum number of games on any single day (spread) —
+     distributes pool-play games evenly across all available days instead
+     of packing everything into the first available weekend.
+  4. Minimize the index of the latest occupied global slot (makespan).
   5. For Volleyball Court pools, minimize adjacent same-court Men/Women
      switches so net-height changes are reduced.
+  6. Minimize the sum of all games' global slot indices — within the spread
+     and makespan constraints, prefer earlier start slots as a tiebreaker.
 
 Each tier's weight exceeds the maximum possible total of all lower tiers
 combined, so the hierarchy is enforced by arithmetic.  See
@@ -731,6 +733,26 @@ def _solve_one_pool(
         if len(var_list) > 1:
             model.AddAtMostOne(var_list)
 
+    # C3x — cross-pool: forbid placing a game at any slot that a cross-pool
+    # conflict partner is already assigned to in a previously-solved pool.
+    # pool_input["cross_pool_avoidance"] = {team_id: {slot_label, ...}} where
+    # the slots come from other pools' solved assignments.
+    cross_pool_avoidance: dict[str, set[str]] = pool_input.get("cross_pool_avoidance") or {}
+    if cross_pool_avoidance:
+        for gid, vd in game_vars.items():
+            game  = game_meta[gid]
+            teams = _game_team_ids(game)
+            duration = game["duration_minutes"]
+            for (rid, t), var in vd.items():
+                slot_min = res_by_id[rid]["slot_minutes"]
+                n_slots  = max(1, math.ceil(duration / slot_min))
+                if any(
+                    res_slots[rid][s] in cross_pool_avoidance.get(team, set())
+                    for s in range(t, t + n_slots)
+                    for team in teams
+                ):
+                    model.Add(var == 0)
+
     # Global slot IntVar per game (enables C5 and C6)
     game_global_slot: dict[str, Any] = {}
     for gid, vd in game_vars.items():
@@ -846,7 +868,8 @@ def _solve_one_pool(
             model.Add(sum(source_vars) == occ_var)
             game_slot_occ[(gid, slot_label)] = occ_var
 
-    # Objective — minimize the latest occupied global slot (pack games toward start)
+    # Objective — six-tier lexicographic: conflicts > spread > makespan > VB switches > sum
+    max_day_load: Any = None  # set inside block when pool spans multiple days
     if game_global_slot:
         latest = model.NewIntVar(0, max(n_global - 1, 0), "latest_slot")
         for gv in game_global_slot.values():
@@ -928,32 +951,73 @@ def _solve_one_pool(
                     model.Add(women_to_men >= women_current + men_next - 1)
                     volleyball_switch_vars.append(women_to_men)
 
+        # Tier 3 — spread: minimize max games scheduled on any single day.
+        # Distributes pool-play games across all available days so the solver
+        # does not pack everything into the first available weekend.
+        all_pool_days = sorted(
+            {_slot_day_key(lbl) for lbl in sorted_labels},
+            key=_day_chronological_key,
+        )
+        day_load_vars: dict[str, Any] = {}
+        if len(all_pool_days) > 1:
+            for _pool_day in all_pool_days:
+                _day_vars = [
+                    var
+                    for gid, vd in game_vars.items()
+                    for (rid, t), var in vd.items()
+                    if _slot_day_key(res_slots[rid][t]) == _pool_day
+                ]
+                if _day_vars:
+                    _dload = model.NewIntVar(
+                        0, len(game_global_slot), f"dayload_{_pool_day}"
+                    )
+                    model.Add(_dload == sum(_day_vars))
+                    day_load_vars[_pool_day] = _dload
+
+        # Activate spread only when cross-pool avoidance is present — that
+        # signals another sport has claimed specific slots, so the solver needs
+        # encouragement to use alternate days.  Without cross-sport pressure,
+        # prefer the default pack-early behavior so games concentrate on the
+        # designated day (e.g. all Table Tennis on Friday).
+        spread_max = len(game_global_slot)
+        if len(day_load_vars) > 1 and cross_pool_avoidance:
+            max_day_load = model.NewIntVar(0, spread_max, "max_day_load")
+            for _dload in day_load_vars.values():
+                model.Add(max_day_load >= _dload)
+
         secondary_penalty_max = sum(max(entry["secondary_weight"], 0) for entry in conflict_overlap_vars)
         latest_max = max(n_global - 1, 0)
         vb_switch_max = len(volleyball_switch_vars)
         sum_slots_max = len(game_global_slot) * latest_max
 
         # Lexicographic objective via integer dominance.  Each higher-tier
-        # weight strictly exceeds the maximum possible contribution from all
-        # lower tiers, so the solver always settles a higher tier before
+        # weight strictly exceeds the maximum possible total of all lower tiers
+        # combined, so the solver always settles a higher tier before
         # spending degrees of freedom on a lower one.
         #
         # Tier ordering (highest priority first):
-        #   primary conflicts > secondary conflicts > latest slot
-        #     > sum of slot indices (chronological packing) > VB switches
-        vb_weight = 1
-        sum_slots_weight = vb_switch_max + 1
-        latest_weight = sum_slots_max * sum_slots_weight + vb_switch_max + 1
-        secondary_weight = (
+        #   primary conflicts > secondary conflicts > spread (max-per-day)
+        #   > latest slot > VB gender switches > sum of slot indices
+        sum_slots_weight = 1
+        vb_weight = sum_slots_max + 1
+        latest_weight = vb_switch_max * vb_weight + sum_slots_max + 1
+        spread_weight = (
             latest_max * latest_weight
-            + sum_slots_max * sum_slots_weight
-            + vb_switch_max + 1
+            + vb_switch_max * vb_weight
+            + sum_slots_max + 1
+        )
+        secondary_weight = (
+            spread_max * spread_weight
+            + latest_max * latest_weight
+            + vb_switch_max * vb_weight
+            + sum_slots_max + 1
         )
         primary_weight = (
             secondary_penalty_max * secondary_weight
+            + spread_max * spread_weight
             + latest_max * latest_weight
-            + sum_slots_max * sum_slots_weight
-            + vb_switch_max + 1
+            + vb_switch_max * vb_weight
+            + sum_slots_max + 1
         )
 
         objective_terms: list[Any] = []
@@ -961,10 +1025,12 @@ def _solve_one_pool(
             objective_terms.append(sum(primary_conflict_terms) * primary_weight)
         if secondary_conflict_terms:
             objective_terms.append(sum(secondary_conflict_terms) * secondary_weight)
+        if max_day_load is not None:
+            objective_terms.append(max_day_load * spread_weight)
         objective_terms.append(latest * latest_weight)
-        objective_terms.append(sum(game_global_slot.values()) * sum_slots_weight)
         if volleyball_switch_vars:
             objective_terms.append(sum(volleyball_switch_vars) * vb_weight)
+        objective_terms.append(sum(game_global_slot.values()) * sum_slots_weight)
         model.Minimize(sum(objective_terms))
 
     # Solve
@@ -1019,6 +1085,12 @@ def _solve_one_pool(
     if game_global_slot:
         result["latest_slot_index"] = (
             int(solver.Value(latest))
+            if status in (STATUS_OPTIMAL, STATUS_FEASIBLE)
+            else None
+        )
+    if max_day_load is not None:
+        result["max_games_per_day"] = (
+            int(solver.Value(max_day_load))
             if status in (STATUS_OPTIMAL, STATUS_FEASIBLE)
             else None
         )
@@ -1166,14 +1238,69 @@ def solve(
 
     day_order: list[str] = schedule_input.get("day_order") or []
 
-    for pool_key in sorted(games_by_pool.keys()):
+    # Solve smaller/quicker pools first so their slot assignments can be passed
+    # to larger pools as cross-pool avoidance constraints (C3x).  Gym Core is
+    # solved last because it benefits most from knowing where BC/Soccer landed.
+    _POOL_SOLVE_PRIORITY: dict[str, int] = {
+        "BC Station":          0,
+        "Soccer Field":        1,
+        "Tennis Court":        2,
+        "Table Tennis Table":  3,
+        "Badminton Court":     4,
+        "Pickleball Court":    5,
+        # "Gym Core" and individual court types sort to 99 (last)
+    }
+
+    def _pool_sort_key(pk: str) -> tuple[int, str]:
+        return (_POOL_SOLVE_PRIORITY.get(pk, 99), pk)
+
+    # Build cross-pool conflict mapping:
+    # cross_pool_partners[pool_key][team_id] = {partner_team_ids in other pools}
+    cross_pool_partners: dict[str, dict[str, set[str]]] = defaultdict(lambda: defaultdict(set))
+    if team_conflicts and "game_pool_by_team" in dir():
+        pass  # game_pool_by_team already built above
+    game_pool_by_team_local: dict[str, str] = {}
+    for pool_key, pool_games in games_by_pool.items():
+        for game in pool_games:
+            for team_id in _game_team_ids(game):
+                game_pool_by_team_local[team_id] = pool_key
+    for edge in team_conflicts:
+        ta = str(edge.get("team_a_id") or "").strip()
+        tb = str(edge.get("team_b_id") or "").strip()
+        pool_a = game_pool_by_team_local.get(ta)
+        pool_b = game_pool_by_team_local.get(tb)
+        if pool_a and pool_b and pool_a != pool_b:
+            cross_pool_partners[pool_a][ta].add(tb)
+            cross_pool_partners[pool_b][tb].add(ta)
+
+    # Slots assigned in already-solved pools, keyed by team_id
+    team_occupied_slots: dict[str, set[str]] = defaultdict(set)
+
+    for pool_key in sorted(games_by_pool.keys(), key=_pool_sort_key):
+        # Build cross-pool avoidance for this pool's teams: slots where their
+        # cross-pool conflict partners are already assigned in solved pools.
+        cross_pool_avoidance: dict[str, set[str]] = {}
+        for team_id, partner_ids in cross_pool_partners.get(pool_key, {}).items():
+            avoided: set[str] = set()
+            for partner_id in partner_ids:
+                avoided.update(team_occupied_slots.get(partner_id, set()))
+            if avoided:
+                cross_pool_avoidance[team_id] = avoided
+        if cross_pool_avoidance:
+            logger.debug(
+                f"Pool {pool_key!r}: C3x avoidance for "
+                f"{len(cross_pool_avoidance)} teams across "
+                f"{sum(len(s) for s in cross_pool_avoidance.values())} slot-team pairs"
+            )
+
         pool_input = {
-            "games":         games_by_pool[pool_key],
-            "resources":     resources_by_pool.get(pool_key, []),
-            "blocked_slots": blocked_slots_by_pool.get(pool_key, {}),
-            "team_conflicts": team_conflicts_by_pool.get(pool_key, []),
-            "precedence":    precedence_by_pool.get(pool_key, []),
-            "day_order":     day_order,
+            "games":               games_by_pool[pool_key],
+            "resources":           resources_by_pool.get(pool_key, []),
+            "blocked_slots":       blocked_slots_by_pool.get(pool_key, {}),
+            "team_conflicts":      team_conflicts_by_pool.get(pool_key, []),
+            "precedence":          precedence_by_pool.get(pool_key, []),
+            "day_order":           day_order,
+            "cross_pool_avoidance": cross_pool_avoidance,
         }
         result = _solve_one_pool(pool_input, timeout_seconds)
         result["resource_type"] = pool_key
@@ -1181,9 +1308,34 @@ def solve(
         all_assignments.extend(result["assignments"])
         all_unscheduled.extend(result["unscheduled"])
         total_wall_seconds += result["solver_wall_seconds"]
+
+        # Record every slot this pool's teams occupy, for subsequent pools' C3x.
+        _pool_game_meta = {g["game_id"]: g for g in games_by_pool[pool_key]}
+        _pool_res = {r["resource_id"]: r for r in resources_by_pool.get(pool_key, [])}
+        _pool_res_slots = build_resource_slots(resources_by_pool.get(pool_key, []))
+        for _asgn in result["assignments"]:
+            _gm = _pool_game_meta.get(str(_asgn.get("game_id") or ""), {})
+            _slot = str(_asgn.get("slot") or "")
+            _rid  = str(_asgn.get("resource_id") or "")
+            if not _slot or not _rid:
+                continue
+            _res = _pool_res.get(_rid, {})
+            _slot_min = int(_res.get("slot_minutes") or 60)
+            _dur = int(_gm.get("duration_minutes") or _slot_min)
+            _n   = max(1, math.ceil(_dur / _slot_min))
+            _slot_list = _pool_res_slots.get(_rid, [])
+            try:
+                _si = _slot_list.index(_slot)
+                _occupied = _slot_list[_si : _si + _n]
+            except ValueError:
+                _occupied = [_slot]
+            for _team in _game_team_ids(_gm):
+                team_occupied_slots[_team].update(_occupied)
         extra_metrics = ""
+        if result.get("max_games_per_day") is not None:
+            extra_metrics += f", max_games_per_day={result['max_games_per_day']}"
         if result.get("volleyball_adjacent_switches") is not None:
-            extra_metrics = (
+            extra_metrics += (
                 f", volleyball_adjacent_switches={result['volleyball_adjacent_switches']}"
             )
         if result.get("cross_sport_same_slot_conflicts") is not None:

--- a/middleware/tests/test_schedule_workbook.py
+++ b/middleware/tests/test_schedule_workbook.py
@@ -2187,16 +2187,94 @@ def test_build_assigned_gym_game_objects_fallback_counts_team_order_units():
                     }
                 )
 
-    games = ScheduleWorkbookBuilder._build_assigned_gym_game_objects(
+    games, _precedence = ScheduleWorkbookBuilder._build_assigned_gym_game_objects(
         roster_rows,
         [],
         allow_placeholder_fallback=False,
     )
 
-    basketball_games = [
-        game for game in games if game["event"] == SPORT_TYPE["BASKETBALL"]
+    basketball_pool_games = [
+        game for game in games
+        if game["event"] == SPORT_TYPE["BASKETBALL"] and game.get("stage") == "Pool"
     ]
-    assert len(basketball_games) == 6
+    assert len(basketball_pool_games) == 6
+
+
+def test_build_assigned_gym_game_objects_auto_generates_playoffs_for_8_teams():
+    """8-team fallback should auto-generate QF/Semi/Final/3rd plus precedence."""
+    roster_rows = []
+    for church_code in ("RPC", "OCB", "ANH", "GLA", "TLC", "FVC", "PHX", "WAG"):
+        for participant_id in range(5):
+            roster_rows.append({
+                "Church Team": church_code,
+                "team_order": "A",
+                "sport_type": SPORT_TYPE["BASKETBALL"],
+                "sport_gender": "Men",
+                "sport_format": "Team",
+                "Participant ID (WP)": f"{church_code}-A-{participant_id}",
+            })
+
+    games, precedence = ScheduleWorkbookBuilder._build_assigned_gym_game_objects(
+        roster_rows,
+        [],
+        allow_placeholder_fallback=False,
+    )
+
+    bbm_games = [g for g in games if g["event"] == SPORT_TYPE["BASKETBALL"]]
+    stages = {g["game_id"]: g.get("stage") for g in bbm_games}
+
+    qf_ids = {gid for gid, st in stages.items() if st == "QF"}
+    semi_ids = {gid for gid, st in stages.items() if st == "Semi"}
+    final_ids = {gid for gid, st in stages.items() if st == "Final"}
+    third_ids = {gid for gid, st in stages.items() if st == "3rd"}
+
+    assert qf_ids == {"BBM-QF-1", "BBM-QF-2", "BBM-QF-3", "BBM-QF-4"}
+    assert semi_ids == {"BBM-Semi-1", "BBM-Semi-2"}
+    assert final_ids == {"BBM-Final"}
+    assert third_ids == {"BBM-3rd"}
+
+    # Final pulls winners of semis
+    final_game = next(g for g in bbm_games if g["game_id"] == "BBM-Final")
+    assert final_game["team_a_id"] == "WIN-BBM-Semi-1"
+    assert final_game["team_b_id"] == "WIN-BBM-Semi-2"
+
+    # Precedence covers Pool→QF, QF→Semi, Semi→Final, Semi→3rd
+    bbm_prec = {
+        (str(r["before_game_id"]), str(r["after_game_id"]))
+        for r in precedence
+        if str(r.get("before_game_id") or "").startswith("BBM-")
+    }
+    pool_ids = {gid for gid, st in stages.items() if st == "Pool"}
+    assert all((p, q) in bbm_prec for p in pool_ids for q in qf_ids)
+    assert all((q, s) in bbm_prec for q in qf_ids for s in semi_ids)
+    assert all((s, "BBM-Final") in bbm_prec for s in semi_ids)
+    assert all((s, "BBM-3rd") in bbm_prec for s in semi_ids)
+
+
+def test_build_assigned_gym_game_objects_4_team_bracket_skips_qf():
+    """4-team bracket should generate Semi/Final/3rd directly, no QFs."""
+    roster_rows = []
+    for church_code in ("RPC", "OCB", "ANH", "GLA"):
+        for participant_id in range(12):
+            roster_rows.append({
+                "Church Team": church_code,
+                "team_order": "A",
+                "sport_type": SPORT_TYPE["VOLLEYBALL_MEN"],
+                "sport_gender": "Men",
+                "sport_format": "Team",
+                "Participant ID (WP)": f"{church_code}-A-{participant_id}",
+            })
+
+    games, _precedence = ScheduleWorkbookBuilder._build_assigned_gym_game_objects(
+        roster_rows,
+        [],
+        allow_placeholder_fallback=False,
+    )
+
+    vbm_stages = {g["game_id"]: g.get("stage") for g in games if g["event"] == SPORT_TYPE["VOLLEYBALL_MEN"]}
+    assert not any(st == "QF" for st in vbm_stages.values())
+    assert {gid for gid, st in vbm_stages.items() if st == "Semi"} == {"VBM-Semi-1", "VBM-Semi-2"}
+    assert {gid for gid, st in vbm_stages.items() if st == "Final"} == {"VBM-Final"}
 
 
 def test_classmethod_schedule_helpers_do_not_instantiate_exporter_subclass():
@@ -3107,6 +3185,8 @@ def test_bc_schedule_input_adds_playoff_precedence(tmp_path):
     precedence_pairs = {
         (str(rule["before_game_id"]), str(rule["after_game_id"]))
         for rule in si["precedence"]
+        if str(rule.get("before_game_id") or "").startswith("BC-")
+           or str(rule.get("after_game_id") or "").startswith("BC-")
     }
     expected_pairs = {
         (pool_game_id, semi_id)


### PR DESCRIPTION
## Summary

- **Auto-generate gym playoff games** (QF/Semi/Final/3rd) — closes #132
- **Master-Schedule venue columns** sorted by sport priority; `Other` group pinned last
- **Six-tier lexicographic objective**: adds a day-spread tier (Tier 3), activated only when cross-pool avoidance is present. Prevents VBW/VBM pool games from spilling onto the 1st weekend when BC/Soccer partners have already claimed those slots.
- **C3x cross-pool hard constraint**: gym games (BBM/VBM/VBW) forbidden from slots already occupied by BC Station or Soccer Field partner teams. Eliminates pink cross-sport conflict audit rows.
- **C4p pinned-playoff precedence fix**: when a precedence rule's `after_game_id` is a manually pinned playoff game (no CP-SAT variable), converts to an upper-bound on the pool game's global slot index. Previously the rule was silently dropped, allowing pool games to appear after QF games on 2nd Saturday.

## Test plan

- [ ] `pytest middleware/tests/ -v` passes in mock mode
- [ ] `run-schedule.bat` produces a valid Excel workbook with no cross-sport pink rows
- [ ] VBM/VBW pool games land on 2nd weekend when BC/Soccer partners are present
- [ ] VBM pool games appear before any pinned VBM-QF games on 2nd Saturday

---
_Generated by [Claude Code](https://claude.ai/code/session_01EHEhRFWLFoXEpBDNuE5s4g)_