### PR TITLE
scheduling: reconcile team-code overrides with master schedule pins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,15 @@
   mechanism; a pairing with no existing match is created from the visual
   schedule (logged, with provenance, not applied silently) since Loc's sheet
   is the authoritative source for who plays whom.
+- Let team-code match schedule overrides supersede older numbered
+  `import-master-schedule` pool pins for the same BB/MVB/WVB visual cells,
+  while keeping hard conflicts for every other fixed-slot source.
+- Prefixed team labels on match-schedule fixed-slot provenance so
+  `schedule_input.json` and `schedule_output.json` stay inside the documented
+  contract schema.
 - Documented the operator workflow in `docs/SCHEDULE-HOW-TO.md` (Step 4C) and
   `docs/SCHEDULING.md`.
+
 ### 2026 scheduling source-of-truth documentation - refs [#215](https://github.com/i12know/vaysf/issues/215)
 
 - Consolidated the 2026 scheduling history from venue estimation through

--- a/middleware/scheduling/match_schedule_overrides.py
+++ b/middleware/scheduling/match_schedule_overrides.py
@@ -451,8 +451,8 @@ def resolve_match_schedule_overrides(
             "event": event,
             "resource_id": resource_id,
             "slot": row["slot"],
-            "team_a_label": team_a,
-            "team_b_label": team_b,
+            "x_match_schedule_team_a_label": team_a,
+            "x_match_schedule_team_b_label": team_b,
             "x_match_schedule_source": payload.get("source_workbook", ""),
             "x_match_schedule_sheet": row.get("source_sheet", ""),
             "x_match_schedule_cell": cell,
@@ -532,6 +532,36 @@ def summarize_payload_for_log(payload: Mapping[str, Any]) -> List[str]:
     return lines
 
 
+def _fixed_slot_key(slot: Mapping[str, Any]) -> Tuple[str, str]:
+    return (_clean_text(slot.get("resource_id")), _clean_text(slot.get("slot")))
+
+
+def _is_supersedable_master_pool_pin(slot: Mapping[str, Any]) -> bool:
+    """Return True for older visual master-schedule pool pins this import replaces.
+
+    The numbered master schedule and the team-code visual schedule describe the
+    same BB/MVB/WVB pool cells.  When both sidecars exist, the team-code sidecar
+    is the more authoritative source because it names the actual pairing in the
+    cell; keep hard conflicts for every other fixed-slot source.
+    """
+    event = _clean_text(slot.get("event"))
+    stage = _clean_text(slot.get("stage"))
+    has_master_source = any(
+        _clean_text(slot.get(key))
+        for key in ("x_master_schedule_source", "x_master_schedule_cell", "x_master_schedule_raw")
+    )
+    return (
+        has_master_source
+        and stage.casefold() == "pool"
+        and event
+        in {
+            master_schedule._EVENT_BY_SPORT["Basketball"],
+            master_schedule._EVENT_BY_SPORT["MVB"],
+            master_schedule._EVENT_BY_SPORT["WVB"],
+        }
+    )
+
+
 def merge_match_schedule_overrides_into_schedule_input(
     games: Sequence[Mapping[str, Any]],
     playoff_slots: Sequence[Mapping[str, Any]],
@@ -568,7 +598,7 @@ def merge_match_schedule_overrides_into_schedule_input(
         if _clean_text(slot.get("game_id"))
     }
     occupied_slots: Dict[Tuple[str, str], str] = {
-        (_clean_text(slot.get("resource_id")), _clean_text(slot.get("slot"))): _clean_text(slot.get("game_id"))
+        _fixed_slot_key(slot): _clean_text(slot.get("game_id"))
         for slot in playoff_slots
         if _clean_text(slot.get("resource_id"))
         and _clean_text(slot.get("slot"))
@@ -576,13 +606,37 @@ def merge_match_schedule_overrides_into_schedule_input(
     }
     for slot_row in validation["resolved_slots"]:
         game_id = _clean_text(slot_row.get("game_id"))
-        slot_key = (_clean_text(slot_row.get("resource_id")), _clean_text(slot_row.get("slot")))
+        previous_game_pin = merged_by_game.get(game_id)
+        if previous_game_pin:
+            previous_slot_key = _fixed_slot_key(previous_game_pin)
+            if occupied_slots.get(previous_slot_key) == game_id:
+                occupied_slots.pop(previous_slot_key, None)
+
+        slot_key = _fixed_slot_key(slot_row)
         existing_game_id = occupied_slots.get(slot_key)
         if existing_game_id and existing_game_id != game_id:
+            existing_slot = merged_by_game.get(existing_game_id, {})
+            if _is_supersedable_master_pool_pin(existing_slot):
+                merged_by_game.pop(existing_game_id, None)
+                occupied_slots.pop(slot_key, None)
+                validation["warnings"].append(
+                    f"{slot_row.get('x_match_schedule_cell', '<unknown>')}: "
+                    f"team-code match schedule override for game {game_id} superseded "
+                    f"numbered master-schedule pool pin {existing_game_id} at "
+                    f"{slot_key[0]} {slot_key[1]}"
+                )
+            else:
+                validation["errors"].append(
+                    f"{slot_row.get('x_match_schedule_cell', '<unknown>')}: "
+                    f"match schedule override for game {game_id} conflicts with existing fixed "
+                    f"assignment {existing_game_id} at {slot_key[0]} {slot_key[1]}"
+                )
+                continue
+        if occupied_slots.get(slot_key) and occupied_slots[slot_key] != game_id:
             validation["errors"].append(
                 f"{slot_row.get('x_match_schedule_cell', '<unknown>')}: "
                 f"match schedule override for game {game_id} conflicts with existing fixed "
-                f"assignment {existing_game_id} at {slot_key[0]} {slot_key[1]}"
+                f"assignment {occupied_slots[slot_key]} at {slot_key[0]} {slot_key[1]}"
             )
             continue
         merged_by_game[game_id] = slot_row

--- a/middleware/tests/test_match_schedule_overrides.py
+++ b/middleware/tests/test_match_schedule_overrides.py
@@ -298,3 +298,90 @@ def test_merge_reports_existing_fixed_slot_conflict():
 
     assert any("conflicts with existing fixed assignment BBM-02" in error for error in summary["errors"])
     assert {slot["game_id"] for slot in merged_slots} == {"BBM-02"}
+
+
+def test_merge_supersedes_numbered_master_pool_pin_for_team_code_schedule():
+    payload = {
+        "events": ["BB"],
+        "source_workbook": "unit.xlsx",
+        "rows": [{
+            "kind": "two_team_game",
+            "sport": "Basketball",
+            "event": SPORT_TYPE["BASKETBALL"],
+            "resource_type": GYM_RESOURCE_TYPE_BASKETBALL,
+            "team_a": "WAG",
+            "team_b": "FVC",
+            "day": "Sat-1",
+            "slot": "Sat-1-12:00",
+            "visual_venue": "Main Gym BB1",
+            "source_cell": "B2:D2",
+            "source_sheet": "Sheet1",
+            "raw_value": "WAG / v / FVC",
+        }],
+    }
+    games = [
+        {
+            "game_id": "BBM-01",
+            "event": SPORT_TYPE["BASKETBALL"],
+            "stage": "Pool",
+            "team_a_label": "WAG",
+            "team_b_label": "FVC",
+            "duration_minutes": 60,
+        },
+        {
+            "game_id": "BBM-02",
+            "event": SPORT_TYPE["BASKETBALL"],
+            "stage": "Pool",
+            "team_a_label": "SDC",
+            "team_b_label": "MWC",
+            "duration_minutes": 60,
+        },
+    ]
+    existing_slots = [
+        {
+            "game_id": "BBM-01",
+            "event": SPORT_TYPE["BASKETBALL"],
+            "stage": "Pool",
+            "resource_id": "BB-2",
+            "slot": "Sat-1-13:00",
+            "x_master_schedule_cell": "E3",
+        },
+        {
+            "game_id": "BBM-02",
+            "event": SPORT_TYPE["BASKETBALL"],
+            "stage": "Pool",
+            "resource_id": "BB-1",
+            "slot": "Sat-1-12:00",
+            "x_master_schedule_cell": "B2",
+        },
+    ]
+    resources = [
+        {
+            "resource_id": "BB-1",
+            "resource_type": GYM_RESOURCE_TYPE_BASKETBALL,
+            "label": "Court-1",
+            "day": "Sat-1",
+            "open_time": "12:00",
+            "close_time": "13:00",
+            "slot_minutes": 60,
+        },
+        {
+            "resource_id": "BB-2",
+            "resource_type": GYM_RESOURCE_TYPE_BASKETBALL,
+            "label": "Court-2",
+            "day": "Sat-1",
+            "open_time": "13:00",
+            "close_time": "14:00",
+            "slot_minutes": 60,
+        },
+    ]
+
+    _merged_games, merged_slots, summary = mso.merge_match_schedule_overrides_into_schedule_input(
+        games, existing_slots, payload, resources,
+    )
+
+    assert summary["errors"] == []
+    assert any("superseded numbered master-schedule pool pin BBM-02" in warning for warning in summary["warnings"])
+    assert {slot["game_id"] for slot in merged_slots} == {"BBM-01"}
+    assert merged_slots[0]["resource_id"] == "BB-1"
+    assert merged_slots[0]["slot"] == "Sat-1-12:00"


### PR DESCRIPTION
## Summary

- Let match_schedule_overrides.json supersede older numbered import-master-schedule BB/MVB/WVB pool pins for the same visual schedule cells.
- Keep hard fixed-slot conflicts for other sources so real operator conflicts are still caught.
- Prefix match schedule team labels as x_match_schedule_* provenance fields so schedule input/output contracts stay clean.

## Why

After #221, the real 2026 run loaded both manual_schedule_overrides.json and match_schedule_overrides.json. The old numbered master schedule sidecar pinned the same BB/MVB/WVB pool cells by game number, while the new team-code sidecar pinned the authoritative matchup for each cell. export-church-teams correctly detected the conflict but blocked schedule_input.json generation.

## Validation

- 40 passed: .\.venv\Scripts\python.exe -m pytest tests\test_match_schedule_overrides.py tests\test_main.py -q
- Real export-church-teams completed and wrote schedule_input.json with 229 games, 75 resources.
- Real un-schedule.bat completed report generation with no schedule contract warnings from match override team labels.
- Remaining solver status is still PARTIAL: Gym Core is infeasible with 8 unscheduled volleyball games, which is separate from the sidecar merge fix.
