### PR TITLE
scheduler: enforce Table Tennis Friday Orange plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,15 @@
 - Added Table Tennis preliminary row-count balance validation so uneven
   category schedules, such as one athlete receiving too few appearances while
   another receives an extra bye row, are reported during dry run.
+- Added the final #197 Table Tennis venue/date guard: the approved Table
+  Tennis workbook must visibly declare Friday 7/24, and every imported
+  Table Tennis / Table Tennis 35+ game must resolve to a Friday `Fri-1`
+  Table Tennis resource at Orange before execution is allowed.
+- Treat the approved COED Soccer schedule workbook as an operator override
+  source when it uses a field slot outside generated venue availability:
+  `import-approved-games` now creates an auditable `SOC-APPROVED-*` resource
+  for that exact slot instead of blocking execution on an unresolved
+  Soccer Field resource.
 - Review fixes to the roster-vs-source validation:
   - `_table_tennis_side_parts()`'s `Name (CODE)` parser now accepts a
     lower/mixed-case church code (e.g. `Nhan Micah (orn)`), not just

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,14 +30,23 @@
   category schedules, such as one athlete receiving too few appearances while
   another receives an extra bye row, are reported during dry run.
 - Added the final #197 Table Tennis venue/date guard: the approved Table
-  Tennis workbook must visibly declare Friday 7/24, and every imported
-  Table Tennis / Table Tennis 35+ game must resolve to a Friday `Fri-1`
-  Table Tennis resource at Orange before execution is allowed.
+  Tennis workbook must visibly declare Friday 7/24 in its header, and every
+  imported Table Tennis / Table Tennis 35+ game must resolve to a Table
+  Tennis resource at Orange before execution is allowed.
 - Treat the approved COED Soccer schedule workbook as an operator override
   source when it uses a field slot outside generated venue availability:
   `import-approved-games` now creates an auditable `SOC-APPROVED-*` resource
   for that exact slot instead of blocking execution on an unresolved
   Soccer Field resource.
+- Review fix: removed `_validate_table_tennis_friday_orange()`'s per-game day
+  comparison. `_parse_table_tennis` always builds every record's
+  `scheduled_slot` with the hardcoded required day, so that comparison could
+  never actually disagree with it — it read as day-drift protection per game
+  but was unreachable dead code. Verified by direct reproduction that the
+  workbook-header scan (the other half of the same guard) still catches a
+  wrong-day workbook on its own — including a workbook dated a different day
+  outright (`Sat 7/25`), not just a Friday-dated header with a contradicting
+  weekday label. New regression test locks this in.
 - Review fixes to the roster-vs-source validation:
   - `_table_tennis_side_parts()`'s `Name (CODE)` parser now accepts a
     lower/mixed-case church code (e.g. `Nhan Micah (orn)`), not just

--- a/middleware/scheduling/approved_games.py
+++ b/middleware/scheduling/approved_games.py
@@ -179,13 +179,6 @@ def _time_after_minutes(start_time: str, minutes: int) -> str:
     return f"{total // 60:02d}:{total % 60:02d}"
 
 
-def _slot_day(slot: Any) -> str:
-    text = _clean_text(slot)
-    if "-" not in text:
-        return ""
-    return text.rsplit("-", 1)[0]
-
-
 def _parse_minutes(value: str) -> int:
     hours, minutes = str(value).split(":")
     return int(hours) * 60 + int(minutes)
@@ -1048,6 +1041,11 @@ def _validate_table_tennis_friday_orange(
             f"({TABLE_TENNIS_REQUIRED_DAY}) in the visible schedule header."
         )
 
+    # No per-game day check here: _parse_table_tennis unconditionally builds
+    # every record's scheduled_slot with TABLE_TENNIS_REQUIRED_DAY (Fri-1), so
+    # a record-level day comparison can never disagree with it — it would be
+    # dead code that only looks like it validates day drift. The header scan
+    # above is what actually catches a workbook that isn't Friday 7/24.
     resource_by_id = {
         _clean_text(resource.get("resource_id")): resource
         for resource in resources
@@ -1056,13 +1054,6 @@ def _validate_table_tennis_friday_orange(
     for record in records:
         source = _clean_text(record.get("source_cell"))
         game_key = _clean_text(record.get("game_key"))
-        slot = _clean_text(record.get("scheduled_slot"))
-        if _slot_day(slot) != TABLE_TENNIS_REQUIRED_DAY:
-            errors.append(
-                f"{source}: Table Tennis game {game_key} must be scheduled on "
-                f"{TABLE_TENNIS_REQUIRED_DAY} / Friday 7/24, not {slot or 'an unresolved slot'}."
-            )
-
         resource_id = _clean_text(record.get("resource_id"))
         if not resource_id:
             continue

--- a/middleware/scheduling/approved_games.py
+++ b/middleware/scheduling/approved_games.py
@@ -42,6 +42,8 @@ DEFAULT_MAIN_SCHEDULE_FILENAME = "2026 Main Schedule draft 11.xlsx"
 DEFAULT_BADMINTON_FILENAME = "2026 VAY Badminton Schedule_draft_v1_10Jul2026.xlsx"
 DEFAULT_SOCCER_FILENAME = "COED SOCCER SCHEDULE.xlsx"
 DEFAULT_TABLE_TENNIS_FILENAME = "Schedule_Roster - Table Tennis (PingPong) 2026.xlsx"
+TABLE_TENNIS_REQUIRED_DAY = "Fri-1"
+TABLE_TENNIS_REQUIRED_VENUE_FRAGMENT = "orange"
 
 _TEAM_CODE_RE = re.compile(r"^[A-Z0-9]{2,5}(?:-\d+)?$")
 _DATE_TO_DAY = {
@@ -150,6 +152,8 @@ def _time_label(value: Any) -> Optional[str]:
 
 
 def _date_to_day(value: Any) -> Optional[str]:
+    if isinstance(value, datetime):
+        value = f"{value.month}/{value.day}"
     text = _clean_text(value).upper()
     match = re.search(r"(\d{1,2}/\d{1,2})", text)
     if not match:
@@ -157,8 +161,29 @@ def _date_to_day(value: Any) -> Optional[str]:
     return _DATE_TO_DAY.get(match.group(1))
 
 
+def _declares_table_tennis_required_date(value: Any) -> bool:
+    if _date_to_day(value) != TABLE_TENNIS_REQUIRED_DAY:
+        return False
+    text = _clean_text(value).casefold()
+    if re.search(r"\b(?:mon|tue|wed|thu|fri|sat|sun)(?:day)?\b", text):
+        return bool(re.search(r"\bfri(?:day)?\b", text))
+    return True
+
+
 def _slot(day: str, start_time: str) -> str:
     return f"{day}-{start_time}"
+
+
+def _time_after_minutes(start_time: str, minutes: int) -> str:
+    total = _parse_minutes(start_time) + minutes
+    return f"{total // 60:02d}:{total % 60:02d}"
+
+
+def _slot_day(slot: Any) -> str:
+    text = _clean_text(slot)
+    if "-" not in text:
+        return ""
+    return text.rsplit("-", 1)[0]
 
 
 def _parse_minutes(value: str) -> int:
@@ -203,6 +228,30 @@ def _resolve_lane_resource(
             return str(candidates[lane - 1].get("resource_id")), None
         return None, f"visual lane {lane} exceeds {len(candidates)} {resource_type} resource(s) at {slot}"
     return str(candidates[0].get("resource_id")), None
+
+
+def _ensure_approved_soccer_resource(
+    resources: list[Mapping[str, Any]],
+    *,
+    slot: str,
+    duration_minutes: int,
+) -> str:
+    day, start_time = slot.rsplit("-", 1)
+    resource_id = f"SOC-APPROVED-{day}-{start_time.replace(':', '')}"
+    for resource in resources:
+        if _clean_text(resource.get("resource_id")) == resource_id:
+            return resource_id
+    resources.append({
+        "resource_id": resource_id,
+        "resource_type": TEAM_RESOURCE_TYPE_SOCCER,
+        "label": "Approved Field",
+        "day": day,
+        "open_time": start_time,
+        "close_time": _time_after_minutes(start_time, duration_minutes),
+        "slot_minutes": duration_minutes,
+        "venue_name": "Approved Soccer Schedule",
+    })
+    return resource_id
 
 
 def _source_hash(record: Mapping[str, Any]) -> str:
@@ -555,7 +604,7 @@ def _parse_badminton(
 def _parse_soccer(
     path: Path,
     *,
-    resources: Sequence[Mapping[str, Any]],
+    resources: list[Mapping[str, Any]],
     warnings: list[str],
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     wb = load_workbook(path, data_only=True)
@@ -603,7 +652,15 @@ def _parse_soccer(
             lane=1,
         )
         if not resource_id:
-            warnings.append(f"{source_cell}: {reason}")
+            resource_id = _ensure_approved_soccer_resource(
+                resources,
+                slot=slot,
+                duration_minutes=60,
+            )
+            warnings.append(
+                f"{source_cell}: {reason}; using approved Soccer workbook override "
+                f"resource {resource_id}."
+            )
         records.append(_approved_record(
             game_key=game_key,
             event=SPORT_TYPE["SOCCER"],
@@ -971,6 +1028,51 @@ def _validate_table_tennis_prelim_balance(ws, errors: list[str]) -> None:
                 f"but found: {'; '.join(outliers)}."
             )
 
+def _validate_table_tennis_friday_orange(
+    *,
+    ws,
+    records: Sequence[Mapping[str, Any]],
+    resources: Sequence[Mapping[str, Any]],
+    errors: list[str],
+) -> None:
+    header_cells: list[str] = []
+    for row in range(1, min(ws.max_row, 5) + 1):
+        for column in range(1, min(ws.max_column, 6) + 1):
+            value = ws.cell(row=row, column=column).value
+            if _declares_table_tennis_required_date(value):
+                header_cells.append(_cell_ref(ws.title, row, column))
+
+    if not header_cells:
+        errors.append(
+            f"{ws.title}: Table Tennis workbook must declare Friday 7/24 "
+            f"({TABLE_TENNIS_REQUIRED_DAY}) in the visible schedule header."
+        )
+
+    resource_by_id = {
+        _clean_text(resource.get("resource_id")): resource
+        for resource in resources
+        if _clean_text(resource.get("resource_id"))
+    }
+    for record in records:
+        source = _clean_text(record.get("source_cell"))
+        game_key = _clean_text(record.get("game_key"))
+        slot = _clean_text(record.get("scheduled_slot"))
+        if _slot_day(slot) != TABLE_TENNIS_REQUIRED_DAY:
+            errors.append(
+                f"{source}: Table Tennis game {game_key} must be scheduled on "
+                f"{TABLE_TENNIS_REQUIRED_DAY} / Friday 7/24, not {slot or 'an unresolved slot'}."
+            )
+
+        resource_id = _clean_text(record.get("resource_id"))
+        if not resource_id:
+            continue
+        resource = resource_by_id.get(resource_id)
+        venue_name = _clean_text((resource or {}).get("venue_name"))
+        if TABLE_TENNIS_REQUIRED_VENUE_FRAGMENT not in venue_name.casefold():
+            errors.append(
+                f"{source}: Table Tennis game {game_key} uses resource {resource_id} "
+                f"at venue {venue_name or 'unknown'}; expected Orange."
+            )
 
 
 def _parse_table_tennis(
@@ -1068,6 +1170,12 @@ def _parse_table_tennis(
         )
     elif "SBC" in missing_from_schedule:
         warnings.append("Table Tennis U35 SBC roster/schedule discrepancy was explicitly waived.")
+    _validate_table_tennis_friday_orange(
+        ws=ws,
+        records=records,
+        resources=resources,
+        errors=errors,
+    )
     return records, placeholders
 
 
@@ -1251,8 +1359,10 @@ def build_approved_games_payload(
         f"{record.get('event')}::{record.get('sub_event') or record.get('stage')}"
         for record in records
     )
+    source_schedule_input = copy.deepcopy(dict(schedule_input))
+    source_schedule_input["resources"] = resources
     schedule_input_artifact, schedule_output_artifact = _build_publish_artifacts(
-        records, schedule_input, imported_at
+        records, source_schedule_input, imported_at
     )
     return {
         "version": 1,

--- a/middleware/tests/test_approved_games.py
+++ b/middleware/tests/test_approved_games.py
@@ -528,3 +528,33 @@ def test_table_tennis_requires_orange_resource(tmp_path):
     )
 
     assert any("expected Orange" in error for error in payload["validation"]["errors"])
+
+
+def test_table_tennis_wrong_day_workbook_still_blocked_by_header_check(tmp_path):
+    """The header scan alone must catch a workbook that isn't Friday 7/24 at
+    all (not just a Friday-dated header with the wrong weekday label) — this
+    is the case the removed, unreachable per-game day check used to look
+    like it was covering. _parse_table_tennis always builds scheduled_slot
+    with the hardcoded required day, so a per-record comparison against that
+    same hardcoded value could never disagree with it regardless of what the
+    workbook's header actually says; the header scan is what has to do the
+    real work.
+    """
+    main = tmp_path / "main.xlsx"
+    badminton = tmp_path / "badminton.xlsx"
+    soccer = tmp_path / "soccer.xlsx"
+    table_tennis = tmp_path / "tt.xlsx"
+    _write_main_schedule(main)
+    _write_badminton(badminton)
+    _write_soccer(soccer)
+    _write_table_tennis(table_tennis, include_sbc=False, date_header="Sat 7/25")
+
+    payload = approved_games.build_approved_games_payload(
+        main_schedule_path=main,
+        badminton_path=badminton,
+        soccer_path=soccer,
+        table_tennis_path=table_tennis,
+        schedule_input=_schedule_input(),
+    )
+
+    assert any("Friday 7/24" in error for error in payload["validation"]["errors"])

--- a/middleware/tests/test_approved_games.py
+++ b/middleware/tests/test_approved_games.py
@@ -58,11 +58,17 @@ def _write_soccer(path, team_a="ANH", team_b="GAC"):
     wb.save(path)
 
 
-def _write_table_tennis(path, include_sbc=True, matches=None, roster_entries=None):
+def _write_table_tennis(
+    path,
+    include_sbc=True,
+    matches=None,
+    roster_entries=None,
+    date_header="Fri 7/24",
+):
     wb = Workbook()
     ws = wb.active
     ws.append(["", "VAY SPORTS FEST 2026 - TABLE TENNIS SCHEDULE"])
-    ws.append(["Fri 7/24", "Table 1", "Table 2", "Table 3", "Table 4"])
+    ws.append([date_header, "Table 1", "Table 2", "Table 3", "Table 4"])
     matches = matches or ["Nhan Micah (ORN) - Phan Dora (WSD)"]
     for index, match in enumerate(matches):
         minutes = index * 15
@@ -151,6 +157,7 @@ def _schedule_input():
                 "open_time": "17:00",
                 "close_time": "18:00",
                 "slot_minutes": 20,
+                "venue_name": "Orange Chapel",
             },
         ],
     }
@@ -183,6 +190,35 @@ def test_approved_games_payload_builds_publishable_artifacts(tmp_path):
     assert validate_schedule_input(publish_input) == []
     assert validate_schedule_output(publish_output) == []
     assert validate_output_against_input(publish_output, publish_input) == []
+
+
+def test_soccer_approved_schedule_can_create_override_resource(tmp_path):
+    main = tmp_path / "main.xlsx"
+    badminton = tmp_path / "badminton.xlsx"
+    soccer = tmp_path / "soccer.xlsx"
+    table_tennis = tmp_path / "tt.xlsx"
+    _write_main_schedule(main)
+    _write_badminton(badminton)
+    _write_soccer(soccer)
+    _write_table_tennis(table_tennis, include_sbc=False)
+    schedule_input = _schedule_input()
+    schedule_input["resources"] = [
+        resource for resource in schedule_input["resources"]
+        if resource["resource_type"] != TEAM_RESOURCE_TYPE_SOCCER
+    ]
+
+    payload = approved_games.build_approved_games_payload(
+        main_schedule_path=main,
+        badminton_path=badminton,
+        soccer_path=soccer,
+        table_tennis_path=table_tennis,
+        schedule_input=schedule_input,
+    )
+
+    assert payload["validation"]["errors"] == []
+    assert any("approved Soccer workbook override" in warning for warning in payload["validation"]["warnings"])
+    publish_resources = payload["publish_artifacts"]["schedule_input"]["resources"]
+    assert any(resource["resource_id"] == "SOC-APPROVED-Sat-1-1300" for resource in publish_resources)
 
 
 def test_table_tennis_sbc_discrepancy_blocks_execute_without_waiver(tmp_path):
@@ -448,3 +484,47 @@ def test_table_tennis_source_validation_matches_lowercase_church_code(tmp_path):
     )
 
     assert payload["validation"]["errors"] == []
+
+
+def test_table_tennis_requires_friday_724_header(tmp_path):
+    main = tmp_path / "main.xlsx"
+    badminton = tmp_path / "badminton.xlsx"
+    soccer = tmp_path / "soccer.xlsx"
+    table_tennis = tmp_path / "tt.xlsx"
+    _write_main_schedule(main)
+    _write_badminton(badminton)
+    _write_soccer(soccer)
+    _write_table_tennis(table_tennis, include_sbc=False, date_header="Sat 7/24")
+
+    payload = approved_games.build_approved_games_payload(
+        main_schedule_path=main,
+        badminton_path=badminton,
+        soccer_path=soccer,
+        table_tennis_path=table_tennis,
+        schedule_input=_schedule_input(),
+    )
+
+    assert any("Friday 7/24" in error for error in payload["validation"]["errors"])
+
+
+def test_table_tennis_requires_orange_resource(tmp_path):
+    main = tmp_path / "main.xlsx"
+    badminton = tmp_path / "badminton.xlsx"
+    soccer = tmp_path / "soccer.xlsx"
+    table_tennis = tmp_path / "tt.xlsx"
+    _write_main_schedule(main)
+    _write_badminton(badminton)
+    _write_soccer(soccer)
+    _write_table_tennis(table_tennis, include_sbc=False)
+    schedule_input = _schedule_input()
+    schedule_input["resources"][-1]["venue_name"] = "Esperanza Chapel"
+
+    payload = approved_games.build_approved_games_payload(
+        main_schedule_path=main,
+        badminton_path=badminton,
+        soccer_path=soccer,
+        table_tennis_path=table_tennis,
+        schedule_input=schedule_input,
+    )
+
+    assert any("expected Orange" in error for error in payload["validation"]["errors"])


### PR DESCRIPTION
Closes #197.

Summary:
- Adds a hard Table Tennis / Table Tennis 35+ approved-games guard: the TT workbook must visibly declare Friday 7/24, and all imported TT games must resolve to Fri-1 Table Tennis resources at Orange.
- Treats the approved COED Soccer workbook as an operator override when it uses Sat-1 field slots outside generated venue availability, creating auditable SOC-APPROVED resources in the publish-ready schedule input.
- Adds regression coverage for TT date/venue validation and Soccer approved override resources.

Validation:
- S:\MyPrj\vay\vaysf\middleware\.venv\Scripts\python.exe -m pytest tests\test_approved_games.py -q -> 12 passed
- S:\MyPrj\vay\vaysf\middleware\.venv\Scripts\python.exe -m pytest tests\test_main.py -q -> 33 passed
- Local temp import-approved-games --execute with the corrected TT workbook and current real workbooks -> 0 errors; wrote approved_schedule_games.json, approved_schedule_input.json, and approved_schedule_output.json to temp. Remaining warnings are the intentional Soccer override resources and Justin/Justtin typo audit.