### PR TITLE
scheduler: clarify spreadsheet tab roles — closes #139

### DIFF
--- a/docs/SCHEDULE-HOW-TO.md
+++ b/docs/SCHEDULE-HOW-TO.md
@@ -42,6 +42,33 @@ So after editing `venue_input.xlsx`, you usually rerun
 
 ---
 
+## Tab Status Map
+
+Generated workbooks now include a status banner near the top-right of each
+important tab. The banner is intentionally outside the data table so it does
+not move headers or break imports.
+
+Use this map when deciding whether to edit a sheet:
+
+| Workbook | Tab | Status | What to do |
+|----------|-----|--------|------------|
+| `venue_input.xlsx` | `Venue-Input` | `EDITABLE INPUT` | Edit booked resource blocks here, then rerun `export-church-teams`. |
+| `venue_input.xlsx` | `Gym-Modes` | `EDITABLE INPUT` | Edit physical gym mode capacities here. |
+| `venue_input.xlsx` | `Playoff-Slots` | `EDITABLE OVERRIDE INPUT` | Optional playoff pins; copy exact `game_id`, `resource_id`, and `slot` values from `Schedule-Input`. |
+| `Church_Team_Status_ALL_*.xlsx` | `Summary`, `Contacts-Status`, sport tabs | `READ-ONLY OUTPUT` | Review only; rerun `export-church-teams` after source data changes. |
+| `Church_Team_Status_ALL_*.xlsx` | `Roster`, `Validation-Issues` | `GENERATED DATA SOURCE` | Scheduling reads these tabs; fix source data upstream instead of editing cells. |
+| `Schedule_Workbook_*.xlsx` | `Summary`, `Pod-Divisions` | `READ-ONLY OUTPUT` | Generated planning context. |
+| `Schedule_Workbook_*.xlsx` | `Venue-Estimator`, `Court-Schedule-Sketch` | `READ-ONLY PLANNING OUTPUT` | Use for planning; edit `venue_input.xlsx` for capacity changes. |
+| `Schedule_Workbook_*.xlsx` | `Pod-Entries-Review` | `READ-ONLY REVIEW OUTPUT` | Review pod entries; fix roster/source data upstream. |
+| `Schedule_Workbook_*.xlsx` | `Pod-Resource-Estimate` | `READ-ONLY CAPACITY CHECK` | Compare demand to venue capacity; edit `venue_input.xlsx` if capacity is wrong. |
+| `Schedule_Workbook_*.xlsx` | `Schedule-Input` | `GENERATED LOOKUP / MACHINE CONTRACT VIEW` | Copy exact IDs and slots from here; do not hand-edit. |
+| `Schedule_Workbook_*.xlsx` | `Pool-Assignment` | `TEMPORARY EDIT SURFACE` | Edit seeds/pool placements here, then rerun `assign-pools --workbook`. |
+| `Schedule_Workbook_*.xlsx` | `Gym-Allocation` | `READ-ONLY ALLOCATION AUDIT` | Review gym-mode allocation; change venue inputs and rerun the workflow if needed. |
+| `VAYSF_Schedule_*.xlsx` | `Schedule-by-Time`, `Schedule-by-Sport`, `Master-Schedule` | `FINAL OUTPUT` | Publish/review only; rerun the scheduler if inputs change. |
+| `VAYSF_Schedule_*.xlsx` | `Conflict-Audit` | `AUDIT OUTPUT` | Check conflicts and warnings before publishing. |
+
+---
+
 ## Workflow Map
 
 ```mermaid

--- a/middleware/church_teams_export.py
+++ b/middleware/church_teams_export.py
@@ -3018,6 +3018,11 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
                         adjusted_width = min(max_length + 2, 50)  # Max width of 50
                         worksheet.column_dimensions[column_letter].width = adjusted_width
 
+                ScheduleWorkbookBuilder._stamp_known_tab_statuses(
+                    writer.book,
+                    default_unknown=ScheduleWorkbookBuilder._SPORT_EXPORT_TAB_STATUS,
+                )
+
             logger.info(f"Successfully wrote Excel report: {filepath}")
         except Exception as e:
             logger.error(f"Failed to write Excel file {filepath}: {e}", exc_info=True)

--- a/middleware/main.py
+++ b/middleware/main.py
@@ -701,6 +701,7 @@ def generate_venue_template(output_path: Optional[Path] = None) -> bool:
     from openpyxl import Workbook
     from openpyxl.styles import PatternFill, Font, Alignment
     from openpyxl.utils import get_column_letter
+    from schedule_workbook import ScheduleWorkbookBuilder
     from config import (
         DATA_DIR, VENUE_TEMPLATE_FILENAME,
         POD_RESOURCE_TYPE_TENNIS, POD_RESOURCE_TYPE_PICKLEBALL,
@@ -832,6 +833,7 @@ def generate_venue_template(output_path: Optional[Path] = None) -> bool:
     )
 
     try:
+        ScheduleWorkbookBuilder._stamp_known_tab_statuses(wb)
         wb.save(output_path)
         logger.info(f"Venue input template written to: {output_path}")
         return True

--- a/middleware/schedule_workbook.py
+++ b/middleware/schedule_workbook.py
@@ -94,6 +94,108 @@ class ScheduleWorkbookBuilder:
         pass
 
     _GYM_CORE_SOLVER_POOL = "Gym Core"
+    _TAB_STATUS_GUIDE: Dict[str, Tuple[str, str, str]] = {
+        "Venue-Input": (
+            "EDITABLE INPUT",
+            "Edit booked venue resource blocks here, then rerun export-church-teams.",
+            "D9EAD3",
+        ),
+        "Gym-Modes": (
+            "EDITABLE INPUT",
+            "Edit physical gym mode capacities here when a gym can switch sports.",
+            "D9EAD3",
+        ),
+        "Playoff-Slots": (
+            "EDITABLE OVERRIDE INPUT",
+            "Optional pinned playoff overrides. Copy exact resource_id and slot values from Schedule-Input.",
+            "FCE5CD",
+        ),
+        "Summary": (
+            "READ-ONLY OUTPUT",
+            "Generated guide or status summary. Do not edit; rerun the source command instead.",
+            "D9EAF7",
+        ),
+        "Contacts-Status": (
+            "READ-ONLY OUTPUT",
+            "Generated church contact and approval snapshot. Do not edit this tab.",
+            "D9EAF7",
+        ),
+        "Roster": (
+            "GENERATED DATA SOURCE",
+            "Generated roster source for scheduling. Fix source data, then rerun export-church-teams.",
+            "D9EAF7",
+        ),
+        "Validation-Issues": (
+            "GENERATED DATA SOURCE",
+            "Generated validation source for scheduling. Resolve issues upstream, then rerun export-church-teams.",
+            "D9EAF7",
+        ),
+        "Venue-Estimator": (
+            "READ-ONLY PLANNING OUTPUT",
+            "Use for capacity planning only. Change venue capacity in venue_input.xlsx.",
+            "D9EAF7",
+        ),
+        "Court-Schedule-Sketch": (
+            "READ-ONLY PLANNING OUTPUT",
+            "Layer-1 planning sketch. Rerun build-schedule-workbook after changing inputs.",
+            "D9EAF7",
+        ),
+        "Pod-Divisions": (
+            "READ-ONLY OUTPUT",
+            "Generated pod division planning view. Do not edit this tab.",
+            "D9EAF7",
+        ),
+        "Pod-Entries-Review": (
+            "READ-ONLY REVIEW OUTPUT",
+            "Review pod entries here, but fix roster data upstream instead of editing cells.",
+            "D9EAF7",
+        ),
+        "Pod-Resource-Estimate": (
+            "READ-ONLY CAPACITY CHECK",
+            "Use to compare pod demand against venue capacity. Edit venue_input.xlsx for changes.",
+            "D9EAF7",
+        ),
+        "Schedule-Input": (
+            "GENERATED LOOKUP / MACHINE CONTRACT VIEW",
+            "Copy exact resource_id, slot, and game_id values from here; do not hand-edit.",
+            "D9EAF7",
+        ),
+        "Pool-Assignment": (
+            "TEMPORARY EDIT SURFACE",
+            "Edit seeds or pool placements here, then rerun assign-pools --workbook.",
+            "FFF2CC",
+        ),
+        "Gym-Allocation": (
+            "READ-ONLY ALLOCATION AUDIT",
+            "Generated gym-mode allocation audit. Change venue inputs, then rerun the workflow.",
+            "D9EAF7",
+        ),
+        "Schedule-by-Time": (
+            "FINAL OUTPUT",
+            "Final schedule view by time. Do not edit; rerun the scheduler if inputs change.",
+            "D9EAD3",
+        ),
+        "Schedule-by-Sport": (
+            "FINAL OUTPUT",
+            "Final schedule view by sport. Do not edit; rerun the scheduler if inputs change.",
+            "D9EAD3",
+        ),
+        "Master-Schedule": (
+            "FINAL OUTPUT",
+            "Final master grid. Do not edit; rerun the scheduler if inputs change.",
+            "D9EAD3",
+        ),
+        "Conflict-Audit": (
+            "AUDIT OUTPUT",
+            "Audit conflicts and warnings here before publishing the final schedule.",
+            "F4CCCC",
+        ),
+    }
+    _SPORT_EXPORT_TAB_STATUS: Tuple[str, str, str] = (
+        "READ-ONLY OUTPUT",
+        "Generated sport-specific roster view. Do not edit; rerun export-church-teams.",
+        "D9EAF7",
+    )
 
     _POOL_ASSIGNMENT_COLUMNS: List[str] = [
         "Event",
@@ -3564,6 +3666,85 @@ class ScheduleWorkbookBuilder:
         cell.comment = Comment(note, "VAYSF")
 
     @classmethod
+    def _stamp_tab_status_banner(
+        cls,
+        ws,
+        status: str,
+        guidance: str,
+        *,
+        fill_color: str,
+    ) -> None:
+        """Add a non-disruptive tab role banner outside the data table."""
+        from openpyxl.styles import Alignment, Border, Font, PatternFill, Side
+        from openpyxl.utils import get_column_letter
+
+        start_col = max(ws.max_column or 1, 1) + 2
+        end_col = start_col + 3
+        ws.merge_cells(
+            start_row=1,
+            start_column=start_col,
+            end_row=1,
+            end_column=end_col,
+        )
+        ws.merge_cells(
+            start_row=2,
+            start_column=start_col,
+            end_row=2,
+            end_column=end_col,
+        )
+
+        title_cell = ws.cell(row=1, column=start_col, value=f"STATUS: {status}")
+        body_cell = ws.cell(row=2, column=start_col, value=guidance)
+        fill = PatternFill("solid", fgColor=fill_color)
+        border = Border(
+            left=Side(style="thin", color="999999"),
+            right=Side(style="thin", color="999999"),
+            top=Side(style="thin", color="999999"),
+            bottom=Side(style="thin", color="999999"),
+        )
+        for row_idx in (1, 2):
+            for col_idx in range(start_col, end_col + 1):
+                cell = ws.cell(row=row_idx, column=col_idx)
+                cell.fill = fill
+                cell.border = border
+                cell.alignment = Alignment(
+                    horizontal="center",
+                    vertical="center",
+                    wrap_text=True,
+                )
+
+        title_cell.font = Font(bold=True, color="1F1F1F")
+        body_cell.font = Font(italic=True, color="1F1F1F")
+        ws.row_dimensions[1].height = max(ws.row_dimensions[1].height or 0, 22)
+        ws.row_dimensions[2].height = max(ws.row_dimensions[2].height or 0, 36)
+        for col_idx in range(start_col, end_col + 1):
+            col_letter = get_column_letter(col_idx)
+            ws.column_dimensions[col_letter].width = 18
+        ws.sheet_properties.tabColor = fill_color
+
+    @classmethod
+    def _stamp_known_tab_statuses(
+        cls,
+        wb,
+        *,
+        default_unknown: Optional[Tuple[str, str, str]] = None,
+    ) -> None:
+        """Stamp known workbook sheets with operator-facing role guidance."""
+        for ws in wb.worksheets:
+            guide = cls._TAB_STATUS_GUIDE.get(ws.title)
+            if guide is None:
+                guide = default_unknown
+            if guide is None:
+                continue
+            status, guidance, fill_color = guide
+            cls._stamp_tab_status_banner(
+                ws,
+                status,
+                guidance,
+                fill_color=fill_color,
+            )
+
+    @classmethod
     def _annotate_header_row(
         cls,
         ws,
@@ -5749,6 +5930,7 @@ class ScheduleWorkbookBuilder:
         for row_num in range(4, cur_row4):
             ws4.row_dimensions[row_num].height = 36
 
+        ScheduleWorkbookBuilder._stamp_known_tab_statuses(wb)
         wb.save(filepath)
         logger.info(f"Schedule output report written to: {filepath}")
 
@@ -5981,6 +6163,7 @@ class ScheduleWorkbookBuilder:
             # Summary tab (openpyxl native — operator guide / command cheat sheet)
             summary_ws = writer.book.create_sheet(title="Summary", index=0)
             self._write_summary_tab(summary_ws)
+            self._stamp_known_tab_statuses(writer.book)
 
         logger.info(f"Schedule workbook written to: {output_path}")
 

--- a/middleware/tests/test_church_teams_export.py
+++ b/middleware/tests/test_church_teams_export.py
@@ -4,11 +4,21 @@ from unittest.mock import MagicMock
 
 import pandas as pd
 import pytest
+from openpyxl import load_workbook
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from church_teams_export import ChurchTeamsExporter, CHM_FIELDS, MEMBERSHIP_QUESTION
 from config import Config, SPORT_TYPE
+
+
+def _status_banner_values(ws) -> set[str]:
+    return {
+        str(cell.value)
+        for row in ws.iter_rows(min_row=1, max_row=2)
+        for cell in row
+        if cell.value is not None
+    }
 
 
 @pytest.fixture()
@@ -550,6 +560,11 @@ def test_write_excel_report_adds_validation_issues_tab(mock_connectors, tmp_path
     assert validation_df.loc[0, "Issue Type"] == "doubles_non_member_limit"
     assert "Open_TEAM_Issue_Count (WP)" in roster_df.columns
     assert int(roster_df.loc[0, "Open_TEAM_Issue_Count (WP)"]) == 1
+    wb = load_workbook(filepath)
+    assert "STATUS: READ-ONLY OUTPUT" in _status_banner_values(wb["Summary"])
+    assert "STATUS: GENERATED DATA SOURCE" in _status_banner_values(wb["Roster"])
+    assert "STATUS: GENERATED DATA SOURCE" in _status_banner_values(wb["Validation-Issues"])
+    assert "STATUS: READ-ONLY OUTPUT" in _status_banner_values(wb["Badminton"])
 
 
 def test_validation_issue_rows_add_reverse_partner_suggestion(mock_connectors):

--- a/middleware/tests/test_main.py
+++ b/middleware/tests/test_main.py
@@ -15,6 +15,15 @@ def _run_main_expect_exit(expected_code: int) -> None:
     assert exc.value.code == expected_code
 
 
+def _status_banner_values(ws) -> set[str]:
+    return {
+        str(cell.value)
+        for row in ws.iter_rows(min_row=1, max_row=2)
+        for cell in row
+        if cell.value is not None
+    }
+
+
 def _minimal_schedule_input() -> dict:
     return {
         "generated_at": "2026-05-15T00:00:00",
@@ -324,6 +333,9 @@ def test_generate_venue_template_example_dates_match_day_labels(tmp_path):
     assert ws["F2"].value == "2026-07-18"
     assert ws["E4"].value == "Sun-1"
     assert ws["F4"].value == "2026-07-19"
+    assert "STATUS: EDITABLE INPUT" in _status_banner_values(wb["Venue-Input"])
+    assert "STATUS: EDITABLE INPUT" in _status_banner_values(wb["Gym-Modes"])
+    assert "STATUS: EDITABLE OVERRIDE INPUT" in _status_banner_values(wb["Playoff-Slots"])
 
 
 def test_main_solve_schedule_uses_default_paths(mocker, monkeypatch, tmp_path):

--- a/middleware/tests/test_schedule_workbook.py
+++ b/middleware/tests/test_schedule_workbook.py
@@ -42,6 +42,15 @@ def _sheet_rows(ws) -> list[dict]:
     return rows
 
 
+def _status_banner_values(ws) -> set[str]:
+    return {
+        str(cell.value)
+        for row in ws.iter_rows(min_row=1, max_row=2)
+        for cell in row
+        if cell.value is not None
+    }
+
+
 def _make_gym_roster(n_churches: int = 8) -> list[dict]:
     """Return minimal Basketball-Men roster rows for n_churches churches."""
     codes = ["RPC", "ANH", "FVC", "GAC", "NSD", "TLC", "GLA", "ORN"][:n_churches]
@@ -238,6 +247,12 @@ def test_write_schedule_workbook_creates_planning_tabs(tmp_path):
     assert "run-schedule.bat" in summary_text
     assert "assign-pools" in summary_text
     assert "BB/VBM/VBW/BC/SOC" in summary_text
+    assert "STATUS: READ-ONLY OUTPUT" in _status_banner_values(summary_ws)
+    assert "STATUS: TEMPORARY EDIT SURFACE" in _status_banner_values(wb["Pool-Assignment"])
+    assert "STATUS: GENERATED LOOKUP / MACHINE CONTRACT VIEW" in _status_banner_values(
+        wb["Schedule-Input"]
+    )
+    assert "STATUS: READ-ONLY ALLOCATION AUDIT" in _status_banner_values(wb["Gym-Allocation"])
     venue_ws = wb["Venue-Estimator"]
     assert venue_ws["A1"].comment is not None
     assert "Canonical event name" in venue_ws["A1"].comment.text
@@ -461,6 +476,8 @@ def test_write_schedule_output_workbook_creates_schedule_tabs(tmp_path):
 
     wb = load_workbook(workbook_path)
     assert wb.sheetnames == ["Schedule-by-Time", "Schedule-by-Sport", "Conflict-Audit", "Master-Schedule"]
+    assert "STATUS: FINAL OUTPUT" in _status_banner_values(wb["Schedule-by-Time"])
+    assert "STATUS: AUDIT OUTPUT" in _status_banner_values(wb["Conflict-Audit"])
 
 
 def test_read_roster_validation_rows_missing_path_degrades():


### PR DESCRIPTION
## Summary

Implements #139 — adds operator-facing status banners to all generated Excel workbooks so operators can immediately tell whether a tab is editable, read-only, a lookup view, or a temporary edit surface.

- **`schedule_workbook.py`** (+183 lines): stamped status banners at the top of each worksheet with fill colors and next-step guidance for `Pool-Assignment`, `Schedule-Input`, `Playoff-Slots`, `venue_input` tabs, and all `VAYSF_Schedule` / `Church_Team_Status` tabs
- **`church_teams_export.py`** (+5): banner stamps on church team status tabs
- **`main.py`** (+2): minor wiring for banner helper
- **`docs/SCHEDULE-HOW-TO.md`** (+27): tab status map matching the spreadsheet banners
- **`tests/test_schedule_workbook.py`** (+17), **`tests/test_church_teams_export.py`** (+15), **`tests/test_main.py`** (+12): regression tests for banner presence

## Test plan

- [ ] All tests pass (`pytest tests/`)
- [ ] Generated workbooks show status banners with correct fill colors
- [ ] `Pool-Assignment` banner warns that edits require re-running `assign-pools`
- [ ] `Schedule-Input` banner warns not to edit and explains it is a lookup view
- [ ] `docs/SCHEDULE-HOW-TO.md` tab status map is present and accurate

---
_Generated by [Claude Code](https://claude.ai/code/session_01RHRXW2PQXgDmbHAcpbqVYS)_