### PR TITLE
scheduler: support draft 12 schedule override import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
 - Suppressed intentional control/reservation blocks such as QF/SF labels,
   Scripture Memorization, Bible Challenge finals, and broad playoff blocks
   from the team-code override audit so dry-runs focus on actual matchup rows.
+- Updated scheduler documentation and importer defaults to reference
+  `VAY2026_Main_Schedule_draft_12.xlsx` as the current official override
+  workbook.
 
 ### Event-day schedule/results admin screens - closes [#229](https://github.com/i12know/vaysf/issues/229)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+### Draft 12 visual schedule override import - closes [#233](https://github.com/i12know/vaysf/issues/233)
+
+- Updated `import-match-schedule-overrides` to understand Excel theme/tint
+  fills in Loc's `VAY2026_Main_Schedule_draft_12.xlsx` workbook, so BB/MVB
+  cells no longer fail sport detection when the workbook stores colors as
+  theme references instead of literal RGB fills.
+- Rounded real Excel time values to the nearest minute before building slot
+  ids, avoiding false `13:59`/`19:59` resource lookups from near-hour floating
+  point time values in the workbook.
+- Suppressed intentional control/reservation blocks such as QF/SF labels,
+  Scripture Memorization, Bible Challenge finals, and broad playoff blocks
+  from the team-code override audit so dry-runs focus on actual matchup rows.
+
 ### Event-day schedule/results admin screens - closes [#229](https://github.com/i12know/vaysf/issues/229)
 
 - Added wp-admin `Schedules` and `Results` submenu pages for back-office

--- a/docs/SCHEDULE-HOW-TO.md
+++ b/docs/SCHEDULE-HOW-TO.md
@@ -496,7 +496,7 @@ the current importer can use every cell semantically:
 
 | Workbook | Role |
 |----------|------|
-| `2026 Main Schedule draft 11.xlsx` | Event-wide Master Schedule: BB/MVB/WVB/BC first-weekend matchups plus event operations envelope |
+| `VAY2026_Main_Schedule_draft_12.xlsx` | Event-wide Master Schedule: BB/MVB/WVB/BC first-weekend matchups plus event operations envelope |
 | `2026 VAY Badminton Schedule_draft_v1_10Jul2026.xlsx` | Badminton detailed Friday schedule and roster reference |
 | `COED SOCCER SCHEDULE.xlsx` | Soccer groups, pool matches, referees, and bracket reference |
 | `Schedule_Roster - Table Tennis (PingPong) 2026.xlsx` | Table Tennis schedule, rules, stage placeholders, and doubles roster reference |
@@ -596,7 +596,7 @@ middleware/data/VAY2026_Main_Schedule_draft_4.xlsx
 The latest reviewed human-scheduler workbook is:
 
 ```text
-middleware/data/2026 Main Schedule draft 11.xlsx
+middleware/data/VAY2026_Main_Schedule_draft_12.xlsx
 ```
 
 Run the import step after the matchup import and before the next
@@ -646,11 +646,11 @@ python main.py diagnose-schedule
 run-schedule.bat
 ```
 
-If leadership adopts `2026 Main Schedule draft 11.xlsx` as the current Master
+If leadership adopts `VAY2026_Main_Schedule_draft_12.xlsx` as the current Master
 Schedule, pass that file instead:
 
 ```bash
-python main.py import-master-schedule --file "data/2026 Main Schedule draft 11.xlsx"
+python main.py import-master-schedule --file "data/VAY2026_Main_Schedule_draft_12.xlsx"
 ```
 
 If `import-master-schedule` says a row is unresolved, treat it as a comparison
@@ -682,14 +682,14 @@ playing* in each slot, and that pairing is authoritative.
 The workbook currently lives in:
 
 ```text
-middleware/data/2026 Main Schedule draft 11.xlsx
+middleware/data/VAY2026_Main_Schedule_draft_12.xlsx
 ```
 
 Always start with a dry run so you can review the audit before anything is
 written:
 
 ```bash
-python main.py import-match-schedule-overrides --file "data/2026 Main Schedule draft 11.xlsx" --events BB,MVB,WVB --dry-run
+python main.py import-match-schedule-overrides --file "data/VAY2026_Main_Schedule_draft_12.xlsx" --events BB,MVB,WVB --dry-run
 ```
 
 The dry run writes `match_schedule_overrides.audit.json` to the normal export
@@ -698,7 +698,7 @@ folder and never touches `match_schedule_overrides.json` or
 understood), commit it:
 
 ```bash
-python main.py import-match-schedule-overrides --file "data/2026 Main Schedule draft 11.xlsx" --events BB,MVB,WVB --execute
+python main.py import-match-schedule-overrides --file "data/VAY2026_Main_Schedule_draft_12.xlsx" --events BB,MVB,WVB --execute
 ```
 
 `--execute` only writes `match_schedule_overrides.json` when validation has
@@ -723,8 +723,8 @@ Recommended 2026 override loop:
 
 ```bash
 python main.py import-team-matchups --file "data/2026-VAY-Lottery-Drawing_Team-Assignment(ALL-TEAM-SPORTS)_template.xlsx"
-python main.py import-match-schedule-overrides --file "data/2026 Main Schedule draft 11.xlsx" --events BB,MVB,WVB --dry-run
-python main.py import-match-schedule-overrides --file "data/2026 Main Schedule draft 11.xlsx" --events BB,MVB,WVB --execute
+python main.py import-match-schedule-overrides --file "data/VAY2026_Main_Schedule_draft_12.xlsx" --events BB,MVB,WVB --dry-run
+python main.py import-match-schedule-overrides --file "data/VAY2026_Main_Schedule_draft_12.xlsx" --events BB,MVB,WVB --execute
 python main.py export-church-teams
 python main.py build-schedule-workbook
 python main.py diagnose-schedule

--- a/docs/SCHEDULING.md
+++ b/docs/SCHEDULING.md
@@ -161,7 +161,7 @@ stop and audit the source rather than choosing one silently.
 
 | Workbook | Role | Authoritative for | Notes |
 |---|---|---|---|
-| `2026 Main Schedule draft 11.xlsx` | Event-wide Master Schedule | BB/MVB/WVB/BC first-weekend matchups, court/time boundaries, later-stage reservations, ceremonies, meals, setup, closures, and cross-event flow | Supersedes older visual master drafts for operational review. The current importer originally targeted `VAY2026_Main_Schedule_draft_4.xlsx`; pass `--file` when testing another draft. |
+| `VAY2026_Main_Schedule_draft_12.xlsx` | Event-wide Master Schedule | BB/MVB/WVB/BC first-weekend matchups, court/time boundaries, later-stage reservations, ceremonies, meals, setup, closures, and cross-event flow | Supersedes older visual master drafts, including draft 11, for operational review. Pass `--file` when testing another draft. |
 | `2026 VAY Badminton Schedule_draft_v1_10Jul2026.xlsx` | Badminton detailed schedule | Friday July 24 preliminary matchups, three-court timing, roster reference | Saturday playoff block remains an envelope in the Master Schedule; individual game schedule is coordinated by Badminton leadership. |
 | `COED SOCCER SCHEDULE.xlsx` | Soccer detailed schedule | Soccer groups, six pool matches, referee assignments, advancement bracket | G7-G12 advancement bracket times remain TBD in this workbook. |
 | `Schedule_Roster - Table Tennis (PingPong) 2026.xlsx` | Table Tennis detailed schedule and roster | Friday July 24 schedule, stage placeholders, rules, doubles rosters | Under-35 roster/schedule discrepancy remains: roster has `SBC`, schedule has `FVC`; resolve before treating that portion as authoritative. |
@@ -217,7 +217,7 @@ Detailed sport schedules         - fixed game/stage slots
 `import-approved-games` is the bridge from human-approved preliminary-game
 workbooks to the WordPress event-day score-entry table. It parses:
 
-- `2026 Main Schedule draft 11.xlsx` for BB/MVB/WVB/BC exact preliminary games;
+- `VAY2026_Main_Schedule_draft_12.xlsx` for BB/MVB/WVB/BC exact preliminary games;
 - `2026 VAY Badminton Schedule_draft_v1_10Jul2026.xlsx` for Badminton
   preliminary matches and category identity;
 - `COED SOCCER SCHEDULE.xlsx` for Soccer G1-G6 exact games while preserving
@@ -324,7 +324,7 @@ LAYER 2 — TACTICAL (post-booking): maximize use of the booked venue
 |------|----------|------|-------|
 | `venue_input.xlsx` | `middleware/data/` (gitignored) | Booked venue: courts, times, gym modes, playoff slots | Layer 2 input |
 | `2026-VAY-Lottery-Drawing_Team-Assignment(ALL-TEAM-SPORTS)_template.xlsx` | `middleware/data/` | 2026 approved BB/MVB/WVB/SOC/BC matchup import source | Layer 2/3 human input |
-| `2026 Main Schedule draft 11.xlsx` | `middleware/data/` | Latest reviewed event-wide Master Schedule and operational envelope | Layer 3 human input |
+| `VAY2026_Main_Schedule_draft_12.xlsx` | `middleware/data/` | Latest reviewed event-wide Master Schedule and operational envelope | Layer 3 human input |
 | `2026 VAY Badminton Schedule_draft_v1_10Jul2026.xlsx` | `middleware/data/` | Badminton detailed schedule inside Master Schedule blocks | Layer 3 sport-detail input |
 | `COED SOCCER SCHEDULE.xlsx` | `middleware/data/` | Soccer detailed schedule and referee/bracket reference | Layer 3 sport-detail input |
 | `Schedule_Roster - Table Tennis (PingPong) 2026.xlsx` | `middleware/data/` | Table Tennis detailed schedule, rules, and roster reference | Layer 3 sport-detail input |
@@ -1221,7 +1221,7 @@ middleware/data/VAY2026_Main_Schedule_draft_4.xlsx
 The latest reviewed human-scheduler workbook is:
 
 ```text
-middleware/data/2026 Main Schedule draft 11.xlsx
+middleware/data/VAY2026_Main_Schedule_draft_12.xlsx
 ```
 
 Import it with:
@@ -1258,14 +1258,14 @@ other manual imports.
 The workbook currently lives at:
 
 ```text
-middleware/data/2026 Main Schedule draft 11.xlsx
+middleware/data/VAY2026_Main_Schedule_draft_12.xlsx
 ```
 
 Import it with:
 
 ```bash
-python main.py import-match-schedule-overrides --file "data/2026 Main Schedule draft 11.xlsx" --events BB,MVB,WVB --dry-run
-python main.py import-match-schedule-overrides --file "data/2026 Main Schedule draft 11.xlsx" --events BB,MVB,WVB --execute
+python main.py import-match-schedule-overrides --file "data/VAY2026_Main_Schedule_draft_12.xlsx" --events BB,MVB,WVB --dry-run
+python main.py import-match-schedule-overrides --file "data/VAY2026_Main_Schedule_draft_12.xlsx" --events BB,MVB,WVB --execute
 ```
 
 This is a **different workbook family** from `import-master-schedule`'s, not a

--- a/middleware/main.py
+++ b/middleware/main.py
@@ -473,7 +473,7 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help=(
             "Path to the visual match schedule workbook; --file is an alias "
-            "(default: data/2026 Main Schedule draft 11.xlsx)"
+            "(default: data/VAY2026_Main_Schedule_draft_12.xlsx)"
         ),
     )
     import_match_overrides_parser.add_argument(
@@ -521,7 +521,7 @@ def parse_args() -> argparse.Namespace:
     approved_games_parser.add_argument(
         "--main-schedule",
         default=None,
-        help="Path to Loc's approved main schedule workbook (default: data/2026 Main Schedule draft 11.xlsx)",
+        help="Path to Loc's approved main schedule workbook (default: data/VAY2026_Main_Schedule_draft_12.xlsx)",
     )
     approved_games_parser.add_argument(
         "--badminton",

--- a/middleware/scheduling/approved_games.py
+++ b/middleware/scheduling/approved_games.py
@@ -38,7 +38,7 @@ APPROVED_GAMES_AUDIT_FILENAME = "approved_schedule_games.audit.json"
 APPROVED_SCHEDULE_INPUT_FILENAME = "approved_schedule_input.json"
 APPROVED_SCHEDULE_OUTPUT_FILENAME = "approved_schedule_output.json"
 
-DEFAULT_MAIN_SCHEDULE_FILENAME = "2026 Main Schedule draft 11.xlsx"
+DEFAULT_MAIN_SCHEDULE_FILENAME = "VAY2026_Main_Schedule_draft_12.xlsx"
 DEFAULT_BADMINTON_FILENAME = "2026 VAY Badminton Schedule_draft_v1_10Jul2026.xlsx"
 DEFAULT_SOCCER_FILENAME = "COED SOCCER SCHEDULE.xlsx"
 DEFAULT_TABLE_TENNIS_FILENAME = "Schedule_Roster - Table Tennis (PingPong) 2026.xlsx"

--- a/middleware/scheduling/match_schedule_overrides.py
+++ b/middleware/scheduling/match_schedule_overrides.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import json
 import re
+import xml.etree.ElementTree as ET
 from collections import Counter
 from datetime import datetime
 from datetime import time as _dt_time
@@ -55,6 +56,20 @@ _CANONICAL_RGB_BY_SPORT = {
     if event_name in SPORT_STYLES
 }
 _COLOR_MATCH_DISTANCE_THRESHOLD = 15000
+_THEME_INDEX_NAMES = (
+    "lt1",
+    "dk1",
+    "lt2",
+    "dk2",
+    "accent1",
+    "accent2",
+    "accent3",
+    "accent4",
+    "accent5",
+    "accent6",
+    "hlink",
+    "folHlink",
+)
 
 _CONTROL_WORDS = master_schedule._CONTROL_WORDS | {
     "SET UP - TAPE LINES",
@@ -67,6 +82,7 @@ _CONTROL_WORDS = master_schedule._CONTROL_WORDS | {
     "BASKETBALL 3RD",
     "BASKETBALL FINAL",
 }
+_NORMAL_CONTROL_WORDS = {" ".join(word.upper().split()) for word in _CONTROL_WORDS}
 
 _TEAM_CODE_RE = re.compile(r"^[A-Z0-9]{2,5}$")
 
@@ -98,7 +114,17 @@ def _time_label(value: Any) -> Optional[str]:
     if isinstance(value, datetime):
         value = value.time()
     if isinstance(value, _dt_time):
-        return f"{value.hour:02d}:{value.minute:02d}"
+        minutes = int(
+            round(
+                value.hour * 60
+                + value.minute
+                + (value.second / 60.0)
+                + (value.microsecond / 60_000_000.0)
+            )
+        )
+        hour = (minutes // 60) % 24
+        minute = minutes % 60
+        return f"{hour:02d}:{minute:02d}"
     text = _clean_text(value)
     if not text or text.casefold() == "legend":
         return None
@@ -114,14 +140,18 @@ def _time_label(value: Any) -> Optional[str]:
 
 
 def _is_control_text(value: Any) -> bool:
-    text = _clean_text(value).upper()
+    text = " ".join(_clean_text(value).upper().split())
     if not text:
         return True
-    if text in _CONTROL_WORDS:
+    if text in _NORMAL_CONTROL_WORDS:
         return True
-    if re.fullmatch(r"(BB|MVB|WVB|BC)\s+(QF|SF|FINAL|3RD)", text):
+    if re.fullmatch(r"(BB|MVB|WVB|BC)\s+(QF|SF|FINAL|3RD)(?:\s+\d+)?", text):
         return True
-    if re.search(r"CEREMONY|SERVICE|SET\s*UP", text):
+    if "BIBLE CHALLENGE FINAL" in text:
+        return True
+    if "PLAYOFF" in text and ("FINAL" in text or "3RD" in text):
+        return True
+    if re.search(r"CEREMONY|SERVICE|SCRIPTURE|SET\s*UP", text):
         return True
     return False
 
@@ -131,9 +161,75 @@ def _rgb_of(cell) -> Optional[str]:
     if not fill or fill.fill_type != "solid":
         return None
     color = fill.fgColor
-    if color.type != "rgb" or not isinstance(color.rgb, str) or len(color.rgb) < 6:
+    if color.type == "rgb" and isinstance(color.rgb, str) and len(color.rgb) >= 6:
+        return color.rgb[-6:].upper()
+    if color.type == "theme":
+        workbook = getattr(cell.parent, "parent", None)
+        theme_rgb = _theme_rgb_by_index(workbook).get(_color_theme_index(color))
+        if theme_rgb:
+            return _apply_tint(theme_rgb, _color_tint(color))
+    return None
+
+
+def _color_theme_index(color) -> Optional[int]:
+    try:
+        return int(color.theme)
+    except (TypeError, ValueError):
         return None
-    return color.rgb[-6:].upper()
+
+
+def _color_tint(color) -> float:
+    try:
+        return float(color.tint or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _theme_rgb_by_index(workbook) -> Dict[int, str]:
+    theme_xml = getattr(workbook, "loaded_theme", None)
+    if not theme_xml:
+        return {}
+    try:
+        root = ET.fromstring(theme_xml)
+    except ET.ParseError:
+        return {}
+
+    ns = {"a": "http://schemas.openxmlformats.org/drawingml/2006/main"}
+    scheme = root.find(".//a:clrScheme", ns)
+    if scheme is None:
+        return {}
+
+    rgb_by_name: Dict[str, str] = {}
+    for child in list(scheme):
+        name = child.tag.rsplit("}", 1)[-1]
+        srgb = child.find("a:srgbClr", ns)
+        system = child.find("a:sysClr", ns)
+        value = None
+        if srgb is not None:
+            value = srgb.get("val")
+        elif system is not None:
+            value = system.get("lastClr")
+        if value and len(value) >= 6:
+            rgb_by_name[name] = value[-6:].upper()
+
+    return {
+        index: rgb_by_name[name]
+        for index, name in enumerate(_THEME_INDEX_NAMES)
+        if name in rgb_by_name
+    }
+
+
+def _apply_tint(rgb: str, tint: float) -> str:
+    """Apply Excel's theme tint transform to an RRGGBB color."""
+    channels = [int(rgb[i : i + 2], 16) for i in (0, 2, 4)]
+    transformed = []
+    for channel in channels:
+        if tint < 0:
+            value = channel * (1.0 + tint)
+        else:
+            value = channel * (1.0 - tint) + (255 * tint)
+        transformed.append(max(0, min(255, int(round(value)))))
+    return "".join(f"{channel:02X}" for channel in transformed)
 
 
 def _rgb_distance(a: str, b: str) -> int:
@@ -194,7 +290,7 @@ def _classify_block(
     nonempty = [value for value in values if value]
     if not nonempty:
         return None
-    if len(nonempty) == 1 and _is_control_text(nonempty[0]):
+    if all(_is_control_text(value) for value in nonempty):
         return None
 
     cell_range = (

--- a/middleware/scheduling/match_schedule_overrides.py
+++ b/middleware/scheduling/match_schedule_overrides.py
@@ -38,7 +38,7 @@ from schedule_styles import SPORT_STYLES
 from scheduling import master_schedule
 from scheduling.manual_matchups import _extract_roster_team_codes, _is_bye
 
-MATCH_SCHEDULE_OVERRIDES_WORKBOOK_FILENAME = "2026 Main Schedule draft 11.xlsx"
+MATCH_SCHEDULE_OVERRIDES_WORKBOOK_FILENAME = "VAY2026_Main_Schedule_draft_12.xlsx"
 MATCH_SCHEDULE_OVERRIDES_SIDECAR_FILENAME = "match_schedule_overrides.json"
 
 DEFAULT_EVENT_CODES = ("BB", "MVB", "WVB")

--- a/middleware/tests/test_approved_games.py
+++ b/middleware/tests/test_approved_games.py
@@ -16,6 +16,13 @@ from schedule_styles import SPORT_STYLES
 from scheduling import approved_games
 
 
+def test_default_main_schedule_path_uses_current_official_draft_12(tmp_path):
+    assert (
+        approved_games.default_main_schedule_path(tmp_path)
+        == tmp_path / "VAY2026_Main_Schedule_draft_12.xlsx"
+    )
+
+
 def _solid(color: str) -> PatternFill:
     return PatternFill(fill_type="solid", fgColor=color)
 

--- a/middleware/tests/test_match_schedule_overrides.py
+++ b/middleware/tests/test_match_schedule_overrides.py
@@ -1,5 +1,7 @@
+from datetime import time
+
 from openpyxl import Workbook
-from openpyxl.styles import PatternFill
+from openpyxl.styles import Color, PatternFill
 
 from config import (
     GYM_RESOURCE_TYPE_BASKETBALL,
@@ -16,6 +18,8 @@ _BB_FILL = PatternFill("solid", fgColor="F8CBAD")
 _MVB_FILL = PatternFill("solid", fgColor="9BC2E6")
 _WVB_FILL = PatternFill("solid", fgColor="FFCCFF")
 _BC_FILL = PatternFill("solid", fgColor="92D050")
+_BB_THEME_FILL = PatternFill("solid", fgColor=Color(theme=5, tint=0.5999938962981048))
+_MVB_THEME_FILL = PatternFill("solid", fgColor=Color(theme=8, tint=0.3999755851924192))
 
 
 def _venue_row(ws, row: int, day_label: str, venues: list):
@@ -119,6 +123,59 @@ def test_parser_classifies_real_world_fill_colors(tmp_path):
     assert two_team["B2:D2"]["team_b"] == "FVC"
     assert bc[0]["teams"] == ["AAA", "BBB", "CCC"]
     assert bye[0]["team_a"] == "WAG" and bye[0]["team_b"] is None
+
+
+def test_parser_classifies_theme_fill_colors_from_draft_12_layout(tmp_path, monkeypatch):
+    monkeypatch.setattr(mso, "_theme_rgb_by_index", lambda workbook: {5: "ED7D31", 8: "5B9BD5"})
+
+    workbook = tmp_path / "draft12-theme.xlsx"
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "2026_Draft (12)"
+    _venue_row(
+        ws, 1, "SAT 7/18",
+        [(2, "Main Gym BB1"), (10, "Prac. Gym VB1")],
+    )
+    ws.cell(row=2, column=1, value=time(13, 59, 59, 999000))
+    for col, value in ((2, "WAG"), (3, "v"), (4, "FVC")):
+        cell = ws.cell(row=2, column=col, value=value)
+        cell.fill = _BB_THEME_FILL
+    for col, value in ((10, "SDC"), (11, "v"), (12, "MWC")):
+        cell = ws.cell(row=2, column=col, value=value)
+        cell.fill = _MVB_THEME_FILL
+    wb.save(workbook)
+
+    payload = mso.parse_match_schedule_overrides_workbook(workbook)
+    two_team = {row["source_cell"]: row for row in payload["rows"] if row["kind"] == "two_team_game"}
+
+    assert payload["diagnostics"]["errors"] == []
+    assert two_team["B2:D2"]["sport"] == "Basketball"
+    assert two_team["J2:L2"]["sport"] == "MVB"
+    assert two_team["B2:D2"]["slot"] == "Sat-1-14:00"
+    assert two_team["J2:L2"]["slot"] == "Sat-1-14:00"
+
+
+def test_parser_ignores_repeated_wide_control_blocks(tmp_path):
+    workbook = tmp_path / "wide-controls.xlsx"
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "2026_Draft (12)"
+    ws.cell(row=1, column=1, value="SAT 7/25")
+    ws.cell(row=1, column=2, value="Main Gym BB1 / BB2")
+    ws.merge_cells(start_row=1, start_column=2, end_row=1, end_column=8)
+    ws.cell(row=2, column=1, value="9:00 AM")
+    ws.cell(row=2, column=2, value="BB QF")
+    ws.cell(row=2, column=6, value="BB QF")
+    ws.cell(row=3, column=1, value="2:00 PM")
+    ws.cell(row=3, column=2, value="BADMINTON\nPLAYOFF / 3RD / FINAL\n[3 COURTS]")
+    wb.save(workbook)
+
+    payload = mso.parse_match_schedule_overrides_workbook(workbook)
+
+    assert payload["rows"] == []
+    assert payload["diagnostics"]["block_count"] == 0
+    assert payload["diagnostics"]["warnings"] == []
+    assert payload["diagnostics"]["unmapped_cells"] == []
 
 
 def test_unknown_team_code_is_reported_with_cell_and_event(tmp_path):

--- a/middleware/tests/test_match_schedule_overrides.py
+++ b/middleware/tests/test_match_schedule_overrides.py
@@ -1,6 +1,6 @@
 from datetime import time
 
-from openpyxl import Workbook
+from openpyxl import Workbook, load_workbook
 from openpyxl.styles import Color, PatternFill
 
 from config import (
@@ -20,6 +20,13 @@ _WVB_FILL = PatternFill("solid", fgColor="FFCCFF")
 _BC_FILL = PatternFill("solid", fgColor="92D050")
 _BB_THEME_FILL = PatternFill("solid", fgColor=Color(theme=5, tint=0.5999938962981048))
 _MVB_THEME_FILL = PatternFill("solid", fgColor=Color(theme=8, tint=0.3999755851924192))
+
+
+def test_default_workbook_path_uses_current_official_draft_12(tmp_path):
+    assert (
+        mso.default_workbook_path(tmp_path)
+        == tmp_path / "VAY2026_Main_Schedule_draft_12.xlsx"
+    )
 
 
 def _venue_row(ws, row: int, day_label: str, venues: list):
@@ -153,6 +160,22 @@ def test_parser_classifies_theme_fill_colors_from_draft_12_layout(tmp_path, monk
     assert two_team["J2:L2"]["sport"] == "MVB"
     assert two_team["B2:D2"]["slot"] == "Sat-1-14:00"
     assert two_team["J2:L2"]["slot"] == "Sat-1-14:00"
+
+
+def test_theme_rgb_by_index_parses_saved_workbook_theme(tmp_path):
+    workbook = tmp_path / "theme.xlsx"
+    wb = Workbook()
+    wb.save(workbook)
+
+    reloaded = load_workbook(workbook)
+    theme = mso._theme_rgb_by_index(reloaded)
+
+    assert theme[0] == "FFFFFF"  # lt1
+    assert theme[1] == "000000"  # dk1
+    assert theme[2] == "EEECE1"  # lt2
+    assert theme[3] == "1F497D"  # dk2
+    assert theme[5] == "C0504D"  # accent2
+    assert theme[8] == "4BACC6"  # accent5
 
 
 def test_parser_ignores_repeated_wide_control_blocks(tmp_path):


### PR DESCRIPTION
## Summary

- Decode Excel theme/tint fills in `import-match-schedule-overrides` so draft 12 BB/MVB cells resolve to the right sport.
- Round real Excel time cells to the nearest minute before building slot ids, avoiding false `13:59`/`19:59` slots.
- Ignore intentional control/reservation blocks in the team-code override importer so dry-runs focus on actual matchup rows.

## Verification

- `python -m pytest tests/test_match_schedule_overrides.py tests/test_main.py -q`
- `python -m pytest tests -q`
- Real draft 12 dry-run:
  - `80 candidate game(s), 1 bye row(s), 0 unmapped block(s)`
  - `66 pinned assignment(s), 0 newly-created game(s)`

