### PR TITLE
scheduler: add resource-vector diagnostics for schedule attempts

### DIFF
--- a/docs/SCHEDULE-HOW-TO.md
+++ b/docs/SCHEDULE-HOW-TO.md
@@ -64,6 +64,11 @@ The report summarizes game demand, resource supply, overlapping physical gym
 mode windows, playoff pins, precedence, gym allocation, unscheduled games,
 conflict audit status, and next-action suggestions.
 
+If a solved schedule is `OPTIMAL` or `FEASIBLE`, has zero unscheduled games,
+and has no physical gym overlap warnings, gym-mode shortfalls are shown as
+informational capacity notes. They mean the rough venue estimate is tight or
+conservative, not that a game failed to schedule.
+
 ---
 
 ## Tab Status Map

--- a/docs/SCHEDULE-HOW-TO.md
+++ b/docs/SCHEDULE-HOW-TO.md
@@ -40,6 +40,30 @@ The most important dependency to remember:
 So after editing `venue_input.xlsx`, you usually rerun
 `export-church-teams` first.
 
+There are two different success levels:
+
+- **Feasible schedule**: every required game can be placed legally.
+- **Reasonable master schedule**: every game can be placed legally, and the
+  result makes human sense for directors, athletes, and venue staff.
+
+When a run fails or looks strange, treat the next step as a vector diagnosis
+rather than a one-shot retry. The main vectors are demand, supply, gym modes,
+pool assignment, fixed playoff pins, precedence, shared-athlete conflicts, and
+quality preferences.
+
+Use the diagnostic command any time you want a compact "what should I adjust
+next?" report:
+
+```text
+python main.py diagnose-schedule
+python main.py diagnose-schedule --output data/schedule_diagnostics.json
+python main.py diagnose-schedule --input data/schedule_input.json --schedule-output data/schedule_output.json
+```
+
+The report summarizes game demand, resource supply, overlapping physical gym
+mode windows, playoff pins, precedence, gym allocation, unscheduled games,
+conflict audit status, and next-action suggestions.
+
 ---
 
 ## Tab Status Map
@@ -84,9 +108,10 @@ flowchart TD
     F -- No --> I{"Did Playoff-Slots change?"}
     I -- Yes --> J["Edit Playoff-Slots tab in venue_input.xlsx"]
     J --> B
-    I -- No --> K["run-schedule.bat"]
-    B --> K
-    K --> L["VAYSF_Schedule_*.xlsx"]
+    I -- No --> K["python main.py diagnose-schedule"]
+    K --> L["run-schedule.bat"]
+    B --> L
+    L --> M["VAYSF_Schedule_*.xlsx"]
 ```
 
 ---

--- a/middleware/gym_allocator.py
+++ b/middleware/gym_allocator.py
@@ -290,7 +290,7 @@ def allocate(
                 ch = _court_hours(block, courts)
                 if ch <= 0:
                     continue
-                available.discard(block)
+                _claim_physical_gym_window(available, block)
                 decisions.append(AllocationDecision(
                     gym_name=gym_name,
                     day=block.day,
@@ -337,7 +337,7 @@ def allocate(
             candidates,
             key=lambda mc: (_spread_blocks_per_mode[mc[0]], -mc[1], sorted_modes.index(mc[0])),
         )
-        available.discard(block)
+        _claim_physical_gym_window(available, block)
         decisions.append(AllocationDecision(
             gym_name=block.gym_name,
             day=block.day,
@@ -376,6 +376,58 @@ def _court_hours(block: GymBlock, courts: int) -> float:
     """Court-hours a block provides at a given court count."""
     duration = max(0.0, _parse_time(block.close_time) - _parse_time(block.open_time))
     return courts * duration
+
+
+def _blocks_overlap_same_gym(left: GymBlock, right: GymBlock) -> bool:
+    """Return True when two blocks consume the same physical gym time."""
+    if left.gym_name != right.gym_name or left.day != right.day:
+        return False
+    return (
+        _parse_time(left.open_time) < _parse_time(right.close_time)
+        and _parse_time(right.open_time) < _parse_time(left.close_time)
+    )
+
+
+def _claim_physical_gym_window(available: set[GymBlock], block: GymBlock) -> None:
+    """Remove the claimed window while preserving non-overlapping fragments."""
+    replacements: set[GymBlock] = set()
+    for candidate in list(available):
+        if not _blocks_overlap_same_gym(block, candidate):
+            continue
+        available.discard(candidate)
+        if candidate == block:
+            continue
+
+        candidate_open = _parse_time(candidate.open_time)
+        candidate_close = _parse_time(candidate.close_time)
+        claim_open = _parse_time(block.open_time)
+        claim_close = _parse_time(block.close_time)
+
+        if candidate_open < claim_open:
+            before = GymBlock(
+                gym_name=candidate.gym_name,
+                day=candidate.day,
+                open_time=candidate.open_time,
+                close_time=block.open_time,
+                slot_minutes=candidate.slot_minutes,
+                resource_types=candidate.resource_types,
+            )
+            if _court_hours(before, 1) * 60 >= candidate.slot_minutes:
+                replacements.add(before)
+
+        if claim_close < candidate_close:
+            after = GymBlock(
+                gym_name=candidate.gym_name,
+                day=candidate.day,
+                open_time=block.close_time,
+                close_time=candidate.close_time,
+                slot_minutes=candidate.slot_minutes,
+                resource_types=candidate.resource_types,
+            )
+            if _court_hours(after, 1) * 60 >= candidate.slot_minutes:
+                replacements.add(after)
+
+    available.update(replacements)
 
 
 def _last_mode_in_gym(gym_name: str, decisions: List[AllocationDecision]) -> Optional[str]:

--- a/middleware/main.py
+++ b/middleware/main.py
@@ -171,6 +171,27 @@ def parse_args() -> argparse.Namespace:
         help="Path for schedule_output.json (default: DATA_DIR/schedule_output.json)",
     )
 
+    # Diagnose-schedule command
+    diagnose_schedule_parser = subparsers.add_parser(
+        "diagnose-schedule",
+        help="Explain demand/supply/control/audit pressure for a schedule attempt",
+    )
+    diagnose_schedule_parser.add_argument(
+        "--input",
+        default=None,
+        help="Path to schedule_input.json (default: EXPORT_DIR/schedule_input.json)",
+    )
+    diagnose_schedule_parser.add_argument(
+        "--schedule-output",
+        default=None,
+        help="Optional path to schedule_output.json (default: EXPORT_DIR/schedule_output.json if it exists)",
+    )
+    diagnose_schedule_parser.add_argument(
+        "--output",
+        default=None,
+        help="Optional path for diagnostics JSON",
+    )
+
     # Produce-schedule command
     produce_schedule_parser = subparsers.add_parser(
         "produce-schedule",
@@ -360,6 +381,15 @@ def _resolve_pool_assignments_sidecar_path(
     return ScheduleWorkbookBuilder._pool_assignments_sidecar_path(
         Path(workbook_or_output_path).parent
     )
+
+
+def _default_schedule_json_path(filename: str) -> Path:
+    """Return the default runtime schedule JSON path.
+
+    run-schedule.bat uses EXPORT_DIR when it is configured, so the interactive
+    CLI should point at the same schedule_input/output files.
+    """
+    return Path(EXPORT_DIR) / filename if EXPORT_DIR else DATA_DIR / filename
 
 @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, min=4, max=10))
 def run_sync(manager: SyncManager, sync_type: str = "full", chm_id: Optional[str] = None,
@@ -999,6 +1029,21 @@ def main() -> None:
         input_path = Path(args.input) if args.input else DATA_DIR / "schedule_input.json"
         output_path = Path(args.output) if args.output else DATA_DIR / "schedule_output.json"
         exit_code = run_solve_schedule(input_path, output_path)
+        sys.exit(exit_code)
+    elif args.command == "diagnose-schedule":
+        from schedule_diagnostics import run_diagnose_schedule
+        input_path = Path(args.input) if args.input else _default_schedule_json_path("schedule_input.json")
+        if args.schedule_output:
+            schedule_output_path = Path(args.schedule_output)
+        else:
+            default_output = _default_schedule_json_path("schedule_output.json")
+            schedule_output_path = default_output if default_output.exists() else None
+        diagnostics_path = Path(args.output) if args.output else None
+        exit_code = run_diagnose_schedule(
+            input_path,
+            schedule_output_path=schedule_output_path,
+            output_path=diagnostics_path,
+        )
         sys.exit(exit_code)
     elif args.command == "produce-schedule":
         from schedule_workbook import ScheduleWorkbookBuilder

--- a/middleware/schedule_diagnostics.py
+++ b/middleware/schedule_diagnostics.py
@@ -400,9 +400,33 @@ def _suggest_next_actions(
                 }
             )
 
+    output_status = str(audit.get("status") or "")
+    has_bad_output = bool(output_status and output_status not in SOLVED_STATUSES)
+    has_unscheduled = _as_int(audit.get("unscheduled_count"), 0) > 0
+    has_physical_overlaps = bool(supply.get("exclusive_group_overlaps"))
+    has_healthy_solution = (
+        audit.get("available")
+        and output_status in SOLVED_STATUSES
+        and not has_unscheduled
+        and not has_physical_overlaps
+    )
+
     gym_shortfall = control.get("gym_allocation", {}).get("mode_shortfall", {}) or {}
     for mode, shortfall in sorted(gym_shortfall.items()):
-        if _as_int(shortfall, 0) > 0:
+        if _as_int(shortfall, 0) <= 0:
+            continue
+        if has_healthy_solution:
+            suggestions.append(
+                {
+                    "vector": "capacity note",
+                    "severity": "info",
+                    "message": (
+                        f"{mode} estimated demand exceeds allocator supply by "
+                        f"{shortfall} slot(s), but all games were scheduled."
+                    ),
+                }
+            )
+        else:
             suggestions.append(
                 {
                     "vector": "gym modes",
@@ -414,9 +438,6 @@ def _suggest_next_actions(
                 }
             )
 
-    output_status = str(audit.get("status") or "")
-    has_bad_output = bool(output_status and output_status not in SOLVED_STATUSES)
-    has_unscheduled = _as_int(audit.get("unscheduled_count"), 0) > 0
     if (has_bad_output or has_unscheduled) and control.get("playoff_slots_count", 0):
         suggestions.append(
             {

--- a/middleware/schedule_diagnostics.py
+++ b/middleware/schedule_diagnostics.py
@@ -1,0 +1,572 @@
+"""Operator-facing diagnostics for iterative schedule planning.
+
+The solver answers "can this exact contract be scheduled?"  This module helps
+operators answer the next question: which vector should we adjust before the
+next attempt?
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+
+from scheduler import build_infeasibility_diagnostics, build_resource_slots
+
+
+SOLVED_STATUSES = {"OPTIMAL", "FEASIBLE"}
+
+
+def _as_int(value: Any, default: int = 0) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _parse_hhmm_minutes(value: Any) -> int | None:
+    text = str(value or "").strip()
+    if not text or ":" not in text:
+        return None
+    hour, minute = text.split(":", 1)
+    try:
+        return int(hour) * 60 + int(minute)
+    except ValueError:
+        return None
+
+
+def _counter_rows(counter: Counter, key_name: str) -> list[dict[str, Any]]:
+    return [
+        {key_name: key, "count": count}
+        for key, count in sorted(counter.items(), key=lambda item: (-item[1], str(item[0])))
+    ]
+
+
+def _solver_pool_key(item: dict[str, Any]) -> str:
+    return str(item.get("solver_pool") or item.get("resource_type") or "Unspecified")
+
+
+def _resource_type_by_game(schedule_input: dict[str, Any]) -> dict[str, str]:
+    return {
+        str(game.get("game_id") or ""): str(game.get("resource_type") or "Unspecified")
+        for game in schedule_input.get("games", [])
+    }
+
+
+def _event_by_game(schedule_input: dict[str, Any]) -> dict[str, str]:
+    return {
+        str(game.get("game_id") or ""): str(game.get("event") or "Unspecified")
+        for game in schedule_input.get("games", [])
+    }
+
+
+def _find_exclusive_group_overlaps(resources: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Find overlapping sport-mode windows inside one physical gym group.
+
+    These overlaps are dangerous because separate solver pools can each use
+    their own resources legally while the physical gym can only be in one mode
+    at a time.
+    """
+    by_group_day: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
+    for resource in resources:
+        group = str(resource.get("exclusive_group") or "").strip()
+        day = str(resource.get("day") or "").strip()
+        if group and day:
+            by_group_day[(group, day)].append(resource)
+
+    grouped_overlaps: dict[tuple[str, ...], dict[str, Any]] = {}
+    for (group, day), group_resources in by_group_day.items():
+        ordered = sorted(
+            group_resources,
+            key=lambda resource: (
+                str(resource.get("open_time") or ""),
+                str(resource.get("close_time") or ""),
+                str(resource.get("resource_type") or ""),
+                str(resource.get("resource_id") or ""),
+            ),
+        )
+        for idx, first in enumerate(ordered):
+            first_type = str(first.get("resource_type") or "Unspecified")
+            first_open = _parse_hhmm_minutes(first.get("open_time"))
+            first_close = _parse_hhmm_minutes(first.get("close_time"))
+            if first_open is None or first_close is None:
+                continue
+            for second in ordered[idx + 1:]:
+                second_type = str(second.get("resource_type") or "Unspecified")
+                if second_type == first_type:
+                    continue
+                second_open = _parse_hhmm_minutes(second.get("open_time"))
+                second_close = _parse_hhmm_minutes(second.get("close_time"))
+                if second_open is None or second_close is None:
+                    continue
+                if not (first_open < second_close and second_open < first_close):
+                    continue
+
+                left = (
+                    first_type,
+                    str(first.get("open_time") or ""),
+                    str(first.get("close_time") or ""),
+                )
+                right = (
+                    second_type,
+                    str(second.get("open_time") or ""),
+                    str(second.get("close_time") or ""),
+                )
+                if right < left:
+                    first_resource = second
+                    second_resource = first
+                    left, right = right, left
+                else:
+                    first_resource = first
+                    second_resource = second
+                key = (group, day, *left, *right)
+                row = grouped_overlaps.setdefault(
+                    key,
+                    {
+                        "exclusive_group": group,
+                        "day": day,
+                        "first_resource_type": left[0],
+                        "first_open_time": left[1],
+                        "first_close_time": left[2],
+                        "second_resource_type": right[0],
+                        "second_open_time": right[1],
+                        "second_close_time": right[2],
+                        "overlapping_resource_pairs": 0,
+                        "example_resource_ids": [],
+                    },
+                )
+                row["overlapping_resource_pairs"] += 1
+                if len(row["example_resource_ids"]) < 3:
+                    row["example_resource_ids"].append(
+                        [
+                            str(first_resource.get("resource_id") or ""),
+                            str(second_resource.get("resource_id") or ""),
+                        ]
+                    )
+
+    return sorted(
+        grouped_overlaps.values(),
+        key=lambda row: (
+            row["exclusive_group"],
+            row["day"],
+            row["first_open_time"],
+            row["first_resource_type"],
+            row["second_open_time"],
+            row["second_resource_type"],
+        ),
+    )
+
+
+def _summarize_demand(schedule_input: dict[str, Any]) -> dict[str, Any]:
+    games = schedule_input.get("games", []) or []
+    resources = schedule_input.get("resources", []) or []
+    resources_by_type: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for resource in resources:
+        resources_by_type[str(resource.get("resource_type") or "Unspecified")].append(resource)
+
+    by_resource_type: dict[str, dict[str, Any]] = {}
+    by_event = Counter()
+    by_solver_pool = Counter()
+    constrained_games = 0
+
+    for game in games:
+        resource_type = str(game.get("resource_type") or "Unspecified")
+        event = str(game.get("event") or "Unspecified")
+        solver_pool = _solver_pool_key(game)
+        by_event[event] += 1
+        by_solver_pool[solver_pool] += 1
+        if game.get("earliest_slot") or game.get("latest_slot"):
+            constrained_games += 1
+
+        compatible = resources_by_type.get(resource_type, [])
+        lower_bound_slots = 0
+        if compatible:
+            duration = _as_int(game.get("duration_minutes"), 0)
+            lower_bound_slots = min(
+                max(1, math.ceil(duration / max(_as_int(resource.get("slot_minutes"), 1), 1)))
+                for resource in compatible
+            )
+
+        row = by_resource_type.setdefault(
+            resource_type,
+            {
+                "resource_type": resource_type,
+                "game_count": 0,
+                "required_slots_lower_bound": 0,
+                "events": Counter(),
+                "solver_pools": Counter(),
+            },
+        )
+        row["game_count"] += 1
+        row["required_slots_lower_bound"] += lower_bound_slots
+        row["events"][event] += 1
+        row["solver_pools"][solver_pool] += 1
+
+    resource_rows = []
+    for row in by_resource_type.values():
+        resource_rows.append(
+            {
+                "resource_type": row["resource_type"],
+                "game_count": row["game_count"],
+                "required_slots_lower_bound": row["required_slots_lower_bound"],
+                "events": _counter_rows(row["events"], "event"),
+                "solver_pools": _counter_rows(row["solver_pools"], "solver_pool"),
+            }
+        )
+
+    resource_rows.sort(
+        key=lambda row: (-row["required_slots_lower_bound"], -row["game_count"], row["resource_type"])
+    )
+
+    return {
+        "total_games": len(games),
+        "constrained_games": constrained_games,
+        "by_resource_type": resource_rows,
+        "by_event": _counter_rows(by_event, "event"),
+        "by_solver_pool": _counter_rows(by_solver_pool, "solver_pool"),
+    }
+
+
+def _summarize_supply(schedule_input: dict[str, Any]) -> dict[str, Any]:
+    resources = schedule_input.get("resources", []) or []
+    blocked_slots = {
+        str(resource_id): set(slots or [])
+        for resource_id, slots in (schedule_input.get("blocked_slots", {}) or {}).items()
+    }
+    slots_by_resource = build_resource_slots(resources) if resources else {}
+
+    by_resource_type: dict[str, dict[str, Any]] = {}
+    by_solver_pool = Counter()
+
+    for resource in resources:
+        resource_type = str(resource.get("resource_type") or "Unspecified")
+        solver_pool = _solver_pool_key(resource)
+        resource_id = str(resource.get("resource_id") or "")
+        slots = slots_by_resource.get(resource_id, [])
+        blocked_count = sum(1 for slot in slots if slot in blocked_slots.get(resource_id, set()))
+        row = by_resource_type.setdefault(
+            resource_type,
+            {
+                "resource_type": resource_type,
+                "resource_count": 0,
+                "available_slots": 0,
+                "blocked_slots": 0,
+                "days": set(),
+                "solver_pools": Counter(),
+            },
+        )
+        row["resource_count"] += 1
+        row["available_slots"] += max(len(slots) - blocked_count, 0)
+        row["blocked_slots"] += blocked_count
+        row["days"].add(str(resource.get("day") or ""))
+        row["solver_pools"][solver_pool] += 1
+        by_solver_pool[solver_pool] += len(slots)
+
+    resource_rows = []
+    for row in by_resource_type.values():
+        resource_rows.append(
+            {
+                "resource_type": row["resource_type"],
+                "resource_count": row["resource_count"],
+                "available_slots": row["available_slots"],
+                "blocked_slots": row["blocked_slots"],
+                "days": sorted(day for day in row["days"] if day),
+                "solver_pools": _counter_rows(row["solver_pools"], "solver_pool"),
+            }
+        )
+    resource_rows.sort(key=lambda row: (-row["available_slots"], row["resource_type"]))
+
+    return {
+        "total_resources": len(resources),
+        "by_resource_type": resource_rows,
+        "slot_capacity_by_solver_pool": _counter_rows(by_solver_pool, "solver_pool"),
+        "exclusive_group_overlaps": _find_exclusive_group_overlaps(resources),
+    }
+
+
+def _summarize_control(schedule_input: dict[str, Any]) -> dict[str, Any]:
+    playoff_slots = schedule_input.get("playoff_slots", []) or []
+    gym_modes = schedule_input.get("gym_modes", {}) or {}
+    gym_allocation = schedule_input.get("gym_allocation", {}) or {}
+    stage_counts = Counter(str(slot.get("stage") or "Unspecified") for slot in playoff_slots)
+    resource_counts = Counter(str(slot.get("resource_type") or "Unspecified") for slot in playoff_slots)
+
+    conflict_edges = schedule_input.get("team_conflicts", []) or []
+    primary_edges = sum(
+        1 for edge in conflict_edges if _as_int(edge.get("primary_overlap_count"), 0) > 0
+    )
+    secondary_edges = max(len(conflict_edges) - primary_edges, 0)
+
+    return {
+        "playoff_slots_count": len(playoff_slots),
+        "playoff_slots_by_stage": _counter_rows(stage_counts, "stage"),
+        "playoff_slots_by_resource_type": _counter_rows(resource_counts, "resource_type"),
+        "precedence_count": len(schedule_input.get("precedence", []) or []),
+        "team_conflict_edges": len(conflict_edges),
+        "primary_conflict_edges": primary_edges,
+        "secondary_conflict_edges": secondary_edges,
+        "gym_modes_count": len(gym_modes),
+        "gym_allocation": {
+            "source": gym_allocation.get("source"),
+            "decision_count": len(gym_allocation.get("decisions", []) or []),
+            "switch_count": gym_allocation.get("switch_count"),
+            "mode_shortfall": gym_allocation.get("mode_shortfall", {}) or {},
+        },
+    }
+
+
+def _summarize_audit(
+    schedule_input: dict[str, Any],
+    schedule_output: dict[str, Any] | None,
+) -> dict[str, Any]:
+    if not schedule_output:
+        return {"available": False}
+
+    resource_type_by_game = _resource_type_by_game(schedule_input)
+    event_by_game = _event_by_game(schedule_input)
+    unscheduled = [str(game_id) for game_id in schedule_output.get("unscheduled", []) or []]
+    unscheduled_by_resource = Counter(
+        resource_type_by_game.get(game_id, "Unknown") for game_id in unscheduled
+    )
+    unscheduled_by_event = Counter(event_by_game.get(game_id, "Unknown") for game_id in unscheduled)
+    pool_statuses = Counter(
+        str(pool.get("status") or "Unknown")
+        for pool in schedule_output.get("pool_results", []) or []
+    )
+
+    return {
+        "available": True,
+        "status": schedule_output.get("status"),
+        "assigned_count": len(schedule_output.get("assignments", []) or []),
+        "unscheduled_count": len(unscheduled),
+        "unscheduled_by_resource_type": _counter_rows(unscheduled_by_resource, "resource_type"),
+        "unscheduled_by_event": _counter_rows(unscheduled_by_event, "event"),
+        "pool_statuses": _counter_rows(pool_statuses, "status"),
+        "conflict_audit_summary": schedule_output.get("conflict_audit_summary", {}) or {},
+    }
+
+
+def _suggest_next_actions(
+    diagnostics: dict[str, Any],
+    capacity_diagnostics: list[dict[str, Any]],
+) -> list[dict[str, str]]:
+    suggestions: list[dict[str, str]] = []
+    control = diagnostics["control"]
+    audit = diagnostics["audit"]
+    supply = diagnostics["supply"]
+
+    for overlap in supply.get("exclusive_group_overlaps", []):
+        suggestions.append(
+            {
+                "vector": "supply",
+                "severity": "high",
+                "message": (
+                    f"{overlap['exclusive_group']} on {overlap['day']} has overlapping "
+                    f"{overlap['first_resource_type']} "
+                    f"{overlap['first_open_time']}-{overlap['first_close_time']} and "
+                    f"{overlap['second_resource_type']} "
+                    f"{overlap['second_open_time']}-{overlap['second_close_time']} windows. "
+                    "Split or narrow venue rows so one physical gym is in only one mode at a time."
+                ),
+            }
+        )
+
+    for capacity in capacity_diagnostics:
+        for missing in capacity.get("missing_resource_events", []):
+            suggestions.append(
+                {
+                    "vector": "supply",
+                    "severity": "high",
+                    "message": (
+                        f"Add or rename {capacity['resource_type']} supply; "
+                        f"{missing['game_count']} {missing['event']} game(s) have no compatible resource."
+                    ),
+                }
+            )
+        if capacity.get("shortage_slots", 0) > 0:
+            suggestions.append(
+                {
+                    "vector": "demand/supply",
+                    "severity": "high",
+                    "message": (
+                        f"{capacity['resource_type']} is short by "
+                        f"{capacity['shortage_slots']} lower-bound slot(s); reduce games, "
+                        "add resources, or widen time windows."
+                    ),
+                }
+            )
+
+    gym_shortfall = control.get("gym_allocation", {}).get("mode_shortfall", {}) or {}
+    for mode, shortfall in sorted(gym_shortfall.items()):
+        if _as_int(shortfall, 0) > 0:
+            suggestions.append(
+                {
+                    "vector": "gym modes",
+                    "severity": "medium",
+                    "message": (
+                        f"Gym mode allocation reports {shortfall} missing slot(s) for {mode}; "
+                        "adjust Gym-Modes or protect direct venue rows."
+                    ),
+                }
+            )
+
+    output_status = str(audit.get("status") or "")
+    has_bad_output = bool(output_status and output_status not in SOLVED_STATUSES)
+    has_unscheduled = _as_int(audit.get("unscheduled_count"), 0) > 0
+    if (has_bad_output or has_unscheduled) and control.get("playoff_slots_count", 0):
+        suggestions.append(
+            {
+                "vector": "fixed pins",
+                "severity": "medium",
+                "message": (
+                    "Run one solve without Playoff-Slots, then add pins back gradually "
+                    "to see whether fixed playoff rows are blocking feasible pool slots."
+                ),
+            }
+        )
+
+    if has_unscheduled and control.get("precedence_count", 0):
+        suggestions.append(
+            {
+                "vector": "precedence",
+                "severity": "medium",
+                "message": (
+                    "Review QF/Semi/Final ordering windows; precedence may be making an "
+                    "otherwise roomy schedule impossible."
+                ),
+            }
+        )
+
+    conflict_summary = audit.get("conflict_audit_summary", {}) or {}
+    remaining_conflicts = (
+        _as_int(conflict_summary.get("overlapping_edges"), 0)
+        + _as_int(conflict_summary.get("remaining_primary_overlap_penalty"), 0)
+        + _as_int(conflict_summary.get("remaining_secondary_overlap_penalty"), 0)
+    )
+    if remaining_conflicts > 0:
+        suggestions.append(
+            {
+                "vector": "conflict graph",
+                "severity": "medium",
+                "message": (
+                    "Remaining shared-athlete conflicts exist; inspect Conflict-Audit "
+                    "and consider pool assignment changes before adding more supply."
+                ),
+            }
+        )
+
+    if not audit.get("available"):
+        suggestions.append(
+            {
+                "vector": "audit",
+                "severity": "info",
+                "message": (
+                    "No schedule_output.json was supplied; run solve-schedule after "
+                    "reviewing demand/supply pressure."
+                ),
+            }
+        )
+
+    if not suggestions:
+        suggestions.append(
+            {
+                "vector": "quality",
+                "severity": "info",
+                "message": (
+                    "No obvious hard pressure found. If the schedule is feasible but ugly, "
+                    "review late finishes, spacing, gym switches, and operator concerns."
+                ),
+            }
+        )
+
+    return suggestions
+
+
+def build_schedule_diagnostics(
+    schedule_input: dict[str, Any],
+    schedule_output: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build demand/supply/control/audit diagnostics for one schedule attempt."""
+    capacity = build_infeasibility_diagnostics(schedule_input)
+    diagnostics = {
+        "summary": {
+            "generated_at": schedule_input.get("generated_at"),
+            "game_count": len(schedule_input.get("games", []) or []),
+            "resource_count": len(schedule_input.get("resources", []) or []),
+            "has_schedule_output": schedule_output is not None,
+        },
+        "demand": _summarize_demand(schedule_input),
+        "supply": _summarize_supply(schedule_input),
+        "control": _summarize_control(schedule_input),
+        "capacity_pressure": capacity,
+        "audit": _summarize_audit(schedule_input, schedule_output),
+    }
+    diagnostics["next_actions"] = _suggest_next_actions(diagnostics, capacity)
+    return diagnostics
+
+
+def format_schedule_diagnostics(diagnostics: dict[str, Any]) -> list[str]:
+    """Render a compact text summary for CLI logs."""
+    summary = diagnostics["summary"]
+    audit = diagnostics["audit"]
+    lines = [
+        (
+            "Schedule diagnostics: "
+            f"{summary['game_count']} game(s), {summary['resource_count']} resource(s), "
+            f"schedule_output={'yes' if summary['has_schedule_output'] else 'no'}."
+        )
+    ]
+    if audit.get("available"):
+        lines.append(
+            f"Audit: status={audit.get('status')}, assigned={audit.get('assigned_count')}, "
+            f"unscheduled={audit.get('unscheduled_count')}."
+        )
+    for action in diagnostics.get("next_actions", []):
+        lines.append(
+            f"Next action [{action['severity']}/{action['vector']}]: {action['message']}"
+        )
+    return lines
+
+
+def run_diagnose_schedule(
+    input_path: Path,
+    schedule_output_path: Path | None = None,
+    output_path: Path | None = None,
+) -> int:
+    """Load schedule files, log diagnostics, and optionally write a JSON report."""
+    try:
+        schedule_input = json.loads(Path(input_path).read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        logger.error(f"diagnose-schedule: schedule_input.json not found at {input_path}")
+        return 1
+    except json.JSONDecodeError as exc:
+        logger.error(f"diagnose-schedule: invalid JSON in {input_path}: {exc}")
+        return 1
+
+    schedule_output = None
+    if schedule_output_path:
+        path = Path(schedule_output_path)
+        if path.exists():
+            try:
+                schedule_output = json.loads(path.read_text(encoding="utf-8"))
+            except json.JSONDecodeError as exc:
+                logger.error(f"diagnose-schedule: invalid JSON in {path}: {exc}")
+                return 1
+        else:
+            logger.warning(f"diagnose-schedule: schedule output not found at {path}")
+
+    diagnostics = build_schedule_diagnostics(schedule_input, schedule_output)
+    for line in format_schedule_diagnostics(diagnostics):
+        logger.info(line)
+
+    if output_path:
+        output = Path(output_path)
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(json.dumps(diagnostics, indent=2), encoding="utf-8")
+        logger.info(f"Schedule diagnostics JSON written to: {output.resolve()}")
+
+    return 0

--- a/middleware/schedule_workbook.py
+++ b/middleware/schedule_workbook.py
@@ -6,6 +6,7 @@
 # ChurchTeamsExporter.  One-way dependency: church_teams_export.py may import
 # from here; this module must NOT import from church_teams_export.
 import json
+import os
 import pandas as pd
 from pathlib import Path
 from loguru import logger
@@ -14,6 +15,7 @@ from datetime import datetime
 from collections import defaultdict, deque
 import random
 import re
+import zipfile
 from math import ceil
 
 from config import (
@@ -3666,6 +3668,77 @@ class ScheduleWorkbookBuilder:
 
         cell.comment = Comment(note, "VAYSF")
 
+    @staticmethod
+    def _make_excel_note_shapes_visible(xlsx_path: Path) -> bool:
+        """Patch openpyxl's hidden VML note shapes so Excel opens them by default.
+
+        openpyxl writes comments as legacy VML notes and currently ignores
+        Comment.visible. The workbook XML is otherwise valid, so we patch only
+        the generated VML note shapes after save, preserving openpyxl's existing
+        Excel namespace prefix instead of injecting a conflicting namespace.
+        """
+        xlsx_path = Path(xlsx_path)
+        excel_ns = "urn:schemas-microsoft-com:office:excel"
+        patched_any = False
+        tmp_path = xlsx_path.with_suffix(f"{xlsx_path.suffix}.tmp")
+
+        try:
+            with zipfile.ZipFile(xlsx_path, "r") as zin, zipfile.ZipFile(
+                tmp_path, "w", compression=zipfile.ZIP_DEFLATED
+            ) as zout:
+                for item in zin.infolist():
+                    data = zin.read(item.filename)
+                    if (
+                        item.filename.startswith("xl/drawings/")
+                        and item.filename.endswith(".vml")
+                        and b'ObjectType="Note"' in data
+                    ):
+                        text = data.decode("utf-8")
+                        prefix_match = re.search(
+                            rf'xmlns:([A-Za-z_][\w.-]*)="{re.escape(excel_ns)}"',
+                            text,
+                        )
+                        if prefix_match:
+                            excel_prefix = prefix_match.group(1)
+                            client_data_re = re.compile(
+                                rf"(<{re.escape(excel_prefix)}:ClientData\b"
+                                rf"(?=[^>]*\bObjectType=\"Note\")[^>]*>)"
+                                rf"(.*?)"
+                                rf"(</{re.escape(excel_prefix)}:ClientData>)",
+                                re.DOTALL,
+                            )
+
+                            def _show_note(match: re.Match) -> str:
+                                nonlocal patched_any
+                                body = match.group(2)
+                                if f"<{excel_prefix}:Visible" not in body:
+                                    patched_any = True
+                                    body = f"{body}<{excel_prefix}:Visible />"
+                                return f"{match.group(1)}{body}{match.group(3)}"
+
+                            text = client_data_re.sub(_show_note, text)
+
+                        visible_text = re.sub(
+                            r"visibility\s*:\s*hidden",
+                            "visibility:visible",
+                            text,
+                        )
+                        if visible_text != text:
+                            patched_any = True
+                        data = visible_text.encode("utf-8")
+
+                    zout.writestr(item, data)
+
+            if patched_any:
+                os.replace(tmp_path, xlsx_path)
+            else:
+                tmp_path.unlink(missing_ok=True)
+            return patched_any
+        except Exception as exc:
+            tmp_path.unlink(missing_ok=True)
+            logger.warning(f"Could not patch Excel note visibility in {xlsx_path}: {exc}")
+            return False
+
     @classmethod
     def _stamp_tab_status_banner(
         cls,
@@ -5957,6 +6030,7 @@ class ScheduleWorkbookBuilder:
 
         ScheduleWorkbookBuilder._stamp_known_tab_statuses(wb)
         wb.save(filepath)
+        ScheduleWorkbookBuilder._make_excel_note_shapes_visible(filepath)
         logger.info(f"Schedule output report written to: {filepath}")
 
     # ── ALL-workbook readers (build-schedule-workbook input) ─────────────────

--- a/middleware/tests/test_gym_allocator.py
+++ b/middleware/tests/test_gym_allocator.py
@@ -10,6 +10,7 @@ from gym_allocator import (
     aggregate_demand_by_mode,
     allocate,
     _court_hours,
+    _blocks_overlap_same_gym,
     _switch_penalty,
     _count_switches,
 )
@@ -541,13 +542,13 @@ def _block_with_types(gym: str, resource_types, open_t: str = "08:00",
                     slot_minutes=slot, resource_types=frozenset(resource_types))
 
 
-def test_allocate_bd_prefers_own_block_over_bb_block():
-    """Regression: Badminton should claim its 13:00-17:00 block, not the 08:00-17:00
-    Basketball/Volleyball block that happens to be available in the same gym.
+def test_allocate_overlapping_same_gym_blocks_are_mutually_exclusive():
+    """A physical gym cannot be Basketball 08:00-17:00 and Badminton 13:00-17:00.
 
-    Before the fix: allocate() sorted blocks earliest-first so BD grabbed the
-    08:00-17:00 block (born from BB/VB rows) instead of its 13:00-17:00 block.
-    After the fix: resource_types-aware sort prefers the BD-native 13:00-17:00 block.
+    The earlier resource-types fix made Badminton prefer its native 13:00 block.
+    That still left a physical double-booking when Basketball had already claimed
+    the wider 08:00-17:00 window. Claiming one block must remove overlapping
+    same-gym windows from later allocation.
     """
     demand = {"Basketball Court": 100.0, "Badminton Court": 20.0}
     gym_modes = {"EHS Main Gym": {"Basketball Court": 2, "Badminton Court": 6}}
@@ -560,13 +561,73 @@ def test_allocate_bd_prefers_own_block_over_bb_block():
                                 open_t="13:00", close_t="17:00", day="Sat-2")
 
     # Demand for BB is far above what either block provides; it will claim Block A.
-    # BD should then take Block B (its native block), not whatever is left.
+    # BD must not also take Block B because the two windows overlap physically.
     result = allocate(demand, gym_modes, [block_a, block_b])
 
+    assert _blocks_overlap_same_gym(block_a, block_b)
+    bb_decisions = [d for d in result.decisions if d.mode == "Basketball Court"]
     bd_decisions = [d for d in result.decisions if d.mode == "Badminton Court"]
-    assert len(bd_decisions) == 1
-    assert bd_decisions[0].open_time == "13:00", (
-        "BD should have claimed its native 13:00-17:00 block, not the BB 08:00-17:00 block"
+    assert len(bb_decisions) == 1
+    assert bd_decisions == []
+    assert result.mode_shortfall["Badminton Court"] == pytest.approx(20.0)
+
+
+def test_allocate_non_overlapping_same_gym_blocks_can_switch_modes():
+    """Back-to-back windows in the same gym are still valid mode switches."""
+    demand = {"Basketball Court": 8.0, "Badminton Court": 24.0}
+    gym_modes = {"EHS Main Gym": {"Basketball Court": 2, "Badminton Court": 6}}
+
+    bb_block = _block_with_types("EHS Main Gym", ["Basketball Court"],
+                                 open_t="08:00", close_t="12:00", day="Sat-2")
+    bad_block = _block_with_types("EHS Main Gym", ["Badminton Court"],
+                                  open_t="13:00", close_t="17:00", day="Sat-2")
+
+    result = allocate(demand, gym_modes, [bb_block, bad_block])
+
+    assert not _blocks_overlap_same_gym(bb_block, bad_block)
+    assert {(d.mode, d.open_time, d.close_time) for d in result.decisions} == {
+        ("Basketball Court", "08:00", "12:00"),
+        ("Badminton Court", "13:00", "17:00"),
+    }
+    assert result.mode_shortfall["Basketball Court"] == pytest.approx(0.0)
+    assert result.mode_shortfall["Badminton Court"] == pytest.approx(0.0)
+
+
+def test_allocate_claimed_window_preserves_non_overlapping_residual():
+    """A 13:00-17:00 Badminton claim should leave Basketball 08:00-13:00."""
+    demand = {"Basketball Court": 8.0, "Badminton Court": 24.0}
+    gym_modes = {"EHS Main Gym": {"Basketball Court": 2, "Badminton Court": 6}}
+    bb_wide = _block_with_types("EHS Main Gym", ["Basketball Court"],
+                                open_t="08:00", close_t="17:00", day="Sat-2")
+    bad_afternoon = _block_with_types("EHS Main Gym", ["Badminton Court"],
+                                      open_t="13:00", close_t="17:00", day="Sat-2")
+
+    result = allocate(demand, gym_modes, [bb_wide, bad_afternoon])
+
+    assert {(d.mode, d.open_time, d.close_time) for d in result.decisions} == {
+        ("Badminton Court", "13:00", "17:00"),
+        ("Basketball Court", "08:00", "13:00"),
+    }
+    assert result.mode_shortfall["Basketball Court"] == pytest.approx(0.0)
+    assert result.mode_shortfall["Badminton Court"] == pytest.approx(0.0)
+
+
+def test_allocate_spreading_pass_does_not_claim_overlapping_leftover_block():
+    """The spreading pass must not reintroduce an overlap after demand is met."""
+    demand = {"Basketball Court": 18.0, "Badminton Court": 0.0}
+    gym_modes = {"EHS Main Gym": {"Basketball Court": 2, "Badminton Court": 6}}
+    block_a = _block_with_types("EHS Main Gym", ["Basketball Court"],
+                                open_t="08:00", close_t="17:00", day="Sat-2")
+    block_b = _block_with_types("EHS Main Gym", ["Badminton Court"],
+                                open_t="13:00", close_t="17:00", day="Sat-2")
+
+    result = allocate(demand, gym_modes, [block_a, block_b])
+
+    assert [(d.mode, d.open_time, d.close_time) for d in result.decisions] == [
+        ("Basketball Court", "08:00", "17:00")
+    ], (
+        "Spreading pass must not add the overlapping Badminton block after "
+        "Basketball claims the physical gym window"
     )
 
 

--- a/middleware/tests/test_main.py
+++ b/middleware/tests/test_main.py
@@ -83,6 +83,15 @@ def test_parse_args_solve_schedule_defaults(monkeypatch):
     assert args.output is None
 
 
+def test_parse_args_diagnose_schedule_defaults(monkeypatch):
+    monkeypatch.setattr(main.sys, "argv", ["main.py", "diagnose-schedule"])
+    args = main.parse_args()
+    assert args.command == "diagnose-schedule"
+    assert args.input is None
+    assert args.schedule_output is None
+    assert args.output is None
+
+
 def test_parse_args_produce_schedule_aliases(monkeypatch):
     monkeypatch.setattr(
         main.sys,
@@ -352,6 +361,30 @@ def test_main_solve_schedule_uses_default_paths(mocker, monkeypatch, tmp_path):
     mock_run.assert_called_once_with(
         tmp_path / "schedule_input.json",
         tmp_path / "schedule_output.json",
+    )
+
+
+def test_main_diagnose_schedule_uses_default_paths(mocker, monkeypatch, tmp_path):
+    monkeypatch.setattr(main, "EXPORT_DIR", tmp_path)
+    (tmp_path / "schedule_output.json").write_text("{}", encoding="utf-8")
+    mock_run = mocker.patch("schedule_diagnostics.run_diagnose_schedule", return_value=0)
+    monkeypatch.setattr(
+        main,
+        "parse_args",
+        lambda: argparse.Namespace(
+            command="diagnose-schedule",
+            input=None,
+            schedule_output=None,
+            output=None,
+        ),
+    )
+
+    _run_main_expect_exit(0)
+
+    mock_run.assert_called_once_with(
+        tmp_path / "schedule_input.json",
+        schedule_output_path=tmp_path / "schedule_output.json",
+        output_path=None,
     )
 
 

--- a/middleware/tests/test_schedule_diagnostics.py
+++ b/middleware/tests/test_schedule_diagnostics.py
@@ -160,6 +160,46 @@ def test_build_schedule_diagnostics_flags_exclusive_group_mode_overlap():
     )
 
 
+def test_build_schedule_diagnostics_downgrades_shortfall_when_solution_is_healthy():
+    schedule_input = _diagnostic_schedule_input()
+    schedule_input["resources"] = [
+        {
+            "resource_id": "BAD-Sat-1-A",
+            "resource_type": "Badminton Court",
+            "label": "Court-1",
+            "day": "Sat-2",
+            "open_time": "08:00",
+            "close_time": "11:00",
+            "slot_minutes": 30,
+            "exclusive_group": "EHS Main Gym",
+        }
+    ]
+    schedule_output = {
+        "status": "FEASIBLE",
+        "assignments": [
+            {"game_id": "BAD-01", "resource_id": "BAD-Sat-1-A", "slot": "Sat-2-08:00"},
+            {"game_id": "BAD-02", "resource_id": "BAD-Sat-1-A", "slot": "Sat-2-08:30"},
+            {"game_id": "BAD-03", "resource_id": "BAD-Sat-1-A", "slot": "Sat-2-09:00"},
+        ],
+        "unscheduled": [],
+        "pool_results": [{"resource_type": "Badminton Court", "status": "FEASIBLE"}],
+        "conflict_audit_summary": {},
+    }
+
+    diagnostics = build_schedule_diagnostics(schedule_input, schedule_output)
+
+    assert any(
+        action["severity"] == "info"
+        and action["vector"] == "capacity note"
+        and "but all games were scheduled" in action["message"]
+        for action in diagnostics["next_actions"]
+    )
+    assert not any(
+        action["vector"] == "gym modes" and action["severity"] == "medium"
+        for action in diagnostics["next_actions"]
+    )
+
+
 def test_format_schedule_diagnostics_includes_compact_next_action_lines():
     diagnostics = build_schedule_diagnostics(_diagnostic_schedule_input())
 

--- a/middleware/tests/test_schedule_diagnostics.py
+++ b/middleware/tests/test_schedule_diagnostics.py
@@ -1,0 +1,182 @@
+import json
+
+from schedule_diagnostics import (
+    build_schedule_diagnostics,
+    format_schedule_diagnostics,
+    run_diagnose_schedule,
+)
+
+
+def _diagnostic_schedule_input() -> dict:
+    return {
+        "generated_at": "2026-05-15T00:00:00",
+        "games": [
+            {
+                "game_id": "BAD-01",
+                "event": "Badminton - Men Doubles",
+                "stage": "Pool",
+                "team_a_id": "BAD-T1",
+                "team_b_id": "BAD-T2",
+                "duration_minutes": 30,
+                "resource_type": "Badminton Court",
+                "earliest_slot": None,
+                "latest_slot": None,
+            },
+            {
+                "game_id": "BAD-02",
+                "event": "Badminton - Women Doubles",
+                "stage": "Pool",
+                "team_a_id": "BAD-T3",
+                "team_b_id": "BAD-T4",
+                "duration_minutes": 30,
+                "resource_type": "Badminton Court",
+                "earliest_slot": None,
+                "latest_slot": None,
+            },
+            {
+                "game_id": "BAD-03",
+                "event": "Badminton - Mixed Doubles",
+                "stage": "Pool",
+                "team_a_id": "BAD-T5",
+                "team_b_id": "BAD-T6",
+                "duration_minutes": 30,
+                "resource_type": "Badminton Court",
+                "earliest_slot": None,
+                "latest_slot": None,
+            },
+        ],
+        "resources": [
+            {
+                "resource_id": "BAD-Sat-1",
+                "resource_type": "Badminton Court",
+                "label": "Court-1",
+                "day": "Sat-2",
+                "open_time": "08:00",
+                "close_time": "09:00",
+                "slot_minutes": 30,
+            }
+        ],
+        "playoff_slots": [
+            {
+                "game_id": "BAD-QF-1",
+                "event": "Badminton - Men Doubles",
+                "stage": "QF",
+                "resource_type": "Badminton Court",
+                "resource_id": "BAD-Sat-1",
+                "slot": "Sat-2-08:00",
+            }
+        ],
+        "precedence": [{"before": "BAD-01", "after": "BAD-QF-1", "min_gap_slots": 1}],
+        "team_conflicts": [{"team_a_id": "BAD-T1", "team_b_id": "BAD-T3", "primary_overlap_count": 1}],
+        "gym_modes": {},
+        "gym_allocation": {"source": "allocator", "mode_shortfall": {"Badminton Court": 2}},
+    }
+
+
+def test_build_schedule_diagnostics_groups_vectors_and_suggests_next_actions():
+    schedule_input = _diagnostic_schedule_input()
+    schedule_output = {
+        "status": "PARTIAL",
+        "assignments": [{"game_id": "BAD-01", "resource_id": "BAD-Sat-1", "slot": "Sat-2-08:00"}],
+        "unscheduled": ["BAD-02", "BAD-03"],
+        "pool_results": [{"resource_type": "Badminton Court", "status": "INFEASIBLE"}],
+        "conflict_audit_summary": {"overlapping_edges": 1},
+    }
+
+    diagnostics = build_schedule_diagnostics(schedule_input, schedule_output)
+
+    assert diagnostics["summary"]["game_count"] == 3
+    assert diagnostics["demand"]["by_resource_type"][0]["resource_type"] == "Badminton Court"
+    assert diagnostics["demand"]["by_resource_type"][0]["required_slots_lower_bound"] == 3
+    assert diagnostics["supply"]["by_resource_type"][0]["available_slots"] == 2
+    assert diagnostics["control"]["playoff_slots_count"] == 1
+    assert diagnostics["audit"]["unscheduled_count"] == 2
+
+    vectors = {action["vector"] for action in diagnostics["next_actions"]}
+    assert "demand/supply" in vectors
+    assert "gym modes" in vectors
+    assert "fixed pins" in vectors
+    assert "precedence" in vectors
+    assert "conflict graph" in vectors
+
+
+def test_build_schedule_diagnostics_reports_missing_resource_type():
+    schedule_input = _diagnostic_schedule_input()
+    schedule_input["resources"] = []
+
+    diagnostics = build_schedule_diagnostics(schedule_input)
+
+    assert diagnostics["supply"]["total_resources"] == 0
+    assert diagnostics["capacity_pressure"][0]["missing_resource_events"]
+    assert diagnostics["next_actions"][0]["vector"] == "supply"
+    assert diagnostics["audit"]["available"] is False
+
+
+def test_build_schedule_diagnostics_flags_exclusive_group_mode_overlap():
+    schedule_input = _diagnostic_schedule_input()
+    schedule_input["resources"] = [
+        {
+            "resource_id": "GYM-Sat-2-1",
+            "resource_type": "Basketball Court",
+            "label": "Court-1",
+            "day": "Sat-2",
+            "open_time": "08:00",
+            "close_time": "17:00",
+            "slot_minutes": 60,
+            "exclusive_group": "EHS Main Gym",
+        },
+        {
+            "resource_id": "GYM-Sat-2-6",
+            "resource_type": "Badminton Court",
+            "label": "Court-1",
+            "day": "Sat-2",
+            "open_time": "13:00",
+            "close_time": "17:00",
+            "slot_minutes": 60,
+            "exclusive_group": "EHS Main Gym",
+        },
+    ]
+    schedule_output = {
+        "status": "OPTIMAL",
+        "assignments": [],
+        "unscheduled": [],
+        "pool_results": [],
+        "conflict_audit_summary": {},
+    }
+
+    diagnostics = build_schedule_diagnostics(schedule_input, schedule_output)
+
+    overlaps = diagnostics["supply"]["exclusive_group_overlaps"]
+    assert len(overlaps) == 1
+    assert overlaps[0]["exclusive_group"] == "EHS Main Gym"
+    assert overlaps[0]["first_resource_type"] == "Badminton Court"
+    assert overlaps[0]["second_resource_type"] == "Basketball Court"
+    assert overlaps[0]["overlapping_resource_pairs"] == 1
+    assert any(
+        action["severity"] == "high"
+        and action["vector"] == "supply"
+        and "EHS Main Gym on Sat-2" in action["message"]
+        for action in diagnostics["next_actions"]
+    )
+
+
+def test_format_schedule_diagnostics_includes_compact_next_action_lines():
+    diagnostics = build_schedule_diagnostics(_diagnostic_schedule_input())
+
+    lines = format_schedule_diagnostics(diagnostics)
+
+    assert lines[0].startswith("Schedule diagnostics:")
+    assert any("Next action" in line for line in lines)
+
+
+def test_run_diagnose_schedule_writes_json_report(tmp_path):
+    input_path = tmp_path / "schedule_input.json"
+    output_path = tmp_path / "schedule_diagnostics.json"
+    input_path.write_text(json.dumps(_diagnostic_schedule_input()), encoding="utf-8")
+
+    exit_code = run_diagnose_schedule(input_path, output_path=output_path)
+
+    assert exit_code == 0
+    report = json.loads(output_path.read_text(encoding="utf-8"))
+    assert report["summary"]["game_count"] == 3
+    assert report["next_actions"]

--- a/middleware/tests/test_schedule_workbook.py
+++ b/middleware/tests/test_schedule_workbook.py
@@ -3165,6 +3165,7 @@ def test_master_schedule_first_write_wins_on_exclusive_group_double_booking(tmp_
     overwritten by the second resource (Badminton). Reproduces the BBM-Semi-1 hidden
     bug where Badminton overwrote Basketball on the same physical court."""
     import openpyxl
+    import zipfile
 
     schedule_input = {
         "games": [
@@ -3276,6 +3277,16 @@ def test_master_schedule_first_write_wins_on_exclusive_group_double_booking(tmp_
     assert conflict_cell.font.color.rgb.endswith("FF2400"), "Conflict cell must have red text"
     assert conflict_cell.comment is not None, "Conflict cell must carry a Note"
     assert "SCHEDULING CONFLICT" in conflict_cell.comment.text
+
+    # Excel stores comment visibility in VML. openpyxl can read the workbook
+    # after our post-save patch, and the VML should request an open note.
+    with zipfile.ZipFile(out) as zf:
+        vml_names = [name for name in zf.namelist() if name.endswith(".vml")]
+        assert vml_names
+        vml_text = "\n".join(zf.read(name).decode("utf-8") for name in vml_names)
+    assert "visibility:visible" in vml_text
+    assert ":Visible" in vml_text
+    assert 'xmlns="urn:schemas-microsoft-com:office:excel"' not in vml_text
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Implements incremental Issue #140 scheduler diagnostics work. Includes the diagnose-schedule command and JSON report, overlapping gym-mode allocation prevention, and solved-schedule capacity-pressure downgrade to info notes when there are no unscheduled games or physical overlaps. Validation run locally: pytest tests/test_schedule_diagnostics.py -q, pytest tests/test_gym_allocator.py -q, pytest tests/test_main.py -q, pytest tests/test_scheduler.py -q. Real-world operator validation: export-church-teams regenerated schedule_input.json, run-schedule.bat scheduled 209 games with 0 unscheduled, and the prior F43 double-booking was removed after venue input regeneration.