### PR TITLE
scheduler: validate Table Tennis approved schedule source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@
   `Church_Team_Status_ALL` export: source team codes must exist in registered
   Table Tennis roster rows, and named athletes must match the event/category
   they are scheduled for before execution is allowed.
+- Added Table Tennis preliminary row-count balance validation so uneven
+  category schedules, such as one athlete receiving too few appearances while
+  another receives an extra bye row, are reported during dry run.
 - Documented the dry-run-first operator workflow and approved-game publication
   path in `docs/SCHEDULE-HOW-TO.md` and `docs/SCHEDULING.md`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@
   `placeholders` list with `classification=bye`, matching Soccer, so a
   dry-run's placeholder count reflects every skipped bye across all three
   sports instead of only Soccer's.
+- Added `--input-xlsx` roster context support to `import-approved-games` so the
+  Table Tennis source workbook is dry-run checked against the latest
+  `Church_Team_Status_ALL` export: source team codes must exist in registered
+  Table Tennis roster rows, and named athletes must match the event/category
+  they are scheduled for before execution is allowed.
 - Documented the dry-run-first operator workflow and approved-game publication
   path in `docs/SCHEDULE-HOW-TO.md` and `docs/SCHEDULING.md`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@
 - Added Table Tennis preliminary row-count balance validation so uneven
   category schedules, such as one athlete receiving too few appearances while
   another receives an extra bye row, are reported during dry run.
+- Downgraded unique same-church/same-category Table Tennis athlete name typos
+  to dry-run warnings instead of hard errors, preserving an audit trail while
+  allowing source sheets like `Justin Pham` vs `Justtin Pham` to proceed.
 - Documented the dry-run-first operator workflow and approved-game publication
   path in `docs/SCHEDULE-HOW-TO.md` and `docs/SCHEDULING.md`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,16 @@
 - Added Table Tennis preliminary row-count balance validation so uneven
   category schedules, such as one athlete receiving too few appearances while
   another receives an extra bye row, are reported during dry run.
+- Review fixes to the roster-vs-source validation:
+  - `_table_tennis_side_parts()`'s `Name (CODE)` parser now accepts a
+    lower/mixed-case church code (e.g. `Nhan Micah (orn)`), not just
+    uppercase. It previously fell through to treating the whole
+    `"Name (code)"` string as a single athlete label whenever the code
+    wasn't already uppercase, which would have raised a spurious
+    "not present in the current roster" error for a hand-typed cell.
+  - `_format_class()` now delegates to the existing
+    `ScheduleWorkbookBuilder._pod_format_class()` instead of re-implementing
+    the same "single"/"double" substring check a second time.
 - Downgraded unique same-church/same-category Table Tennis athlete name typos
   to dry-run warnings instead of hard errors, preserving an audit trail while
   allowing source sheets like `Justin Pham` vs `Justtin Pham` to proceed.

--- a/middleware/main.py
+++ b/middleware/main.py
@@ -555,6 +555,14 @@ def parse_args() -> argparse.Namespace:
         ),
     )
     approved_games_parser.add_argument(
+        "--input-xlsx",
+        default=None,
+        help=(
+            "Optional Church_Team_Status_ALL workbook for Table Tennis source-vs-roster "
+            "validation; defaults to the newest workbook beside --output/EXPORT_DIR."
+        ),
+    )
+    approved_games_parser.add_argument(
         "--output",
         default=None,
         help="Sidecar/audit path (default: EXPORT_DIR/approved_schedule_games*.json)",
@@ -1797,6 +1805,7 @@ def main() -> None:
                     logger.info(f"Match schedule overrides sidecar written to: {output_path.resolve()}")
                     success = True
     elif args.command == "import-approved-games":
+        from schedule_workbook import ScheduleWorkbookBuilder
         from schedule_contracts import (
             ScheduleContractError,
             validate_output_against_input,
@@ -1849,6 +1858,22 @@ def main() -> None:
             if args.publish_output
             else approved_games.default_publish_output_path(Path(EXPORT_DIR))
         )
+        context_xlsx = Path(args.input_xlsx) if args.input_xlsx else None
+        if context_xlsx is None:
+            context_xlsx = _find_latest_all_workbook(output_path.parent)
+            if context_xlsx is None and Path(EXPORT_DIR) != output_path.parent:
+                context_xlsx = _find_latest_all_workbook(Path(EXPORT_DIR))
+
+        roster_rows = None
+        if context_xlsx:
+            logger.info(f"import-approved-games: using roster context workbook {context_xlsx}")
+            builder = ScheduleWorkbookBuilder()
+            roster_rows, _validation_rows = builder.read_roster_validation_rows(context_xlsx)
+        else:
+            logger.warning(
+                "import-approved-games: no Church_Team_Status_ALL workbook found; "
+                "Table Tennis source-vs-roster validation will be skipped."
+            )
 
         try:
             schedule_input = json.loads(schedule_input_path.read_text(encoding="utf-8"))
@@ -1874,6 +1899,8 @@ def main() -> None:
                 table_tennis_path=table_tennis_path,
                 venue_input_path=Path(args.venue_input) if args.venue_input else None,
                 schedule_input=schedule_input,
+                roster_rows=roster_rows,
+                roster_context_path=context_xlsx,
                 waive_table_tennis_discrepancy=args.waive_table_tennis_discrepancy,
             )
             for line in approved_games.summarize_payload_for_log(payload):

--- a/middleware/scheduling/approved_games.py
+++ b/middleware/scheduling/approved_games.py
@@ -29,6 +29,7 @@ from config import (
 )
 from scheduling import master_schedule
 from scheduling import match_schedule_overrides
+from validation.name_matcher import likely_name_match
 
 APPROVED_GAMES_SIDECAR_FILENAME = "approved_schedule_games.json"
 APPROVED_GAMES_AUDIT_FILENAME = "approved_schedule_games.audit.json"
@@ -107,6 +108,15 @@ def _team_code(value: Any) -> str:
 
 def _is_bye(value: Any) -> bool:
     return _clean_text(value).casefold() == "bye"
+
+
+def _format_class(value: Any) -> str:
+    text = _clean_text(value).casefold()
+    if "double" in text:
+        return "doubles"
+    if "single" in text:
+        return "singles"
+    return text
 
 
 def _cell_ref(sheet: str, row: int, col: int) -> str:
@@ -635,10 +645,227 @@ def _strip_table_tennis_marker(text: str) -> str:
     return re.sub(r"^\((?:U35|35\+)\)\s*", "", text.strip(), flags=re.I)
 
 
+def _table_tennis_marker_event(text: str) -> Optional[str]:
+    upper = _clean_text(text).upper()
+    if upper.startswith("(35+)"):
+        return SPORT_TYPE["TABLE_TENNIS_35"]
+    if upper.startswith("(U35)"):
+        return SPORT_TYPE["TABLE_TENNIS"]
+    return None
+
+
+def _table_tennis_side_parts(text: str) -> tuple[str, Optional[str]]:
+    cleaned = _strip_table_tennis_marker(_clean_text(text))
+    match = re.match(r"^(.*?)\s*\(([A-Z0-9-]{2,8})\)\s*$", cleaned)
+    if match:
+        return match.group(1).strip(), _team_code(match.group(2))
+    return cleaned.strip(), None
+
+
+def _split_table_tennis_athletes(value: Any) -> list[str]:
+    text = _clean_text(value)
+    if not text:
+        return []
+    parts = re.split(r"\s*(?:&|/|\band\b)\s*", text, flags=re.I)
+    return [part.strip() for part in parts if part and part.strip()]
+
+
+def _table_tennis_roster_section(ws) -> list[dict[str, Any]]:
+    entries: list[dict[str, Any]] = []
+    for row in range(1, ws.max_row + 1):
+        team_cell = _clean_text(ws.cell(row=row, column=1).value)
+        event = _table_tennis_marker_event(team_cell)
+        if not event:
+            continue
+        team_code = _team_code(_strip_table_tennis_marker(team_cell))
+        if not team_code:
+            continue
+        entries.append({
+            "event": event,
+            "team_code": team_code,
+            "athletes": _split_table_tennis_athletes(ws.cell(row=row, column=2).value),
+            "source_cell": _cell_range(ws.title, row, 1, 2),
+        })
+    return entries
+
+
+def _table_tennis_roster_index(
+    roster_rows: Optional[Sequence[Mapping[str, Any]]],
+) -> dict[tuple[str, str], list[Mapping[str, Any]]]:
+    index: dict[tuple[str, str], list[Mapping[str, Any]]] = {}
+    for row in roster_rows or []:
+        event = _clean_text(row.get("sport_type"))
+        if event not in {SPORT_TYPE["TABLE_TENNIS"], SPORT_TYPE["TABLE_TENNIS_35"]}:
+            continue
+        church = _team_code(row.get("Church Team"))
+        if not church:
+            continue
+        index.setdefault((event, church), []).append(row)
+        team_order = _team_code(row.get("team_order"))
+        if team_order:
+            index.setdefault((event, f"{church}-{team_order}"), []).append(row)
+    return index
+
+
+def _table_tennis_roster_candidates(
+    roster_index: Mapping[tuple[str, str], list[Mapping[str, Any]]],
+    event: str,
+    team_code: str,
+) -> list[Mapping[str, Any]]:
+    exact = roster_index.get((event, team_code), [])
+    if exact:
+        return exact
+    base_team = re.sub(r"-\d+$", "", team_code)
+    if base_team != team_code:
+        return roster_index.get((event, base_team), [])
+    return []
+
+
+def _row_full_name(row: Mapping[str, Any]) -> str:
+    return " ".join(
+        part for part in (
+            _clean_text(row.get("First Name")),
+            _clean_text(row.get("Last Name")),
+        ) if part
+    )
+
+
+def _find_table_tennis_roster_athlete(
+    candidates: Sequence[Mapping[str, Any]],
+    athlete_name: str,
+    *,
+    format_class: Optional[str] = None,
+    gender: Optional[str] = None,
+) -> Optional[Mapping[str, Any]]:
+    for row in candidates:
+        if format_class and _format_class(row.get("sport_format")) != format_class:
+            continue
+        if gender:
+            row_gender = _clean_text(row.get("sport_gender")).casefold()
+            if row_gender and row_gender != gender.casefold():
+                continue
+        if likely_name_match(athlete_name, _row_full_name(row)):
+            return row
+    return None
+
+
+def _validate_table_tennis_source_against_roster(
+    *,
+    ws,
+    roster_rows: Optional[Sequence[Mapping[str, Any]]],
+    warnings: list[str],
+    errors: list[str],
+) -> None:
+    if roster_rows is None:
+        warnings.append(
+            "Table Tennis source validation skipped: no Church_Team_Status_ALL roster context supplied."
+        )
+        return
+    if not roster_rows:
+        warnings.append(
+            "Table Tennis source validation skipped: roster context was empty."
+        )
+        return
+
+    roster_index = _table_tennis_roster_index(roster_rows)
+    roster_entries = _table_tennis_roster_section(ws)
+    source_team_keys = {(entry["event"], entry["team_code"]) for entry in roster_entries}
+    seen_source_roster_mismatches: set[tuple[str, str, str]] = set()
+
+    for entry in roster_entries:
+        candidates = _table_tennis_roster_candidates(
+            roster_index,
+            entry["event"],
+            entry["team_code"],
+        )
+        if not candidates:
+            errors.append(
+                f"{entry['source_cell']}: Table Tennis source team {entry['team_code']} "
+                f"is not present in the current roster for {entry['event']}."
+            )
+            continue
+        for athlete in entry["athletes"]:
+            if not _find_table_tennis_roster_athlete(
+                candidates,
+                athlete,
+                format_class="doubles",
+            ):
+                errors.append(
+                    f"{entry['source_cell']}: athlete {athlete!r} is not registered "
+                    f"for {entry['event']} doubles under {entry['team_code']}."
+                )
+
+    for row in range(3, ws.max_row + 1):
+        if not _time_label(ws.cell(row=row, column=1).value):
+            continue
+        for column in range(2, 6):
+            raw = _clean_text(ws.cell(row=row, column=column).value)
+            if not raw or " - " not in raw:
+                continue
+            if re.search(r"\b(?:SF|FINAL|3RD)\b", raw, re.I):
+                continue
+            left, right = [part.strip() for part in raw.split(" - ", 1)]
+            event, sub_event, _prefix = _table_tennis_category(raw, column)
+            format_class = "doubles" if "Doubles" in sub_event else "singles"
+            gender = None
+            if sub_event.startswith("Women's"):
+                gender = "Women"
+            elif sub_event.startswith("Men's"):
+                gender = "Men"
+            for side in (left, right):
+                label, team_code = _table_tennis_side_parts(side)
+                if _is_bye(label) or _is_bye(team_code):
+                    continue
+                source_cell = _cell_ref(ws.title, row, column)
+                if not team_code:
+                    team_code = _team_code(label)
+                    mismatch_key = (source_cell, event, team_code)
+                    if (event, team_code) not in source_team_keys and mismatch_key not in seen_source_roster_mismatches:
+                        seen_source_roster_mismatches.add(mismatch_key)
+                        errors.append(
+                            f"{source_cell}: Table Tennis schedule team {team_code} "
+                            f"is not listed in the source roster section for {event}."
+                        )
+                    candidates = _table_tennis_roster_candidates(
+                        roster_index,
+                        event,
+                        team_code,
+                    )
+                    if not candidates:
+                        errors.append(
+                            f"{source_cell}: Table Tennis source team {team_code} "
+                            f"is not present in the current roster for {event}."
+                        )
+                    continue
+                candidates = _table_tennis_roster_candidates(
+                    roster_index,
+                    event,
+                    team_code,
+                )
+                if not candidates:
+                    errors.append(
+                        f"{source_cell}: Table Tennis source team {team_code} "
+                        f"is not present in the current roster for {event}."
+                    )
+                    continue
+                if not _find_table_tennis_roster_athlete(
+                    candidates,
+                    label,
+                    format_class=format_class,
+                    gender=gender,
+                ):
+                    errors.append(
+                        f"{source_cell}: athlete {label!r} is not registered for "
+                        f"{event} {sub_event} under {team_code}."
+                    )
+
+
+
 def _parse_table_tennis(
     path: Path,
     *,
     resources: Sequence[Mapping[str, Any]],
+    roster_rows: Optional[Sequence[Mapping[str, Any]]],
     warnings: list[str],
     errors: list[str],
     waive_discrepancy: bool,
@@ -654,6 +881,12 @@ def _parse_table_tennis(
         if _clean_text(value).upper().startswith("(U35)")
     }
     schedule_u35_codes: set[str] = set()
+    _validate_table_tennis_source_against_roster(
+        ws=ws,
+        roster_rows=roster_rows,
+        warnings=warnings,
+        errors=errors,
+    )
 
     for row in range(3, ws.max_row + 1):
         start_time = _time_label(ws.cell(row=row, column=1).value)
@@ -855,6 +1088,8 @@ def build_approved_games_payload(
     soccer_path: Path,
     table_tennis_path: Path,
     schedule_input: Mapping[str, Any],
+    roster_rows: Optional[Sequence[Mapping[str, Any]]] = None,
+    roster_context_path: Optional[Path] = None,
     venue_input_path: Optional[Path] = None,
     waive_table_tennis_discrepancy: bool = False,
 ) -> dict[str, Any]:
@@ -889,6 +1124,7 @@ def build_approved_games_payload(
         table_tennis_records, table_tennis_placeholders = _parse_table_tennis(
             table_tennis_path,
             resources=resources,
+            roster_rows=roster_rows,
             warnings=warnings,
             errors=errors,
             waive_discrepancy=waive_table_tennis_discrepancy,
@@ -913,6 +1149,7 @@ def build_approved_games_payload(
             "badminton": str(badminton_path),
             "soccer": str(soccer_path),
             "table_tennis": str(table_tennis_path),
+            "roster_context": str(roster_context_path) if roster_context_path else None,
             "venue_input": str(venue_input_path) if venue_input_path else None,
         },
         "games": records,

--- a/middleware/scheduling/approved_games.py
+++ b/middleware/scheduling/approved_games.py
@@ -860,6 +860,56 @@ def _validate_table_tennis_source_against_roster(
                     )
 
 
+def _table_tennis_count_label(raw_side: str, sub_event: str) -> str:
+    label, team_code = _table_tennis_side_parts(raw_side)
+    if _is_bye(label) or _is_bye(team_code):
+        return ""
+    if "Doubles" in sub_event:
+        return _team_code(team_code or label)
+    return label
+
+
+def _validate_table_tennis_prelim_balance(ws, errors: list[str]) -> None:
+    by_sub_event: dict[str, dict[str, list[str]]] = {}
+
+    for row in range(3, ws.max_row + 1):
+        if not _time_label(ws.cell(row=row, column=1).value):
+            continue
+        for column in range(2, 6):
+            raw = _clean_text(ws.cell(row=row, column=column).value)
+            if not raw or " - " not in raw:
+                continue
+            if re.search(r"\b(?:SF|FINAL|3RD)\b", raw, re.I):
+                continue
+            left, right = [part.strip() for part in raw.split(" - ", 1)]
+            _event, sub_event, _prefix = _table_tennis_category(raw, column)
+            source_cell = _cell_ref(ws.title, row, column)
+            for side in (left, right):
+                label = _table_tennis_count_label(side, sub_event)
+                if not label:
+                    continue
+                by_sub_event.setdefault(sub_event, {}).setdefault(label, []).append(source_cell)
+
+    for sub_event, appearances in sorted(by_sub_event.items()):
+        if len(appearances) < 3:
+            continue
+        count_frequency = Counter(len(cells) for cells in appearances.values())
+        if len(count_frequency) <= 1:
+            continue
+        expected_count, _frequency = count_frequency.most_common(1)[0]
+        outliers = [
+            f"{label}={len(cells)} ({', '.join(cells)})"
+            for label, cells in sorted(appearances.items())
+            if len(cells) != expected_count
+        ]
+        if outliers:
+            errors.append(
+                f"Table Tennis {sub_event} preliminary row counts are unbalanced; "
+                f"expected {expected_count} appearance(s) based on the category majority, "
+                f"but found: {'; '.join(outliers)}."
+            )
+
+
 
 def _parse_table_tennis(
     path: Path,
@@ -887,6 +937,7 @@ def _parse_table_tennis(
         warnings=warnings,
         errors=errors,
     )
+    _validate_table_tennis_prelim_balance(ws, errors)
 
     for row in range(3, ws.max_row + 1):
         start_time = _time_label(ws.cell(row=row, column=1).value)

--- a/middleware/scheduling/approved_games.py
+++ b/middleware/scheduling/approved_games.py
@@ -14,6 +14,7 @@ import json
 import re
 from collections import Counter
 from datetime import datetime, time as dt_time
+from difflib import SequenceMatcher
 from pathlib import Path
 from typing import Any, Mapping, Optional, Sequence
 
@@ -29,7 +30,7 @@ from config import (
 )
 from scheduling import master_schedule
 from scheduling import match_schedule_overrides
-from validation.name_matcher import likely_name_match
+from validation.name_matcher import likely_name_match, normalized_name
 
 APPROVED_GAMES_SIDECAR_FILENAME = "approved_schedule_games.json"
 APPROVED_GAMES_AUDIT_FILENAME = "approved_schedule_games.audit.json"
@@ -730,13 +731,32 @@ def _row_full_name(row: Mapping[str, Any]) -> str:
     )
 
 
-def _find_table_tennis_roster_athlete(
+def _name_tokens(value: str) -> list[str]:
+    return re.sub(r"[^\w\s]+", " ", normalized_name(value)).split()
+
+
+def _typo_tolerant_name_match(query_name: str, candidate_name: str) -> bool:
+    query_key = normalized_name(query_name)
+    candidate_key = normalized_name(candidate_name)
+    if not query_key or not candidate_key:
+        return False
+
+    direct_ratio = SequenceMatcher(None, query_key, candidate_key).ratio()
+    sorted_ratio = SequenceMatcher(
+        None,
+        " ".join(sorted(_name_tokens(query_key))),
+        " ".join(sorted(_name_tokens(candidate_key))),
+    ).ratio()
+    return max(direct_ratio, sorted_ratio) >= 0.92
+
+
+def _filtered_table_tennis_roster_candidates(
     candidates: Sequence[Mapping[str, Any]],
-    athlete_name: str,
     *,
     format_class: Optional[str] = None,
     gender: Optional[str] = None,
-) -> Optional[Mapping[str, Any]]:
+) -> list[Mapping[str, Any]]:
+    filtered: list[Mapping[str, Any]] = []
     for row in candidates:
         if format_class and _format_class(row.get("sport_format")) != format_class:
             continue
@@ -744,8 +764,44 @@ def _find_table_tennis_roster_athlete(
             row_gender = _clean_text(row.get("sport_gender")).casefold()
             if row_gender and row_gender != gender.casefold():
                 continue
+        filtered.append(row)
+    return filtered
+
+
+def _find_table_tennis_roster_athlete(
+    candidates: Sequence[Mapping[str, Any]],
+    athlete_name: str,
+    *,
+    format_class: Optional[str] = None,
+    gender: Optional[str] = None,
+    warnings: Optional[list[str]] = None,
+    source_cell: str = "",
+    context: str = "",
+) -> Optional[Mapping[str, Any]]:
+    filtered_candidates = _filtered_table_tennis_roster_candidates(
+        candidates,
+        format_class=format_class,
+        gender=gender,
+    )
+    for row in filtered_candidates:
         if likely_name_match(athlete_name, _row_full_name(row)):
             return row
+
+    typo_matches = [
+        row for row in filtered_candidates
+        if _typo_tolerant_name_match(athlete_name, _row_full_name(row))
+    ]
+    if len(typo_matches) == 1:
+        row = typo_matches[0]
+        if warnings is not None:
+            warning_prefix = f"{source_cell}: " if source_cell else ""
+            warning_context = f" {context}" if context else ""
+            warnings.append(
+                f"{warning_prefix}athlete {athlete_name!r} matched roster athlete "
+                f"{_row_full_name(row)!r} by typo-tolerant Table Tennis name matching"
+                f"{warning_context}."
+            )
+        return row
     return None
 
 
@@ -789,6 +845,9 @@ def _validate_table_tennis_source_against_roster(
                 candidates,
                 athlete,
                 format_class="doubles",
+                warnings=warnings,
+                source_cell=entry["source_cell"],
+                context=f"under {entry['team_code']} {entry['event']} doubles",
             ):
                 errors.append(
                     f"{entry['source_cell']}: athlete {athlete!r} is not registered "
@@ -853,6 +912,9 @@ def _validate_table_tennis_source_against_roster(
                     label,
                     format_class=format_class,
                     gender=gender,
+                    warnings=warnings,
+                    source_cell=source_cell,
+                    context=f"under {team_code} {event} {sub_event}",
                 ):
                     errors.append(
                         f"{source_cell}: athlete {label!r} is not registered for "

--- a/middleware/scheduling/approved_games.py
+++ b/middleware/scheduling/approved_games.py
@@ -28,6 +28,7 @@ from config import (
     TEAM_RESOURCE_TYPE_BIBLE_CHALLENGE,
     TEAM_RESOURCE_TYPE_SOCCER,
 )
+from schedule_workbook import ScheduleWorkbookBuilder
 from scheduling import master_schedule
 from scheduling import match_schedule_overrides
 from validation.name_matcher import likely_name_match, normalized_name
@@ -112,12 +113,11 @@ def _is_bye(value: Any) -> bool:
 
 
 def _format_class(value: Any) -> str:
-    text = _clean_text(value).casefold()
-    if "double" in text:
-        return "doubles"
-    if "single" in text:
-        return "singles"
-    return text
+    # Reuses ScheduleWorkbookBuilder's classifier instead of a second copy of the
+    # same "single"/"double" substring check; the one caller only ever compares
+    # the result against the literal "doubles"/"singles", so the "anomaly"
+    # fallback (vs. a bare non-matching string) is not observable here.
+    return ScheduleWorkbookBuilder._pod_format_class(_clean_text(value))
 
 
 def _cell_ref(sheet: str, row: int, col: int) -> str:
@@ -657,7 +657,7 @@ def _table_tennis_marker_event(text: str) -> Optional[str]:
 
 def _table_tennis_side_parts(text: str) -> tuple[str, Optional[str]]:
     cleaned = _strip_table_tennis_marker(_clean_text(text))
-    match = re.match(r"^(.*?)\s*\(([A-Z0-9-]{2,8})\)\s*$", cleaned)
+    match = re.match(r"^(.*?)\s*\(([A-Za-z0-9-]{2,8})\)\s*$", cleaned)
     if match:
         return match.group(1).strip(), _team_code(match.group(2))
     return cleaned.strip(), None

--- a/middleware/tests/test_approved_games.py
+++ b/middleware/tests/test_approved_games.py
@@ -326,6 +326,50 @@ def test_table_tennis_source_validation_flags_unregistered_athlete(tmp_path):
     assert any("Noah Vo" in error and "not registered" in error for error in errors)
 
 
+def test_table_tennis_source_validation_warns_for_unique_name_typo(tmp_path):
+    main = tmp_path / "main.xlsx"
+    badminton = tmp_path / "badminton.xlsx"
+    soccer = tmp_path / "soccer.xlsx"
+    table_tennis = tmp_path / "tt.xlsx"
+    _write_main_schedule(main)
+    _write_badminton(badminton)
+    _write_soccer(soccer)
+    _write_table_tennis(
+        table_tennis,
+        include_sbc=False,
+        matches=["(U35) GAC-2 - BYE"],
+        roster_entries=[("(U35) GAC-2", "Phillip Tran & Justin Pham")],
+    )
+
+    payload = approved_games.build_approved_games_payload(
+        main_schedule_path=main,
+        badminton_path=badminton,
+        soccer_path=soccer,
+        table_tennis_path=table_tennis,
+        schedule_input=_schedule_input(),
+        roster_rows=[
+            _tt_roster_row(
+                "GAC",
+                "Phillip",
+                "Tran",
+                gender="Mixed",
+                sport_format="Mixed Double",
+            ),
+            _tt_roster_row(
+                "GAC",
+                "Justtin",
+                "Pham",
+                gender="Mixed",
+                sport_format="Mixed Double",
+            ),
+        ],
+    )
+
+    assert payload["validation"]["errors"] == []
+    warnings = payload["validation"]["warnings"]
+    assert any("Justin Pham" in warning and "Justtin Pham" in warning for warning in warnings)
+
+
 def test_table_tennis_prelim_balance_flags_low_and_high_appearances(tmp_path):
     main = tmp_path / "main.xlsx"
     badminton = tmp_path / "badminton.xlsx"

--- a/middleware/tests/test_approved_games.py
+++ b/middleware/tests/test_approved_games.py
@@ -65,7 +65,8 @@ def _write_table_tennis(path, include_sbc=True, matches=None, roster_entries=Non
     ws.append(["Fri 7/24", "Table 1", "Table 2", "Table 3", "Table 4"])
     matches = matches or ["Nhan Micah (ORN) - Phan Dora (WSD)"]
     for index, match in enumerate(matches):
-        ws.append([f"17:{index * 20:02d}", match])
+        minutes = index * 15
+        ws.append([f"{17 + minutes // 60:02d}:{minutes % 60:02d}", match])
     ws.append([])
     ws.append(["TEAM", "ATHLETES"])
     for team, athletes in roster_entries or []:
@@ -323,3 +324,45 @@ def test_table_tennis_source_validation_flags_unregistered_athlete(tmp_path):
 
     errors = payload["validation"]["errors"]
     assert any("Noah Vo" in error and "not registered" in error for error in errors)
+
+
+def test_table_tennis_prelim_balance_flags_low_and_high_appearances(tmp_path):
+    main = tmp_path / "main.xlsx"
+    badminton = tmp_path / "badminton.xlsx"
+    soccer = tmp_path / "soccer.xlsx"
+    table_tennis = tmp_path / "tt.xlsx"
+    _write_main_schedule(main)
+    _write_badminton(badminton)
+    _write_soccer(soccer)
+    _write_table_tennis(
+        table_tennis,
+        include_sbc=False,
+        matches=[
+            "Nhan Micah (ORN) - Phan Dora (WSD)",
+            "Phan Dora (WSD) - To Jacklyn (WSD)",
+            "To Jacklyn (WSD) - Ly Jennifer (RPC)",
+            "Ly Jennifer (RPC) - Nguyen Christina (WSD)",
+            "Nguyen Christina (WSD) - Nhan Micah (ORN)",
+            "Nhan Micah (ORN) - To Jacklyn (WSD)",
+            "Phan Dora (WSD) - Ly Jennifer (RPC)",
+            "To Jacklyn (WSD) - Bye",
+        ],
+    )
+    schedule_input = _schedule_input()
+    schedule_input["resources"][-1]["close_time"] = "20:00"
+
+    payload = approved_games.build_approved_games_payload(
+        main_schedule_path=main,
+        badminton_path=badminton,
+        soccer_path=soccer,
+        table_tennis_path=table_tennis,
+        schedule_input=schedule_input,
+    )
+
+    errors = payload["validation"]["errors"]
+    balance_error = next(
+        error for error in errors
+        if "Women's Singles preliminary row counts are unbalanced" in error
+    )
+    assert "Nguyen Christina=2" in balance_error
+    assert "To Jacklyn=4" in balance_error

--- a/middleware/tests/test_approved_games.py
+++ b/middleware/tests/test_approved_games.py
@@ -58,7 +58,7 @@ def _write_soccer(path, team_a="ANH", team_b="GAC"):
     wb.save(path)
 
 
-def _write_table_tennis(path, include_sbc=True, matches=None):
+def _write_table_tennis(path, include_sbc=True, matches=None, roster_entries=None):
     wb = Workbook()
     ws = wb.active
     ws.append(["", "VAY SPORTS FEST 2026 - TABLE TENNIS SCHEDULE"])
@@ -68,9 +68,33 @@ def _write_table_tennis(path, include_sbc=True, matches=None):
         ws.append([f"17:{index * 20:02d}", match])
     ws.append([])
     ws.append(["TEAM", "ATHLETES"])
+    for team, athletes in roster_entries or []:
+        ws.append([team, athletes])
     if include_sbc:
         ws.append(["(U35) SBC", "Player A & Player B"])
     wb.save(path)
+
+
+def _tt_roster_row(
+    church,
+    first,
+    last,
+    *,
+    event=None,
+    gender="Women",
+    sport_format="Singles",
+    team_order=None,
+):
+    return {
+        "Church Team": church,
+        "sport_type": event or SPORT_TYPE["TABLE_TENNIS"],
+        "sport_gender": gender,
+        "sport_format": sport_format,
+        "team_order": team_order,
+        "Participant ID (WP)": f"{church}-{first}-{last}",
+        "First Name": first,
+        "Last Name": last,
+    }
 
 
 def _schedule_input():
@@ -236,3 +260,66 @@ def test_bye_rows_are_not_imported_as_real_games(tmp_path):
     assert str(table_tennis) in bye_workbooks
     # Two bye rows were written for table tennis (left-side and right-side bye).
     assert sum(1 for wb in bye_placeholders if wb["source_workbook"] == str(table_tennis)) == 2
+
+
+def test_table_tennis_source_validation_flags_unregistered_team(tmp_path):
+    main = tmp_path / "main.xlsx"
+    badminton = tmp_path / "badminton.xlsx"
+    soccer = tmp_path / "soccer.xlsx"
+    table_tennis = tmp_path / "tt.xlsx"
+    _write_main_schedule(main)
+    _write_badminton(badminton)
+    _write_soccer(soccer)
+    _write_table_tennis(table_tennis, include_sbc=True)
+
+    payload = approved_games.build_approved_games_payload(
+        main_schedule_path=main,
+        badminton_path=badminton,
+        soccer_path=soccer,
+        table_tennis_path=table_tennis,
+        schedule_input=_schedule_input(),
+        roster_rows=[
+            _tt_roster_row("ORN", "Micah", "Nhan"),
+            _tt_roster_row("WSD", "Dora", "Phan"),
+        ],
+    )
+
+    errors = payload["validation"]["errors"]
+    assert any("source team SBC" in error for error in errors)
+
+
+def test_table_tennis_source_validation_flags_unregistered_athlete(tmp_path):
+    main = tmp_path / "main.xlsx"
+    badminton = tmp_path / "badminton.xlsx"
+    soccer = tmp_path / "soccer.xlsx"
+    table_tennis = tmp_path / "tt.xlsx"
+    _write_main_schedule(main)
+    _write_badminton(badminton)
+    _write_soccer(soccer)
+    _write_table_tennis(
+        table_tennis,
+        include_sbc=False,
+        matches=["(U35) GAC-1 - BYE"],
+        roster_entries=[("(U35) GAC-1", "Joshua Dang & Noah Vo")],
+    )
+
+    payload = approved_games.build_approved_games_payload(
+        main_schedule_path=main,
+        badminton_path=badminton,
+        soccer_path=soccer,
+        table_tennis_path=table_tennis,
+        schedule_input=_schedule_input(),
+        roster_rows=[
+            _tt_roster_row(
+                "GAC",
+                "Joshua",
+                "Dang",
+                gender="Mixed",
+                sport_format="Mixed Double",
+                team_order=1,
+            ),
+        ],
+    )
+
+    errors = payload["validation"]["errors"]
+    assert any("Noah Vo" in error and "not registered" in error for error in errors)

--- a/middleware/tests/test_approved_games.py
+++ b/middleware/tests/test_approved_games.py
@@ -410,3 +410,41 @@ def test_table_tennis_prelim_balance_flags_low_and_high_appearances(tmp_path):
     )
     assert "Nguyen Christina=2" in balance_error
     assert "To Jacklyn=4" in balance_error
+
+
+def test_table_tennis_side_parts_accepts_lowercase_team_code():
+    # A hand-typed workbook cell can write the church code in any case; the
+    # extracted team code should still normalize to uppercase either way.
+    for text in ("Nhan Micah (ORN)", "Nhan Micah (orn)", "Nhan Micah (Orn)"):
+        label, team_code = approved_games._table_tennis_side_parts(text)
+        assert label == "Nhan Micah"
+        assert team_code == "ORN"
+
+
+def test_table_tennis_source_validation_matches_lowercase_church_code(tmp_path):
+    main = tmp_path / "main.xlsx"
+    badminton = tmp_path / "badminton.xlsx"
+    soccer = tmp_path / "soccer.xlsx"
+    table_tennis = tmp_path / "tt.xlsx"
+    _write_main_schedule(main)
+    _write_badminton(badminton)
+    _write_soccer(soccer)
+    _write_table_tennis(
+        table_tennis,
+        include_sbc=False,
+        matches=["Nhan Micah (orn) - Phan Dora (WSD)"],
+    )
+
+    payload = approved_games.build_approved_games_payload(
+        main_schedule_path=main,
+        badminton_path=badminton,
+        soccer_path=soccer,
+        table_tennis_path=table_tennis,
+        schedule_input=_schedule_input(),
+        roster_rows=[
+            _tt_roster_row("ORN", "Micah", "Nhan"),
+            _tt_roster_row("WSD", "Dora", "Phan"),
+        ],
+    )
+
+    assert payload["validation"]["errors"] == []

--- a/middleware/tests/test_main.py
+++ b/middleware/tests/test_main.py
@@ -226,6 +226,8 @@ def test_parse_args_import_approved_games_execute(monkeypatch):
             "tt.xlsx",
             "--schedule-input",
             "schedule_input.json",
+            "--input-xlsx",
+            "Church_Team_Status_ALL.xlsx",
             "--execute",
         ],
     )
@@ -236,6 +238,7 @@ def test_parse_args_import_approved_games_execute(monkeypatch):
     assert args.soccer == "soccer.xlsx"
     assert args.table_tennis == "tt.xlsx"
     assert args.schedule_input == "schedule_input.json"
+    assert args.input_xlsx == "Church_Team_Status_ALL.xlsx"
     assert args.execute is True
     assert args.dry_run is False
 


### PR DESCRIPTION
Refs #197.

Summary:
- Adds roster-context validation for the approved Table Tennis source workbook during import-approved-games.
- Flags unregistered TT teams/athletes and preliminary match-count imbalances before execute.
- Allows unique typo-tolerant TT name matches as warnings, preserving an audit trail for cases like Justin/Justtin Pham.

Validation:
- S:\MyPrj\vay\vaysf\middleware\.venv\Scripts\python.exe -m pytest tests\test_approved_games.py -q -> 7 passed
- S:\MyPrj\vay\vaysf\middleware\.venv\Scripts\python.exe -m pytest tests\test_main.py -q -> 33 passed
- Corrected TT workbook dry-run parsed 178 exact games / 19 placeholders. TT validation is clean except the audited Justin/Justtin typo warning; remaining blocking errors are the existing Soccer resource/slot issues.