### PR TITLE
middleware: mark unapproved athletes on score sheets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+### Score-sheet roster approval markings - closes [#258](https://github.com/i12know/vaysf/issues/258)
+
+- Kept rostered athletes visible on Basketball, Volleyball, and Soccer score
+  sheets even when they are not currently approved, but marked any
+  non-`approved` roster row with a red strike-through and small status label so
+  referees and coordinators can see who is not cleared to play.
+- Added compact Soccer roster blocks to generated Soccer score sheets so Soccer
+  follows the same roster visibility/approval-marking convention as Basketball
+  and Volleyball.
+- Logged a warning when roster workbook rows do not include approval status
+  values, because those rows are intentionally treated as not approved for
+  printed score-sheet marking.
+
 ### Approval drift acceptance workflow - closes [#252](https://github.com/i12know/vaysf/issues/252)
 
 - Added `approval-drift-history` to audit current `reapproval_required`

--- a/middleware/scoresheets.py
+++ b/middleware/scoresheets.py
@@ -39,6 +39,7 @@ LOGO_BOX = (72, 58, 182, 168)
 QR_SIZE = 150
 QR_BOX = (PAGE_W - MARGIN - QR_SIZE, 52)
 MAX_ROSTER_ROWS = 15
+MAX_SOCCER_ROSTER_ROWS_PER_TEAM = 12
 MAX_VOLLEYBALL_ROSTER_ROWS_PER_COLUMN = 9
 MAX_VOLLEYBALL_ROSTER_ROWS = MAX_VOLLEYBALL_ROSTER_ROWS_PER_COLUMN * 2
 
@@ -48,6 +49,7 @@ COL_BORDER = (88, 99, 115)
 COL_LIGHT = (242, 246, 250)
 COL_HEADER = (232, 240, 248)
 COL_MUTED = (94, 105, 116)
+COL_STRIKE = (170, 31, 45)
 
 DAY_LABELS = {
     "Fri-1": "Fri 7/24",
@@ -336,7 +338,38 @@ def _event_matches_roster_row(row: dict[str, Any], event: str) -> bool:
         return sport_type == "Volleyball" and sport_gender == "Men" and sport_format == "Team"
     if event == VOLLEYBALL_WOMEN_EVENT:
         return sport_type == "Volleyball" and sport_gender == "Women" and sport_format == "Team"
+    if event == SOCCER_EVENT:
+        return sport_type == "Soccer" and sport_gender == "Coed" and sport_format == "Exhibition"
     return False
+
+
+def _approval_status(row: dict[str, Any]) -> str:
+    for key in ("approval_status", "Approval Status", "Approval_Status", "approval status"):
+        status = str(row.get(key) or "").strip()
+        if status:
+            return status
+    return ""
+
+
+def _is_approved_roster_row(row: dict[str, Any]) -> bool:
+    return _approval_status(row).casefold() == "approved"
+
+
+def _draw_unapproved_roster_mark(
+    draw: ImageDraw.ImageDraw,
+    row_box: tuple[int, int, int, int],
+    name_box: tuple[int, int, int, int],
+    status: str,
+) -> None:
+    x0, y0, x1, y1 = row_box
+    draw.line((x0 + 4, (y0 + y1) // 2, x1 - 4, (y0 + y1) // 2), fill=COL_STRIKE, width=3)
+    status_text = status or "not approved"
+    draw.text(
+        (name_box[0], max(y0 + 2, name_box[3] - 13)),
+        status_text[:24],
+        font=_font("regular", 10),
+        fill=COL_STRIKE,
+    )
 
 
 def _sort_roster_index(indexed: dict[str, list[dict[str, Any]]]) -> None:
@@ -383,6 +416,33 @@ def build_volleyball_roster_index(roster_rows: Iterable[dict[str, Any]]) -> dict
     for event_index in indexed.values():
         _sort_roster_index(event_index)
     return indexed
+
+
+def build_soccer_roster_index(roster_rows: Iterable[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
+    """Index Soccer roster rows by church/team code."""
+
+    indexed: dict[str, list[dict[str, Any]]] = {}
+    for row in roster_rows:
+        if not _event_matches_roster_row(row, SOCCER_EVENT):
+            continue
+        code = _team_code(row.get("Church Team"))
+        if not code:
+            continue
+        indexed.setdefault(code, []).append(row)
+    _sort_roster_index(indexed)
+    return indexed
+
+
+def _warn_if_approval_status_missing(roster_rows: Iterable[dict[str, Any]], sport_label: str) -> None:
+    rows = list(roster_rows)
+    if not rows:
+        return
+    if any(_approval_status(row) for row in rows):
+        return
+    logger.warning(
+        f"{sport_label} score sheets: roster rows have no approval_status/Approval Status values; "
+        "all printed roster rows will be marked not approved."
+    )
 
 
 def _draw_logo(canvas: Image.Image, logo: Optional[Image.Image]) -> None:
@@ -715,6 +775,13 @@ def _draw_volleyball_roster_table(
             _draw_wrapped(draw, name, (name_x, row_y + 10), _font("regular", 14), age_x - name_x - 6, COL_BLACK, line_gap=1)
             if age_text:
                 _center_text(draw, (age_x, row_y, col_x + column_w, row_y + row_h), age_text, _font("regular", 12), COL_BLACK)
+            if not _is_approved_roster_row(row):
+                _draw_unapproved_roster_mark(
+                    draw,
+                    (col_x, row_y, col_x + column_w, row_y + row_h),
+                    (name_x, row_y, age_x - 4, row_y + row_h),
+                    _approval_status(row),
+                )
 
     if len(roster_rows) > MAX_VOLLEYBALL_ROSTER_ROWS:
         draw.text(
@@ -779,6 +846,13 @@ def _draw_roster_table(
             _draw_wrapped(draw, name, (name_x, row_y + 9), _font("regular", 16), age_x - name_x - 5, COL_BLACK, line_gap=2)
             if age_text:
                 _center_text(draw, (age_x, row_y, foul_x, row_y + row_h), age_text, _font("regular", 13), COL_BLACK)
+            if not _is_approved_roster_row(row):
+                _draw_unapproved_roster_mark(
+                    draw,
+                    (x, row_y, foul_x, row_y + row_h),
+                    (name_x, row_y, age_x - 4, row_y + row_h),
+                    _approval_status(row),
+                )
         else:
             draw.line((x + 8, row_y + 30, no_x - 8, row_y + 30), fill=(190, 196, 204), width=1)
             draw.line((name_x, row_y + 30, age_x - 8, row_y + 30), fill=(190, 196, 204), width=1)
@@ -861,6 +935,74 @@ def _draw_soccer_score_grid(draw: ImageDraw.ImageDraw, game: dict[str, Any], y: 
     return y + height
 
 
+def _draw_soccer_roster_table(
+    canvas: Image.Image,
+    draw: ImageDraw.ImageDraw,
+    origin: tuple[int, int],
+    width: int,
+    title: str,
+    roster_rows: list[dict[str, Any]],
+    photo_cache: PhotoCache,
+) -> None:
+    x, y = origin
+    header_h = 48
+    row_h = 46
+    table_h = header_h + row_h * MAX_SOCCER_ROSTER_ROWS_PER_TEAM
+    draw.rectangle((x, y, x + width, y + table_h), outline=COL_BORDER, width=2)
+    draw.rectangle((x, y, x + width, y + 29), fill=COL_HEADER, outline=COL_BORDER, width=2)
+    _center_text(draw, (x, y, x + width, y + 29), title, _font("bold", 16), COL_BLACK)
+
+    col_no = 32
+    col_photo = 48
+    col_age = 36
+    no_x = x + col_no
+    photo_x = no_x + col_photo
+    age_x = x + width - col_age
+    name_x = photo_x + 7
+    for line_x in (no_x, photo_x, age_x):
+        draw.line((line_x, y + 29, line_x, y + table_h), fill=COL_BORDER, width=1)
+    draw.text((x + 9, y + 33), "#", font=_font("bold", 10), fill=COL_BLACK)
+    draw.text((name_x, y + 33), "ATHLETE", font=_font("bold", 10), fill=COL_BLACK)
+    draw.text((age_x + 8, y + 33), "AGE", font=_font("bold", 10), fill=COL_BLACK)
+
+    rows = roster_rows[:MAX_SOCCER_ROSTER_ROWS_PER_TEAM]
+    for idx in range(MAX_SOCCER_ROSTER_ROWS_PER_TEAM):
+        row_y = y + header_h + idx * row_h
+        draw.line((x, row_y, x + width, row_y), fill=COL_BORDER, width=1)
+        draw.text((x + 9, row_y + 17), str(idx + 1), font=_font("regular", 10), fill=COL_MUTED)
+        photo_box = (no_x + 4, row_y + 4, no_x + 40, row_y + 40)
+        draw.rectangle(photo_box, outline=(185, 193, 203), width=1)
+        if idx >= len(rows):
+            draw.line((name_x, row_y + 24, age_x - 8, row_y + 24), fill=(190, 196, 204), width=1)
+            continue
+
+        row = rows[idx]
+        name = _roster_name(row)
+        age = row.get("Age (at Event)")
+        age_text = f"{int(age)}" if isinstance(age, (int, float)) else str(age or "").strip()
+        photo = photo_cache.load(row.get("Photo"))
+        if photo is not None:
+            _paste_contained(canvas, photo, photo_box)
+        _draw_wrapped(draw, name, (name_x, row_y + 6), _font("regular", 13), age_x - name_x - 6, COL_BLACK, line_gap=1)
+        if age_text:
+            _center_text(draw, (age_x, row_y, x + width, row_y + row_h), age_text, _font("regular", 11), COL_BLACK)
+        if not _is_approved_roster_row(row):
+            _draw_unapproved_roster_mark(
+                draw,
+                (x, row_y, x + width, row_y + row_h),
+                (name_x, row_y, age_x - 4, row_y + row_h),
+                _approval_status(row),
+            )
+
+    if len(roster_rows) > MAX_SOCCER_ROSTER_ROWS_PER_TEAM:
+        draw.text(
+            (x + 12, y + table_h + 4),
+            f"+{len(roster_rows) - MAX_SOCCER_ROSTER_ROWS_PER_TEAM} more",
+            font=_font("regular", 11),
+            fill=COL_MUTED,
+        )
+
+
 def _draw_soccer_event_log(draw: ImageDraw.ImageDraw, y: int) -> int:
     x = MARGIN
     width = PAGE_W - MARGIN * 2
@@ -895,16 +1037,14 @@ def _draw_soccer_event_log(draw: ImageDraw.ImageDraw, y: int) -> int:
     return y + height
 
 
-def _draw_soccer_footer(draw: ImageDraw.ImageDraw) -> None:
-    y = 1288
+def _draw_soccer_footer(draw: ImageDraw.ImageDraw, y: int = 1288) -> None:
     draw.text((MARGIN, y), "REFEREE COMMENTS", font=_font("bold", 18), fill=COL_BLACK)
-    draw.line((MARGIN, y + 50, PAGE_W - MARGIN, y + 50), fill=COL_BORDER, width=1)
-    draw.line((MARGIN, y + 96, PAGE_W - MARGIN, y + 96), fill=COL_BORDER, width=1)
-    draw.line((MARGIN, y + 142, PAGE_W - MARGIN, y + 142), fill=COL_BORDER, width=1)
-    draw.text((MARGIN, y + 190), "REFEREE SIGNATURE:", font=_font("bold", 18), fill=COL_BLACK)
-    draw.line((312, y + 212, 690, y + 212), fill=COL_BORDER, width=2)
-    draw.text((730, y + 190), "SCOREKEEPER:", font=_font("bold", 18), fill=COL_BLACK)
-    draw.line((898, y + 212, PAGE_W - MARGIN, y + 212), fill=COL_BORDER, width=2)
+    draw.line((MARGIN, y + 44, PAGE_W - MARGIN, y + 44), fill=COL_BORDER, width=1)
+    draw.line((MARGIN, y + 82, PAGE_W - MARGIN, y + 82), fill=COL_BORDER, width=1)
+    draw.text((MARGIN, y + 122), "REFEREE SIGNATURE:", font=_font("bold", 18), fill=COL_BLACK)
+    draw.line((312, y + 144, 690, y + 144), fill=COL_BORDER, width=2)
+    draw.text((730, y + 122), "SCOREKEEPER:", font=_font("bold", 18), fill=COL_BLACK)
+    draw.line((898, y + 144, PAGE_W - MARGIN, y + 144), fill=COL_BORDER, width=2)
 
 
 def render_basketball_scoresheet_page(
@@ -978,11 +1118,15 @@ def render_bible_challenge_scoresheet_page(
 
 def render_soccer_scoresheet_page(
     game: dict[str, Any],
+    roster_index: Optional[dict[str, list[dict[str, Any]]]] = None,
     logo_path: Optional[Path] = None,
     score_entry_base_url: Optional[str] = None,
+    photo_cache: Optional[PhotoCache] = None,
 ) -> Image.Image:
     """Render one soccer game score sheet as an RGB image."""
 
+    roster_index = roster_index or {}
+    photo_cache = photo_cache or PhotoCache()
     logo = _load_logo(logo_path or default_logo_path())
     page = Image.new("RGB", (PAGE_W, PAGE_H), "white")
     draw = ImageDraw.Draw(page)
@@ -993,8 +1137,29 @@ def render_soccer_scoresheet_page(
     _draw_score_boxes(draw, game)
     _draw_referee_section(draw, y=372)
     next_y = _draw_soccer_score_grid(draw, game, y=520)
-    _draw_soccer_event_log(draw, next_y + 28)
-    _draw_soccer_footer(draw)
+    team_a_code = _team_code(_team_label(game, "a"))
+    team_b_code = _team_code(_team_label(game, "b"))
+    table_y = next_y + 28
+    table_w = (PAGE_W - MARGIN * 2 - 28) // 2
+    _draw_soccer_roster_table(
+        page,
+        draw,
+        (MARGIN, table_y),
+        table_w,
+        _team_label(game, "a"),
+        roster_index.get(team_a_code, []),
+        photo_cache,
+    )
+    _draw_soccer_roster_table(
+        page,
+        draw,
+        (MARGIN + table_w + 28, table_y),
+        table_w,
+        _team_label(game, "b"),
+        roster_index.get(team_b_code, []),
+        photo_cache,
+    )
+    _draw_soccer_footer(draw, y=1450)
     return page
 
 
@@ -1118,7 +1283,9 @@ def write_basketball_scoresheets_pdf(
     if not games:
         raise ScoreSheetError("No scheduled basketball games found in the supplied schedule artifacts.")
 
-    roster_index = build_roster_index(roster_rows or [])
+    roster_rows = list(roster_rows or [])
+    _warn_if_approval_status_missing(roster_rows, "Basketball")
+    roster_index = build_roster_index(roster_rows)
     photo_cache = PhotoCache()
     pages = [
         render_basketball_scoresheet_page(
@@ -1183,18 +1350,23 @@ def write_soccer_scoresheets_pdf(
 ) -> tuple[Path, int]:
     """Write one combined soccer score-sheet PDF and return (path, pages)."""
 
-    del roster_rows  # Soccer sheets do not need roster/foul tracking.
     schedule_input = _load_json(schedule_input_path)
     schedule_output = _load_json(schedule_output_path)
     games = _soccer_games(schedule_input, schedule_output)
     if not games:
         raise ScoreSheetError("No scheduled soccer games found in the supplied schedule artifacts.")
 
+    roster_rows = list(roster_rows or [])
+    _warn_if_approval_status_missing(roster_rows, "Soccer")
+    roster_index = build_soccer_roster_index(roster_rows)
+    photo_cache = PhotoCache()
     pages = [
         render_soccer_scoresheet_page(
             game,
+            roster_index=roster_index,
             logo_path=logo_path,
             score_entry_base_url=score_entry_base_url,
+            photo_cache=photo_cache,
         )
         for game in games
     ]
@@ -1223,7 +1395,9 @@ def write_volleyball_scoresheets_pdf(
     if not games:
         raise ScoreSheetError("No scheduled volleyball games found in the supplied schedule artifacts.")
 
-    roster_index = build_volleyball_roster_index(roster_rows or [])
+    roster_rows = list(roster_rows or [])
+    _warn_if_approval_status_missing(roster_rows, "Volleyball")
+    roster_index = build_volleyball_roster_index(roster_rows)
     photo_cache = PhotoCache()
     pages = [
         render_volleyball_scoresheet_page(

--- a/middleware/tests/test_scoresheets.py
+++ b/middleware/tests/test_scoresheets.py
@@ -14,6 +14,7 @@ from scoresheets import (
     _extract_photo_ref,
     _friendly_location,
     build_roster_index,
+    build_soccer_roster_index,
     build_volleyball_roster_index,
     enrich_roster_photos_from_workbook,
     render_basketball_scoresheet_page,
@@ -184,6 +185,33 @@ def test_build_volleyball_roster_index_keeps_men_and_women_separate():
     assert [row["First Name"] for row in indexed[VOLLEYBALL_WOMEN_EVENT]["RPC"]] == ["Bao"]
 
 
+def test_build_soccer_roster_index_accepts_exported_coed_exhibition_triplet():
+    rows = [
+        {
+            "Church Team": "RPC",
+            "First Name": "An",
+            "Last Name": "Nguyen",
+            "Age (at Event)": 17,
+            "sport_type": "Soccer",
+            "sport_gender": "Coed",
+            "sport_format": "Exhibition",
+        },
+        {
+            "Church Team": "RPC",
+            "First Name": "Nope",
+            "Last Name": "Nguyen",
+            "Age (at Event)": 17,
+            "sport_type": "Soccer",
+            "sport_gender": "Men",
+            "sport_format": "Team",
+        },
+    ]
+
+    indexed = build_soccer_roster_index(rows)
+
+    assert [row["First Name"] for row in indexed["RPC"]] == ["An"]
+
+
 def test_render_basketball_scoresheet_places_logo_upper_left(tmp_path):
     logo = tmp_path / "logo.png"
     _logo(logo)
@@ -200,6 +228,7 @@ def test_render_basketball_scoresheet_places_logo_upper_left(tmp_path):
                 "sport_type": "Basketball",
                 "sport_gender": "Men",
                 "sport_format": "Team",
+                "approval_status": "approved",
             }
         ]
     )
@@ -226,6 +255,41 @@ def test_render_basketball_scoresheet_places_logo_upper_left(tmp_path):
     assert page.getpixel((124, 570)) == (30, 120, 220)
 
 
+def test_render_basketball_scoresheet_strikes_unapproved_roster_row(tmp_path):
+    logo = tmp_path / "logo.png"
+    _logo(logo)
+    roster_index = build_roster_index(
+        [
+            {
+                "Church Team": "RPC",
+                "First Name": "An",
+                "Last Name": "Nguyen",
+                "Age (at Event)": 17,
+                "sport_type": "Basketball",
+                "sport_gender": "Men",
+                "sport_format": "Team",
+                "approval_status": "reapproval_required",
+            }
+        ]
+    )
+
+    page = render_basketball_scoresheet_page(
+        {
+            "game_key": "BBM-01",
+            "event": BASKETBALL_EVENT,
+            "team_a_label": "RPC",
+            "team_b_label": "GAC",
+            "resource_id": "GYM-Sat-1-1",
+            "scheduled_slot": "Sat-1-16:00",
+        },
+        roster_index=roster_index,
+        logo_path=logo,
+        score_entry_base_url=SCORE_ENTRY_URL,
+    )
+
+    assert page.getpixel((250, 586)) == (170, 31, 45)
+
+
 def test_render_volleyball_scoresheet_places_logo_and_roster_photo(tmp_path):
     logo = tmp_path / "logo.png"
     _logo(logo)
@@ -242,6 +306,7 @@ def test_render_volleyball_scoresheet_places_logo_and_roster_photo(tmp_path):
                 "sport_type": "Volleyball",
                 "sport_gender": "Men",
                 "sport_format": "Team",
+                "approval_status": "approved",
             }
         ]
     )
@@ -264,6 +329,41 @@ def test_render_volleyball_scoresheet_places_logo_and_roster_photo(tmp_path):
     assert page.getpixel((111, 804)) == (40, 200, 90)
 
 
+def test_render_volleyball_scoresheet_strikes_unapproved_roster_row(tmp_path):
+    logo = tmp_path / "logo.png"
+    _logo(logo)
+    roster_index = build_volleyball_roster_index(
+        [
+            {
+                "Church Team": "RPC",
+                "First Name": "An",
+                "Last Name": "Nguyen",
+                "Age (at Event)": 17,
+                "sport_type": "Volleyball",
+                "sport_gender": "Men",
+                "sport_format": "Team",
+                "approval_status": "pending",
+            }
+        ]
+    )
+
+    page = render_volleyball_scoresheet_page(
+        {
+            "game_key": "VBM-01",
+            "event": VOLLEYBALL_MEN_EVENT,
+            "team_a_label": "RPC",
+            "team_b_label": "GAC",
+            "resource_id": "GYM-Sat-1-2",
+            "scheduled_slot": "Sat-1-17:00",
+        },
+        roster_index=roster_index,
+        logo_path=logo,
+        score_entry_base_url=SCORE_ENTRY_URL,
+    )
+
+    assert page.getpixel((180, 816)) == (170, 31, 45)
+
+
 def test_render_soccer_scoresheet_places_logo_upper_left(tmp_path):
     logo = tmp_path / "logo.png"
     _logo(logo)
@@ -282,6 +382,41 @@ def test_render_soccer_scoresheet_places_logo_upper_left(tmp_path):
     )
 
     assert page.getpixel((LOGO_BOX[0] + 20, LOGO_BOX[1] + 20)) == (220, 20, 30)
+
+
+def test_render_soccer_scoresheet_prints_and_strikes_unapproved_roster_row(tmp_path):
+    logo = tmp_path / "logo.png"
+    _logo(logo)
+    roster_index = build_soccer_roster_index(
+        [
+            {
+                "Church Team": "RPC",
+                "First Name": "An",
+                "Last Name": "Nguyen",
+                "Age (at Event)": 17,
+                "sport_type": "Soccer",
+                "sport_gender": "Coed",
+                "sport_format": "Exhibition",
+                "approval_status": "validated",
+            }
+        ]
+    )
+
+    page = render_soccer_scoresheet_page(
+        {
+            "game_key": "SOC-G1",
+            "event": SOCCER_EVENT,
+            "team_a_label": "RPC",
+            "team_b_label": "GAC",
+            "resource_id": "SOC-Sat-1-1",
+            "scheduled_slot": "Sat-1-19:00",
+        },
+        roster_index=roster_index,
+        logo_path=logo,
+        score_entry_base_url=SCORE_ENTRY_URL,
+    )
+
+    assert page.getpixel((250, 921)) == (170, 31, 45)
 
 
 def test_render_bible_challenge_scoresheet_places_logo_upper_left(tmp_path):
@@ -381,6 +516,7 @@ def test_write_basketball_scoresheets_pdf_filters_to_basketball(tmp_path):
                 "Last Name": "Nguyen",
                 "Age (at Event)": 17,
                 "sport_type": BASKETBALL_EVENT,
+                "approval_status": "approved",
             }
         ],
         logo_path=logo,
@@ -412,6 +548,7 @@ def test_write_volleyball_scoresheets_pdf_filters_to_volleyball(tmp_path):
                 "Last Name": "Nguyen",
                 "Age (at Event)": 17,
                 "sport_type": VOLLEYBALL_MEN_EVENT,
+                "approval_status": "approved",
             }
         ],
         logo_path=logo,
@@ -436,7 +573,16 @@ def test_write_soccer_scoresheets_pdf_filters_to_soccer(tmp_path):
         input_path,
         output_path,
         tmp_path / "scoresheets",
-        roster_rows=[],
+        roster_rows=[
+            {
+                "Church Team": "RPC",
+                "First Name": "An",
+                "Last Name": "Nguyen",
+                "Age (at Event)": 17,
+                "sport_type": SOCCER_EVENT,
+                "approval_status": "approved",
+            }
+        ],
         logo_path=logo,
         score_entry_base_url=SCORE_ENTRY_URL,
         output_filename="soccer.pdf",


### PR DESCRIPTION
## Summary
- Keep non-approved Basketball, Volleyball, and Soccer rostered athletes visible on score sheets, but mark their rows with a red strike-through and status label.
- Add compact Soccer roster blocks so Soccer follows the same visible-roster approval convention as Basketball and Volleyball.
- Warn when roster rows do not include approval status data, because missing status is treated as not approved for score-sheet marking.

## Validation
- .\.venv\Scripts\python.exe -m pytest tests\test_scoresheets.py -q

Closes #258