### PR TITLE
scheduling: remove redundant match override conflict check

### DIFF
--- a/middleware/scheduling/match_schedule_overrides.py
+++ b/middleware/scheduling/match_schedule_overrides.py
@@ -632,13 +632,6 @@ def merge_match_schedule_overrides_into_schedule_input(
                     f"assignment {existing_game_id} at {slot_key[0]} {slot_key[1]}"
                 )
                 continue
-        if occupied_slots.get(slot_key) and occupied_slots[slot_key] != game_id:
-            validation["errors"].append(
-                f"{slot_row.get('x_match_schedule_cell', '<unknown>')}: "
-                f"match schedule override for game {game_id} conflicts with existing fixed "
-                f"assignment {occupied_slots[slot_key]} at {slot_key[0]} {slot_key[1]}"
-            )
-            continue
         merged_by_game[game_id] = slot_row
         if slot_key[0] and slot_key[1]:
             occupied_slots[slot_key] = game_id


### PR DESCRIPTION
## Summary

- Remove the dead second fixed-slot conflict check from the match schedule override merge path.
- Keeps the #222 behavior unchanged: supersedable numbered master-schedule pool pins are replaced, and non-supersedable fixed-slot conflicts still error in the first conflict branch.

## Validation

- 40 passed: .\.venv\Scripts\python.exe -m pytest tests\test_match_schedule_overrides.py tests\test_main.py -q

## Notes

This addresses the readability observation from the #222 merge comment. No data files are included.