### PR TITLE
scheduler: complete EHS TT playoff reservation (#133)

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -182,6 +182,48 @@ almost certainly gone and the Team-group row is just stale membership data.
 
 ## Data Synchronization Issues
 
+### Approval Sync Returns 404 for a Deleted or Merged Person ID
+
+**Issue**: Approval synchronization logs an error such as:
+
+```text
+Failed to add person 4371563 to group 1001617: 404 Client Error: Not Found
+API sync completed: 0 added, 1 failed, 0 marked synced.
+```
+
+**What it means**:
+- The approval record in WordPress still references an old ChMeetings person ID.
+- ChMeetings may have deleted that profile or merged it into another profile with
+  a different ID.
+- A confirmed profile merge is a stale-reference/data-reconciliation warning,
+  not an API outage or a failure of the rest of the daily workflow.
+
+**How to classify it**:
+1. Inspect the old ID:
+   ```bash
+   python main.py inspect-person --chm-id <OLD_CHMEETINGS_ID>
+   ```
+2. Search the current sync log or participant export for the same email, phone,
+   birthdate, and church under a different ChMeetings ID.
+3. Inspect the candidate replacement ID:
+   ```bash
+   python main.py inspect-person --chm-id <CURRENT_CHMEETINGS_ID>
+   ```
+
+Treat the result as:
+
+- **Expected stale reference**: the old ID returns `404`, and a live replacement
+  matches the person's identity and registration data.
+- **Needs investigation**: the old ID returns `404`, but no convincing live
+  replacement can be found.
+- **Needs approval reconciliation**: a replacement exists, but the old and new
+  WordPress records disagree on approval status or
+  `synced_to_chmeetings`. Reconcile the live record before removing the stale
+  duplicate.
+
+Do not mark every approval-sync `404` as harmless automatically. The replacement
+identity and approval state must be verified first.
+
 ### Missing Participants
 
 **Issue**: Some participants don't sync from ChMeetings to WordPress.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -543,6 +543,14 @@ This command:
 This is useful when a Team-group membership looks stale and you need to confirm
 whether the person still exists in ChMeetings, WordPress, both, or neither.
 
+It is also the first diagnostic for approval-sync `404` errors. ChMeetings
+profile merges retire the old person ID but can leave a WordPress participant
+and unsynced approval pointing at it. If the current participant export contains
+an exact identity match under a different live ChMeetings ID, classify the old
+ID as a stale merge reference rather than an API outage. Compare the old and
+replacement WordPress approval records before cleanup; differing approval or
+`synced_to_chmeetings` values require reconciliation.
+
 ### Auditing Team Groups for Orphaned IDs
 
 Use this command when `export-church-teams` or `sync --type participants`

--- a/middleware/gym_allocator.py
+++ b/middleware/gym_allocator.py
@@ -267,7 +267,7 @@ def allocate(
             if gym_modes[g].get(mode, 0) > 0
         ]
         eligible.sort(key=lambda x: (
-            _active_mode_count(x[0], gym_modes),
+            _active_mode_count(x[0], gym_modes, blocks),
             _switch_penalty(x[0], mode, decisions),
             -x[1],
             x[0],
@@ -459,9 +459,31 @@ def _switch_penalty(gym_name: str, mode: str, decisions: List[AllocationDecision
     return 0 if (last is None or last == mode) else 1
 
 
-def _active_mode_count(gym_name: str, gym_modes: Dict[str, Dict[str, int]]) -> int:
-    """Count how many sport modes this gym can host with non-zero capacity."""
-    return sum(1 for courts in gym_modes.get(gym_name, {}).values() if courts > 0)
+def _block_accepts_mode(block: GymBlock, mode: str) -> bool:
+    """Return whether an allocator block can actually be assigned to a mode."""
+    return not block.resource_types or mode in block.resource_types
+
+
+def _active_mode_count(
+    gym_name: str,
+    gym_modes: Dict[str, Dict[str, int]],
+    blocks: List[GymBlock],
+) -> int:
+    """Count non-zero modes that have at least one compatible block in the gym.
+
+    A Gym-Modes capability backed only by standalone Venue-Input rows must not
+    make an allocator-managed gym appear more flexible.  In production, EHS
+    Practice Gym has four standalone Table Tennis tables for playoffs but no
+    exclusive-group TT blocks.  Counting that unavailable mode changed the
+    BB/VB gym preference and indirectly consumed EHS Main Gym's Badminton
+    window.
+    """
+    gym_blocks = [block for block in blocks if block.gym_name == gym_name]
+    return sum(
+        1
+        for mode, courts in gym_modes.get(gym_name, {}).items()
+        if courts > 0 and any(_block_accepts_mode(block, mode) for block in gym_blocks)
+    )
 
 
 def _count_switches(decisions: List[AllocationDecision]) -> int:

--- a/middleware/tests/test_gym_allocator.py
+++ b/middleware/tests/test_gym_allocator.py
@@ -531,6 +531,59 @@ def test_allocate_prefers_gym_with_more_courts():
     assert result.mode_shortfall["Badminton Court"] == pytest.approx(0.0)
 
 
+def test_unavailable_mode_does_not_change_gym_preference_or_consume_badminton():
+    """A standalone playoff capability must not affect Stage-A specialization.
+
+    EHS Practice Gym's Table Tennis Tables are standalone Venue-Input rows, not
+    exclusive-group blocks.  Enabling TT=4 in Gym-Modes therefore must not make
+    the Practice Gym look as flexible as the Main Gym and redirect Basketball
+    into the Main Gym's overlapping Badminton window.
+    """
+    demand = {
+        "Basketball Court": 8.0,
+        "Badminton Court": 24.0,
+        "Table Tennis Table": 4.0,
+    }
+    blocks = [
+        _block_with_types(
+            "EHS Practice Gym",
+            ["Basketball Court"],
+            open_t="08:00",
+            close_t="12:00",
+            day="Sat-1",
+        ),
+        _block_with_types(
+            "EHS Main Gym",
+            ["Basketball Court"],
+            open_t="08:00",
+            close_t="17:00",
+            day="Sat-2",
+        ),
+        _block_with_types(
+            "EHS Main Gym",
+            ["Badminton Court"],
+            open_t="13:00",
+            close_t="17:00",
+            day="Sat-2",
+        ),
+    ]
+    base_modes = {
+        "EHS Practice Gym": {"Basketball Court": 2, "Table Tennis Table": 0},
+        "EHS Main Gym": {"Basketball Court": 2, "Badminton Court": 6},
+    }
+    restored_modes = {
+        **base_modes,
+        "EHS Practice Gym": {"Basketball Court": 2, "Table Tennis Table": 4},
+    }
+
+    before = allocate(demand, base_modes, blocks)
+    after = allocate(demand, restored_modes, blocks)
+
+    assert after.decisions == before.decisions
+    assert after.mode_shortfall == before.mode_shortfall
+    assert after.mode_shortfall["Badminton Court"] == pytest.approx(0.0)
+
+
 # ---------------------------------------------------------------------------
 # Bug fixes: resource_types tracking and spreading pass
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- document expected approval-sync 404s after ChMeetings profile merges
- keep standalone playoff-only gym modes out of Stage-A specialization scoring
- add a regression test for restoring EHS Practice Gym Table Tennis Tables from 0 to 4

## Production verification
- restored EHS Practice Gym TT=4 in the operational venue_input.xlsx
- pinned TT Men Singles semis at Sun-2 16:00 and Final/3rd at 16:40
- export produced 225 games and 79 resources
- solver scheduled all 225 games with zero unscheduled
- Badminton: OPTIMAL, 27/27 assigned
- Table Tennis: OPTIMAL, 28/28 assigned
- Orange Chapel hosted 16 TT pool/QF games
- EHS hosted 16 TT playoff games and zero TT pool games
- produce-schedule generated VAYSF_Schedule_2026-06-12.xlsx

## Tests
- 634 passed

Closes #133