### PR TITLE
Add ChMeetings profile photo upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+### ChMeetings profile photo upload — refs [#175](https://github.com/i12know/vaysf/issues/175)
+
+- Added a `ChMeetingsConnector.upload_person_photo()` wrapper for the new
+  `POST /api/v1/people/{person_id}/photo` multipart endpoint announced by
+  ChMeetings Developer Support on 2026-07-07. This keeps `photo` out of normal
+  People create/update payloads while giving the missing-person repair workflow
+  an API path to attach athlete headshots after creating a Person record.
+- Added an operator-gated `upload-person-photo --chm-id ... --photo-file ...`
+  command with documented `file` multipart-field handling, 2 MB local image
+  validation, dry-run support, and post-upload People re-read confirmation for
+  the first safe live mutation test.
+- Extended `upload-person-photo` with `--photo-url` for ChMeetings-hosted form
+  photo URLs, so an operator can promote a form-submission headshot into the
+  linked People profile without a manual download step.
+
 ### Decompose schedule_workbook.py — Step 4: planning_tabs.py — refs [#152](https://github.com/i12know/vaysf/issues/152)
 
 Extraction-only refactor (Step 4 of 8): no behavior changes, all call sites

--- a/middleware/chmeetings/backend_connector.py
+++ b/middleware/chmeetings/backend_connector.py
@@ -1,9 +1,11 @@
 # chmeetings/backend-connector.py
 
 import os
+import mimetypes
 import requests
 import time
-from typing import Dict, List, Optional, Union, Any
+from pathlib import Path
+from typing import BinaryIO, Dict, List, Optional, Union, Any
 from urllib.parse import urljoin
 from loguru import logger
 
@@ -525,6 +527,95 @@ class ChMeetingsConnector:
         except requests.RequestException as e:
             logger.error(f"Failed to create person {first_name!r} {last_name!r}: {e}")
             return None
+
+
+    def upload_person_photo(
+        self,
+        person_id: Union[str, int],
+        photo: Union[str, os.PathLike[str], bytes, BinaryIO],
+        *,
+        filename: Optional[str] = None,
+        content_type: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """
+        Upload or replace a ChMeetings People profile photo.
+
+        Calls POST /api/v1/people/{person_id}/photo, which ChMeetings exposed
+        in July 2026 for the missing-person repair workflow tracked in #175.
+        The endpoint is multipart/form-data using the ``file`` form field and
+        returns the updated person/photo payload on success.  ``photo`` may be
+        a filesystem path, raw bytes, or an already-open binary file object.
+
+        Args:
+            person_id: ChMeetings person ID whose profile photo should be set.
+            photo: Local image path, image bytes, or binary file object.
+            filename: Optional filename for byte/file-object uploads.  Path
+                uploads default to the path basename.
+            content_type: Optional MIME type.  If omitted, it is guessed from
+                the filename and defaults to application/octet-stream.
+
+        Returns:
+            The unwrapped response payload when the upload succeeds, or None on
+            failure.
+        """
+        if not self.use_api:
+            logger.error("API usage is disabled")
+            return None
+
+        close_after = False
+        file_obj: BinaryIO
+        resolved_filename = filename
+
+        try:
+            if isinstance(photo, (str, os.PathLike)):
+                photo_path = Path(photo)
+                resolved_filename = resolved_filename or photo_path.name
+                file_obj = photo_path.open("rb")
+                close_after = True
+            elif isinstance(photo, bytes):
+                from io import BytesIO
+
+                resolved_filename = resolved_filename or "profile-photo.jpg"
+                file_obj = BytesIO(photo)
+                close_after = True
+            else:
+                file_obj = photo
+                resolved_filename = resolved_filename or getattr(photo, "name", "profile-photo.jpg")
+                resolved_filename = os.path.basename(str(resolved_filename))
+
+            content_type = (
+                content_type
+                or mimetypes.guess_type(str(resolved_filename))[0]
+                or "application/octet-stream"
+            )
+
+            logger.info(f"Uploading ChMeetings profile photo for person {person_id}")
+            response = self._api_request(
+                "POST",
+                f"api/v1/people/{person_id}/photo",
+                files={"file": (resolved_filename, file_obj, content_type)},
+            )
+            if not response.ok:
+                logger.error(
+                    f"Failed to upload profile photo for person {person_id}: "
+                    f"HTTP {response.status_code}"
+                )
+                return None
+            raw = response.json()
+            uploaded = self._extract_data(raw)
+            if isinstance(uploaded, dict):
+                return uploaded
+            logger.error(
+                f"upload_person_photo: unexpected response type {type(uploaded)} "
+                f"for person {person_id}"
+            )
+            return None
+        except (OSError, requests.RequestException, ValueError) as e:
+            logger.error(f"Failed to upload profile photo for person {person_id}: {e}")
+            return None
+        finally:
+            if close_after and "file_obj" in locals():
+                file_obj.close()
 
     def update_person(
         self,

--- a/middleware/main.py
+++ b/middleware/main.py
@@ -173,6 +173,29 @@ def parse_args() -> argparse.Namespace:
     inspect_parser.add_argument("--chm-id", type=str, required=True,
                                 help="ChMeetings person ID to inspect")
 
+    upload_photo_parser = subparsers.add_parser(
+        "upload-person-photo",
+        help="Upload one local image as a ChMeetings profile photo",
+    )
+    upload_photo_parser.add_argument("--chm-id", type=str, required=True,
+                                     help="ChMeetings person ID to update")
+    upload_photo_source = upload_photo_parser.add_mutually_exclusive_group(required=True)
+    upload_photo_source.add_argument("--photo-file", type=str,
+                                     help="Path to the local image file to upload")
+    upload_photo_source.add_argument("--photo-url", type=str,
+                                     help="ChMeetings-hosted form/profile photo URL to download and upload")
+    upload_photo_mode = upload_photo_parser.add_mutually_exclusive_group(required=True)
+    upload_photo_mode.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate the local image and show what would be uploaded",
+    )
+    upload_photo_mode.add_argument(
+        "--execute",
+        action="store_true",
+        help="Upload the image to ChMeetings and re-read the person to confirm photo presence",
+    )
+
     # Reset-season command
     reset_parser = subparsers.add_parser(
         "reset-season",
@@ -1272,6 +1295,20 @@ def main() -> None:
         success = test_connectivity(args.system, args.test_type, args.test_email)
     elif args.command == "inspect-person":
         success = inspect_person(args.chm_id)
+    elif args.command == "upload-person-photo":
+        from photo_repair import upload_person_photo
+
+        summary = upload_person_photo(
+            args.chm_id,
+            photo_file=args.photo_file,
+            photo_url=args.photo_url,
+            dry_run=args.dry_run,
+            execute=args.execute,
+        )
+        if args.dry_run:
+            success = bool(summary["validated"])
+        else:
+            success = bool(summary["uploaded"] and summary["confirmed_photo"])
     elif args.command == "reset-season":
         if args.archive_only and args.reset_only:
             logger.error("--archive-only and --reset-only are mutually exclusive.")

--- a/middleware/photo_repair.py
+++ b/middleware/photo_repair.py
@@ -1,0 +1,266 @@
+"""Operator-gated ChMeetings profile photo repair helpers."""
+
+from pathlib import Path
+import hashlib
+import mimetypes
+from typing import Any, Dict, Optional
+from urllib.parse import urlparse
+
+from loguru import logger
+import requests
+
+from chmeetings.backend_connector import ChMeetingsConnector
+
+
+ALLOWED_PROFILE_PHOTO_TYPES = {
+    "image/jpeg",
+    "image/png",
+    "image/webp",
+    "image/gif",
+}
+MAX_PROFILE_PHOTO_BYTES = 2 * 1024 * 1024
+PHOTO_REPAIR_DOWNLOAD_DIR = Path(__file__).resolve().parent / "temp" / "photo-repair"
+ALLOWED_PROFILE_PHOTO_URL_HOSTS = {
+    "cdne-chmeetings-content.azureedge.net",
+    "chmeetings.blob.core.windows.net",
+}
+
+
+def _sniff_image_content_type(path: Path) -> Optional[str]:
+    """Return a conservative image MIME type from file signature bytes."""
+    with path.open("rb") as fh:
+        header = fh.read(16)
+
+    if header.startswith(b"\xff\xd8\xff"):
+        return "image/jpeg"
+    if header.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "image/png"
+    if header.startswith(b"GIF87a") or header.startswith(b"GIF89a"):
+        return "image/gif"
+    if header.startswith(b"RIFF") and header[8:12] == b"WEBP":
+        return "image/webp"
+    return None
+
+
+def validate_profile_photo_file(
+    photo_file: str,
+    *,
+    max_bytes: int = MAX_PROFILE_PHOTO_BYTES,
+) -> Dict[str, Any]:
+    """Validate a local profile photo before sending it to ChMeetings."""
+    path = Path(photo_file)
+    result: Dict[str, Any] = {
+        "ok": False,
+        "path": path,
+        "content_type": None,
+        "size_bytes": 0,
+        "error": "",
+    }
+
+    if not path.exists():
+        result["error"] = f"photo file not found: {path}"
+        return result
+    if not path.is_file():
+        result["error"] = f"photo path is not a file: {path}"
+        return result
+
+    size_bytes = path.stat().st_size
+    result["size_bytes"] = size_bytes
+    if size_bytes <= 0:
+        result["error"] = "photo file is empty"
+        return result
+    if size_bytes > max_bytes:
+        result["error"] = (
+            f"photo file is {size_bytes} bytes; max allowed by this tool is {max_bytes}"
+        )
+        return result
+
+    guessed_type = mimetypes.guess_type(str(path))[0]
+    sniffed_type = _sniff_image_content_type(path)
+    if guessed_type not in ALLOWED_PROFILE_PHOTO_TYPES:
+        result["error"] = f"unsupported profile photo extension/content type: {guessed_type or 'unknown'}"
+        return result
+    if sniffed_type is None:
+        result["error"] = "photo file signature is not a supported image"
+        return result
+    if sniffed_type != guessed_type:
+        result["error"] = (
+            f"photo extension suggests {guessed_type}, but file signature is {sniffed_type}"
+        )
+        return result
+
+    result["ok"] = True
+    result["content_type"] = sniffed_type
+    return result
+
+
+def download_profile_photo_url(
+    photo_url: str,
+    *,
+    download_dir: Path = PHOTO_REPAIR_DOWNLOAD_DIR,
+    max_bytes: int = MAX_PROFILE_PHOTO_BYTES,
+) -> Dict[str, Any]:
+    """Download a ChMeetings-hosted profile photo URL to a local temp file."""
+    result: Dict[str, Any] = {
+        "ok": False,
+        "path": None,
+        "content_type": None,
+        "size_bytes": 0,
+        "error": "",
+    }
+    parsed = urlparse(photo_url)
+    if parsed.scheme != "https":
+        result["error"] = "photo URL must use https"
+        return result
+    if parsed.netloc.lower() not in ALLOWED_PROFILE_PHOTO_URL_HOSTS:
+        result["error"] = "photo URL host is not an allowed ChMeetings image host"
+        return result
+
+    suffix = Path(parsed.path).suffix.lower()
+    if suffix not in {".jpg", ".jpeg", ".png", ".webp", ".gif"}:
+        suffix = ".jpg"
+    download_dir.mkdir(parents=True, exist_ok=True)
+    digest = hashlib.sha256(photo_url.encode("utf-8")).hexdigest()[:16]
+    path = download_dir / f"profile-photo-{digest}{suffix}"
+
+    try:
+        response = requests.get(photo_url, stream=True, timeout=(5, 30))
+        response.raise_for_status()
+        total = 0
+        with path.open("wb") as fh:
+            for chunk in response.iter_content(chunk_size=64 * 1024):
+                if not chunk:
+                    continue
+                total += len(chunk)
+                if total > max_bytes:
+                    result["error"] = (
+                        f"downloaded photo exceeds max allowed size of {max_bytes} bytes"
+                    )
+                    return result
+                fh.write(chunk)
+        result["path"] = path
+        validation = validate_profile_photo_file(str(path), max_bytes=max_bytes)
+        if not validation["ok"]:
+            result["error"] = str(validation["error"])
+            return result
+        result["ok"] = True
+        result["content_type"] = validation["content_type"]
+        result["size_bytes"] = validation["size_bytes"]
+        return result
+    except requests.RequestException as exc:
+        result["error"] = f"photo URL download failed: {exc}"
+        return result
+
+
+def upload_person_photo(
+    person_id: str,
+    *,
+    photo_file: Optional[str] = None,
+    photo_url: Optional[str] = None,
+    dry_run: bool = True,
+    execute: bool = False,
+    connector: Optional[ChMeetingsConnector] = None,
+) -> Dict[str, Any]:
+    """Validate and optionally upload one local photo to one ChMeetings person.
+
+    This uses the VAY SM church-level ChMeetings API key configured for this
+    project. It intentionally does not run inside daily repair flows; operators
+    must target a specific person and pass ``execute=True`` for a live upload.
+    """
+    summary: Dict[str, Any] = {
+        "person_id": str(person_id),
+        "validated": False,
+        "dry_run": dry_run,
+        "uploaded": False,
+        "confirmed_photo": False,
+        "already_had_photo": False,
+        "source": "file" if photo_file else "url" if photo_url else "",
+        "error": "",
+    }
+
+    if bool(photo_file) == bool(photo_url):
+        summary["error"] = "provide exactly one of photo_file or photo_url"
+        logger.error(f"upload-person-photo: {summary['error']}")
+        return summary
+
+    if photo_url:
+        download = download_profile_photo_url(photo_url)
+        if not download["ok"]:
+            summary["error"] = str(download["error"])
+            logger.error(f"upload-person-photo: {summary['error']}")
+            return summary
+        photo_path = Path(download["path"])
+        validation = {
+            "ok": True,
+            "path": photo_path,
+            "content_type": download["content_type"],
+            "size_bytes": download["size_bytes"],
+        }
+    else:
+        validation = validate_profile_photo_file(str(photo_file))
+
+    if not validation["ok"]:
+        summary["error"] = str(validation["error"])
+        logger.error(f"upload-person-photo: {summary['error']}")
+        return summary
+
+    summary["validated"] = True
+    logger.info(
+        "upload-person-photo: validated local image "
+        f"({validation['content_type']}, {validation['size_bytes']} bytes)"
+    )
+
+    if dry_run:
+        logger.info(
+            f"upload-person-photo dry-run: would upload image to ChMeetings person {person_id}"
+        )
+        return summary
+    if not execute:
+        summary["error"] = "execute=True is required for a live upload"
+        logger.error("upload-person-photo requires --dry-run or --execute.")
+        return summary
+
+    owns_connector = connector is None
+    chm_connector = connector or ChMeetingsConnector()
+
+    try:
+        if owns_connector:
+            chm_connector.__enter__()
+        if not chm_connector.authenticate():
+            summary["error"] = "Authentication with ChMeetings failed"
+            logger.error(summary["error"])
+            return summary
+
+        before = chm_connector.get_person(str(person_id))
+        if not before:
+            summary["error"] = f"ChMeetings person {person_id} was not found"
+            logger.error(summary["error"])
+            return summary
+        summary["already_had_photo"] = bool(before.get("photo"))
+
+        uploaded = chm_connector.upload_person_photo(
+            str(person_id),
+            validation["path"],
+            content_type=str(validation["content_type"]),
+        )
+        if not uploaded:
+            summary["error"] = "ChMeetings photo upload returned no payload"
+            logger.error(summary["error"])
+            return summary
+
+        summary["uploaded"] = True
+        after = chm_connector.get_person(str(person_id))
+        summary["confirmed_photo"] = bool(after and after.get("photo"))
+        if summary["confirmed_photo"]:
+            logger.info(
+                f"upload-person-photo: uploaded and confirmed profile photo for person {person_id}"
+            )
+        else:
+            logger.warning(
+                f"upload-person-photo: upload returned success, but person {person_id} "
+                "does not show a photo on immediate re-read"
+            )
+        return summary
+    finally:
+        if owns_connector:
+            chm_connector.__exit__(None, None, None)

--- a/middleware/tests/test_chmeetings_connector.py
+++ b/middleware/tests/test_chmeetings_connector.py
@@ -187,6 +187,47 @@ def test_create_person_posts_complete_payload(chm_connector, mocker):
     assert captured["json"]["additional_fields"][0]["field_id"] == 1281851
 
 
+
+def test_upload_person_photo_posts_multipart_bytes(chm_connector, mocker):
+    """Mock photo upload should POST multipart form data to the ChMeetings endpoint."""
+    live_test = os.getenv("LIVE_TEST", "false").strip().lower() == "true"
+    if live_test:
+        pytest.skip("upload_person_photo is a live mutation; covered in mock mode only")
+
+    captured = {}
+
+    def capturing_post(_session, url, **kwargs):
+        captured["url"] = url
+        captured["files"] = kwargs.get("files", {})
+        uploaded_file = captured["files"]["file"][1]
+        captured["uploaded_bytes"] = uploaded_file.read()
+        uploaded_file.seek(0)
+        mock_resp = mocker.Mock()
+        mock_resp.ok = True
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {
+            "status_code": 200,
+            "data": {"id": "999001", "photo": "https://chm.example/profile.jpg"},
+        }
+        return mock_resp
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr("requests.Session.post", capturing_post)
+        result = chm_connector.upload_person_photo(
+            "999001",
+            b"fake-jpeg-bytes",
+            filename="athlete.jpg",
+            content_type="image/jpeg",
+        )
+
+    assert result["id"] == "999001"
+    assert result["photo"] == "https://chm.example/profile.jpg"
+    assert captured["url"].endswith("/api/v1/people/999001/photo")
+    assert captured["files"]["file"][0] == "athlete.jpg"
+    assert captured["files"]["file"][2] == "image/jpeg"
+    assert captured["uploaded_bytes"] == b"fake-jpeg-bytes"
+
+
 def test_get_person(chm_connector, mocker, mock_chm_people_data):
     live_test = os.getenv("LIVE_TEST", "false").strip().lower() == "true"
     # Use an ID that exists in mock_chm_people_data.json

--- a/middleware/tests/test_main.py
+++ b/middleware/tests/test_main.py
@@ -146,6 +146,50 @@ def test_parse_args_assign_pools_defaults(monkeypatch):
     assert args.pool_assignments is None
 
 
+def test_parse_args_upload_person_photo_execute(monkeypatch):
+    monkeypatch.setattr(
+        main.sys,
+        "argv",
+        [
+            "main.py",
+            "upload-person-photo",
+            "--chm-id",
+            "999001",
+            "--photo-file",
+            "athlete.png",
+            "--execute",
+        ],
+    )
+    args = main.parse_args()
+    assert args.command == "upload-person-photo"
+    assert args.chm_id == "999001"
+    assert args.photo_file == "athlete.png"
+    assert args.execute is True
+    assert args.dry_run is False
+
+
+def test_parse_args_upload_person_photo_url_dry_run(monkeypatch):
+    monkeypatch.setattr(
+        main.sys,
+        "argv",
+        [
+            "main.py",
+            "upload-person-photo",
+            "--chm-id",
+            "999001",
+            "--photo-url",
+            "https://cdne-chmeetings-content.azureedge.net/images/photo.jpg",
+            "--dry-run",
+        ],
+    )
+    args = main.parse_args()
+    assert args.command == "upload-person-photo"
+    assert args.chm_id == "999001"
+    assert args.photo_url.startswith("https://")
+    assert args.photo_file is None
+    assert args.dry_run is True
+
+
 def test_main_build_schedule_workbook_writes_xlsx(monkeypatch, tmp_path):
     data_dir = tmp_path / "data"
     export_dir = tmp_path / "export"

--- a/middleware/tests/test_photo_repair.py
+++ b/middleware/tests/test_photo_repair.py
@@ -1,0 +1,164 @@
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from photo_repair import (
+    download_profile_photo_url,
+    upload_person_photo,
+    validate_profile_photo_file,
+)
+
+
+def _write_png(path: Path) -> None:
+    path.write_bytes(b"\x89PNG\r\n\x1a\n" + b"profile-photo")
+
+
+def test_validate_profile_photo_file_accepts_supported_png(tmp_path):
+    photo = tmp_path / "athlete.png"
+    _write_png(photo)
+
+    result = validate_profile_photo_file(str(photo))
+
+    assert result["ok"] is True
+    assert result["content_type"] == "image/png"
+    assert result["size_bytes"] == photo.stat().st_size
+
+
+def test_validate_profile_photo_file_rejects_non_image(tmp_path):
+    photo = tmp_path / "athlete.png"
+    photo.write_text("not really an image", encoding="utf-8")
+
+    result = validate_profile_photo_file(str(photo))
+
+    assert result["ok"] is False
+    assert "signature" in result["error"]
+
+
+def test_upload_person_photo_dry_run_validates_without_api_calls(tmp_path):
+    photo = tmp_path / "athlete.png"
+    _write_png(photo)
+    connector = MagicMock()
+
+    summary = upload_person_photo(
+        "999001",
+        photo_file=str(photo),
+        dry_run=True,
+        connector=connector,
+    )
+
+    assert summary["validated"] is True
+    assert summary["uploaded"] is False
+    connector.authenticate.assert_not_called()
+    connector.upload_person_photo.assert_not_called()
+
+
+def test_upload_person_photo_execute_uploads_and_confirms(tmp_path):
+    photo = tmp_path / "athlete.png"
+    _write_png(photo)
+    connector = MagicMock()
+    connector.authenticate.return_value = True
+    connector.get_person.side_effect = [
+        {"id": "999001", "photo": ""},
+        {"id": "999001", "photo": "https://chm.example/photo.jpg"},
+    ]
+    connector.upload_person_photo.return_value = {
+        "id": "999001",
+        "photo": "https://chm.example/photo.jpg",
+    }
+
+    summary = upload_person_photo(
+        "999001",
+        photo_file=str(photo),
+        dry_run=False,
+        execute=True,
+        connector=connector,
+    )
+
+    assert summary["uploaded"] is True
+    assert summary["confirmed_photo"] is True
+    assert summary["already_had_photo"] is False
+    connector.authenticate.assert_called_once()
+    connector.get_person.assert_any_call("999001")
+    connector.upload_person_photo.assert_called_once_with(
+        "999001",
+        photo,
+        content_type="image/png",
+    )
+
+
+def test_upload_person_photo_execute_reports_missing_person(tmp_path):
+    photo = tmp_path / "athlete.png"
+    _write_png(photo)
+    connector = MagicMock()
+    connector.authenticate.return_value = True
+    connector.get_person.return_value = None
+
+    summary = upload_person_photo(
+        "999001",
+        photo_file=str(photo),
+        dry_run=False,
+        execute=True,
+        connector=connector,
+    )
+
+    assert summary["uploaded"] is False
+    assert "not found" in summary["error"]
+    connector.upload_person_photo.assert_not_called()
+
+
+def test_download_profile_photo_url_accepts_chmeetings_cdn(mocker, tmp_path):
+    class FakeResponse:
+        def raise_for_status(self):
+            return None
+
+        def iter_content(self, chunk_size):
+            yield b"\x89PNG\r\n\x1a\n"
+            yield b"profile-photo"
+
+    get = mocker.patch("photo_repair.requests.get", return_value=FakeResponse())
+
+    result = download_profile_photo_url(
+        "https://cdne-chmeetings-content.azureedge.net/images/846969/attachments/a/photo.png",
+        download_dir=tmp_path,
+    )
+
+    assert result["ok"] is True
+    assert result["content_type"] == "image/png"
+    assert Path(result["path"]).exists()
+    get.assert_called_once()
+
+
+def test_download_profile_photo_url_rejects_non_chmeetings_host(tmp_path):
+    result = download_profile_photo_url(
+        "https://example.com/photo.png",
+        download_dir=tmp_path,
+    )
+
+    assert result["ok"] is False
+    assert "allowed ChMeetings image host" in result["error"]
+
+
+def test_upload_person_photo_dry_run_accepts_photo_url(mocker, tmp_path):
+    photo = tmp_path / "downloaded.png"
+    _write_png(photo)
+    mocker.patch(
+        "photo_repair.download_profile_photo_url",
+        return_value={
+            "ok": True,
+            "path": photo,
+            "content_type": "image/png",
+            "size_bytes": photo.stat().st_size,
+        },
+    )
+    connector = MagicMock()
+
+    summary = upload_person_photo(
+        "999001",
+        photo_url="https://cdne-chmeetings-content.azureedge.net/images/846969/attachments/a/photo.png",
+        dry_run=True,
+        connector=connector,
+    )
+
+    assert summary["validated"] is True
+    assert summary["source"] == "url"
+    assert summary["uploaded"] is False
+    connector.authenticate.assert_not_called()


### PR DESCRIPTION
## Summary
- add ChMeetingsConnector.upload_person_photo() for POST /api/v1/people/{person_id}/photo
- add the operator-gated upload-person-photo CLI with --photo-file, --photo-url, --dry-run, and --execute
- validate documented ChMeetings image types and 2 MB limit before upload
- add mock coverage for connector multipart shape, CLI parsing, URL download, dry-run, execute, and confirmation paths

## Live validation
- confirmed official OpenAPI uses multipart field ile
- live-uploaded Peter/Phuc Phan's form photo to ChMeetings person 3632793
- ran targeted participant sync and confirmed WordPress participant 558 picked up the new photo_url

## Tests
- pytest tests/test_photo_repair.py tests/test_chmeetings_connector.py::test_upload_person_photo_posts_multipart_bytes tests/test_main.py::test_parse_args_upload_person_photo_execute tests/test_main.py::test_parse_args_upload_person_photo_url_dry_run -q

Closes #175