### PR TITLE
middleware: retry badge uploads after host 403

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
   storing the hosted badge URL in the `Sports Fest Badge URL` one-line Text
   custom field rather than writing unsupported profile HTML; closes
   [#261](https://github.com/i12know/vaysf/issues/261).
+- Made badge uploads retry once with a re-encoded PNG payload after a
+  WordPress/host 403 response, so one problematic compressed image does not
+  block the rest of the final badge upload run.
 - Bumped the WordPress plugin to `1.0.31`.
 
 ### Score-sheet roster approval markings - closes [#258](https://github.com/i12know/vaysf/issues/258)

--- a/middleware/badges/uploader.py
+++ b/middleware/badges/uploader.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Optional
@@ -57,21 +58,32 @@ class WordPressBadgeUploader:
         upload_name = filename or badge_path.name
         self._validate_local_badge(badge_path, upload_name)
 
-        with badge_path.open("rb") as handle:
-            response = self.session.post(
-                f"{self.base_url}/badges",
-                data={"filename": upload_name},
-                files={"badge": (upload_name, handle, "image/png")},
-                timeout=(10, 60),
+        response = self._post_badge(badge_path, upload_name)
+        retry_path: Optional[Path] = None
+        if response.status_code == 403:
+            logger.warning(
+                f"Badge upload was forbidden for {upload_name}; retrying with "
+                "a re-encoded PNG payload in case the host firewall matched "
+                "the original compressed bytes."
             )
+            retry_path = self._reencode_for_firewall_retry(badge_path)
+            response = self._post_badge(retry_path, upload_name)
+
         try:
             response.raise_for_status()
         except requests.RequestException as exc:
+            body = (response.text or "").replace("\r", " ").replace("\n", " ").strip()
+            if len(body) > 500:
+                body = f"{body[:500]}..."
             logger.error(
                 f"Badge upload failed filename={upload_name} "
-                f"status={getattr(response, 'status_code', 'unknown')}"
+                f"status={getattr(response, 'status_code', 'unknown')} "
+                f"body={body!r}"
             )
             raise exc
+        finally:
+            if retry_path is not None:
+                retry_path.unlink(missing_ok=True)
 
         payload = response.json()
         result = BadgeUploadResult(
@@ -82,6 +94,29 @@ class WordPressBadgeUploader:
         )
         logger.debug(f"Badge uploaded filename={result.filename} bytes={result.byte_size}")
         return result
+
+    def _post_badge(self, badge_path: Path, upload_name: str) -> requests.Response:
+        with badge_path.open("rb") as handle:
+            return self.session.post(
+                f"{self.base_url}/badges",
+                data={"filename": upload_name},
+                files={"badge": (upload_name, handle, "image/png")},
+                timeout=(10, 60),
+            )
+
+    @staticmethod
+    def _reencode_for_firewall_retry(badge_path: Path) -> Path:
+        """Create a visually identical PNG with different compressed bytes."""
+        image = Image.open(badge_path).convert("RGBA")
+        temp = tempfile.NamedTemporaryFile(prefix="vaysf-badge-retry-", suffix=".png", delete=False)
+        temp_path = Path(temp.name)
+        temp.close()
+        try:
+            image.save(temp_path, format="PNG", optimize=False, compress_level=6)
+        except Exception:
+            temp_path.unlink(missing_ok=True)
+            raise
+        return temp_path
 
     @staticmethod
     def _validate_local_badge(badge_path: Path, filename: str) -> None:

--- a/middleware/tests/test_badges.py
+++ b/middleware/tests/test_badges.py
@@ -526,6 +526,45 @@ def test_badge_uploader_posts_png_without_json_content_type(tmp_path, monkeypatc
     assert kwargs["files"]["badge"][2] == "image/png"
 
 
+def test_badge_uploader_retries_403_with_reencoded_png(tmp_path, monkeypatch):
+    png_path = tmp_path / "RPC_3139537_abcd1234.png"
+    png_path.write_bytes(_png_bytes(size=(1080, 1920)))
+    retry_path = tmp_path / "retry.png"
+    retry_path.write_bytes(_png_bytes(color=(90, 40, 180), size=(1080, 1920)))
+    monkeypatch.setattr("badges.uploader.Config.WP_URL", "https://sportsfest.example")
+    monkeypatch.setattr("badges.uploader.Config.WP_API_KEY", "secret")
+    monkeypatch.setattr(
+        WordPressBadgeUploader,
+        "_reencode_for_firewall_retry",
+        staticmethod(lambda badge_path: retry_path),
+    )
+
+    forbidden_response = MagicMock()
+    forbidden_response.status_code = 403
+    forbidden_response.text = "Forbidden"
+
+    ok_response = MagicMock()
+    ok_response.status_code = 200
+    ok_response.raise_for_status.return_value = None
+    ok_response.json.return_value = {
+        "filename": png_path.name,
+        "url": "https://sportsfest.example/wp-content/uploads/vaysf/badges/RPC_3139537_abcd1234.png",
+        "size": png_path.stat().st_size,
+        "sha256": "abc123",
+    }
+
+    session = MagicMock()
+    session.headers = {}
+    session.cookies = {}
+    session.post.side_effect = [forbidden_response, ok_response]
+
+    result = WordPressBadgeUploader(session=session).upload_badge(png_path)
+
+    assert result.url.endswith("/RPC_3139537_abcd1234.png")
+    assert session.post.call_count == 2
+    assert not retry_path.exists()
+
+
 def test_badge_uploader_rejects_non_png_filename(tmp_path):
     png_path = tmp_path / "RPC_3139537_abcd1234.jpg"
     png_path.write_bytes(_png_bytes(size=(1080, 1920)))


### PR DESCRIPTION
## Summary
- Retry WordPress badge uploads once with a re-encoded PNG when the host returns 403.
- Include the response body snippet in failed upload logs for easier diagnosis.
- Add focused badge uploader regression coverage and document the hotfix in the changelog.

## Verification
- .\\.venv\\Scripts\\python.exe -m pytest tests\\test_badges.py -q
- .\\.venv\\Scripts\\python.exe -m py_compile badges\\uploader.py