### PR TITLE
middleware: self-heal primary sport before the identity drift check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 ## Unreleased
 
+### Fixed permanent false approval-identity-drift for self-healed primary/secondary sport
+
+- `_sync_single_participant()` ran the approval identity-drift comparison
+  (`_detect_identity_drift`) on the raw ChMeetings-mapped record before
+  `_self_heal_missing_primary_sport()` had a chance to promote a populated
+  `secondary_sport` into a blank `primary_sport`. Every sync therefore
+  compared this run's raw shape against last run's already-healed
+  WordPress snapshot, saw a "changed" primary/secondary sport that never
+  actually changed, and permanently reset the participant to
+  `reapproval_required` — no number of manual `approval-drift-accept` runs
+  could make it stick, since the very next sync reintroduced the same
+  false drift.
+- Moved the self-heal call to run immediately after ChMeetings data is
+  mapped, before the drift comparison, so both sides compare the same
+  (healed) shape. Confirmed against real 2026-07-16 sync logs and fixed
+  for the 3 real participants hitting this exact pattern (chm_id
+  3318938, 4387145, 4386750); 2 further `reapproval_required`
+  participants that day (chm_id 3618011, 4464026) were genuine one-time
+  sport-drop drift, not this bug, and were restored via the normal
+  `approval-drift-accept` prior-status inference.
+- Added a regression test reproducing the exact bug (raw primary blank /
+  secondary populated vs. a self-healed WordPress snapshot) that fails
+  without the reorder and passes with it.
+
 ### Public church filter fallback - part of [#269](https://github.com/i12know/vaysf/issues/269)
 
 - Fixed the public live-schedule church filter never appearing because

--- a/middleware/sync/participants.py
+++ b/middleware/sync/participants.py
@@ -778,7 +778,15 @@ class ParticipantSyncer:
         chm_updated_on = datetime.datetime.fromisoformat(chm_updated_on_str)
         chm_updated_on_utc = chm_updated_on.astimezone(pytz.UTC)
         mapped["updated_at"] = chm_updated_on_utc.strftime("%Y-%m-%d %H:%M:%S")
-        
+
+        # Self-heal before the identity drift comparison below so both
+        # sides compare the same primary/secondary sport shape. ChMeetings can leave
+        # primary_sport blank with the sport sitting in secondary_sport; if we healed
+        # only the payload written to WordPress and left `mapped` raw, every later
+        # sync would keep comparing this run's raw shape against last run's healed
+        # WordPress snapshot and re-detect a false "drift" forever.
+        mapped, self_heal_issues = self._self_heal_missing_primary_sport(mapped)
+
         if chm_id == target_chm_id_for_debug:
             logger.debug(f"[_SYNC_SINGLE_PARTICIPANT - {chm_id}] ChMeetings updated_on (UTC): {chm_updated_on_utc}, Mapped updated_at: {mapped['updated_at']}")
 
@@ -948,9 +956,8 @@ class ParticipantSyncer:
                 mapped["membership_claim_at_approval"] = int(frozen_raw)
         # --- End membership-flip defence ---
 
-        participant_payload, self_heal_issues = self._self_heal_missing_primary_sport(
-            mapped
-        )
+        # Already self-healed above, before the identity drift comparison.
+        participant_payload = mapped
         participant_payload, cutoff_issues = self._apply_new_registration_racquet_cutoff(
             participant_payload,
             existing_wp_participant=participant_in_wp,

--- a/middleware/sync/participants.py
+++ b/middleware/sync/participants.py
@@ -779,12 +779,25 @@ class ParticipantSyncer:
         chm_updated_on_utc = chm_updated_on.astimezone(pytz.UTC)
         mapped["updated_at"] = chm_updated_on_utc.strftime("%Y-%m-%d %H:%M:%S")
 
-        # Self-heal before the identity drift comparison below so both
-        # sides compare the same primary/secondary sport shape. ChMeetings can leave
-        # primary_sport blank with the sport sitting in secondary_sport; if we healed
-        # only the payload written to WordPress and left `mapped` raw, every later
-        # sync would keep comparing this run's raw shape against last run's healed
-        # WordPress snapshot and re-detect a false "drift" forever.
+        # Fetch the existing WordPress row first: the racquet cutoff below needs
+        # its created_at to compute the season registration date.
+        # Use mapped["chmeetings_id"] as it's directly from the mapped data which is from full_person_data
+        participant_in_wp_list = self.wordpress_connector.get_participants({"chmeetings_id": mapped["chmeetings_id"]})
+        participant_in_wp = (participant_in_wp_list[0] if participant_in_wp_list else None)
+
+        # Normalize `mapped` into its effective shape BEFORE the identity drift
+        # comparison below, in the same order the WordPress payload is built.
+        # WordPress only ever stores the post-cutoff, post-self-heal shape; if the
+        # drift check compared the raw ChMeetings shape against that snapshot, it
+        # would re-detect the same "drift" on every sync forever (Issue #171).
+        # 1. Drop disallowed late racquet selections.
+        # 2. Self-heal a blank primary sport — ChMeetings can leave primary_sport
+        #    blank with the sport sitting in secondary_sport, and the cutoff
+        #    itself can blank the primary while a secondary remains.
+        mapped, cutoff_issues = self._apply_new_registration_racquet_cutoff(
+            mapped,
+            existing_wp_participant=participant_in_wp,
+        )
         mapped, self_heal_issues = self._self_heal_missing_primary_sport(mapped)
 
         if chm_id == target_chm_id_for_debug:
@@ -796,10 +809,6 @@ class ParticipantSyncer:
         drift_issues: List[Dict[str, Any]] = []
         existing_approvals: List[Dict[str, Any]] = []
         approval_record_status = ""
-
-        # Use mapped["chmeetings_id"] as it's directly from the mapped data which is from full_person_data
-        participant_in_wp_list = self.wordpress_connector.get_participants({"chmeetings_id": mapped["chmeetings_id"]})
-        participant_in_wp = (participant_in_wp_list[0] if participant_in_wp_list else None)
 
         if chm_id == target_chm_id_for_debug:
             logger.debug(f"[_SYNC_SINGLE_PARTICIPANT - {chm_id}] Participant in WP (direct fetch by chmeetings_id '{mapped['chmeetings_id']}'): {participant_in_wp}")
@@ -956,12 +965,9 @@ class ParticipantSyncer:
                 mapped["membership_claim_at_approval"] = int(frozen_raw)
         # --- End membership-flip defence ---
 
-        # Already self-healed above, before the identity drift comparison.
+        # The racquet cutoff and primary-sport self-heal already ran above,
+        # before the identity drift comparison.
         participant_payload = mapped
-        participant_payload, cutoff_issues = self._apply_new_registration_racquet_cutoff(
-            participant_payload,
-            existing_wp_participant=participant_in_wp,
-        )
         participant_payload["approval_status"] = current_wp_status
         is_valid, base_validation_issues = self.validate_participant(participant_payload)
         validation_issues_list = (

--- a/middleware/tests/test_identity_drift.py
+++ b/middleware/tests/test_identity_drift.py
@@ -490,6 +490,53 @@ class TestSyncSingleParticipantDrift:
         payload = call_args[0][1]
         assert payload["approval_status"] == APPROVAL_STATUS["REAPPROVAL_REQUIRED"]
 
+    def test_self_healed_primary_secondary_swap_is_not_treated_as_drift(self, syncer):
+        """Raw primary-blank/secondary-populated data must not false-positive drift
+        against a WordPress snapshot that was self-healed on a prior sync.
+
+        Real-world case: ChMeetings has 'Primary Sport' blank and 'Secondary Sport'
+        populated for a participant whose WordPress row already holds the
+        self-healed shape (promoted into primary) from an earlier sync. Comparing
+        the raw shape against the healed shape looked like a sport change on every
+        single sync and permanently reset approval to reapproval_required.
+        """
+        wp = _wp_participant()  # primary_sport="Basketball - Men Team", secondary unselected
+        chm = _make_chm_person({
+            "first_name": "Matthew",
+            "last_name": "Tran",
+            "birth_date": "2008-04-23",
+            "additional_fields": [
+                {"field_name": "Church Team", "value": "WAG"},
+                {"field_name": "My role is", "value": "Athlete/Participant"},
+                {"field_name": "Primary Sport", "value": ""},
+                {"field_name": "Secondary Sport", "value": "Basketball - Men Team"},
+                {"field_name": "Other Events", "value": ""},
+                {"field_name": "Primary Racquet Sport Format", "value": ""},
+                {"field_name": "Primary Racquet Sport Partner (if applied)", "value": ""},
+                {"field_name": "Secondary Racquet Sport Format", "value": ""},
+                {"field_name": "Secondary Racquet Sport Partner (if applied)", "value": ""},
+                {"field_name": "Completion Check List", "value": ""},
+                {"field_name": "Name of my parents or legal guardian", "value": ""},
+                {"field_name": "Email of my parents or legal guardian", "value": ""},
+                {"field_name": "Cell phone of my parents or legal guardian", "value": ""},
+                {"field_name": "Would the team's Senior Pastor say that you belong to his church?", "value": "No"},
+            ],
+        })
+        _setup_syncer_for_integration(syncer, wp, chm)
+
+        syncer._sync_single_participant("4371570")
+
+        created_issues = [
+            c[0][0] for c in syncer.wordpress_connector.create_validation_issue.call_args_list
+        ]
+        assert not any(i.get("issue_type") == "approval_identity_drift" for i in created_issues)
+
+        call_args = syncer.wordpress_connector.update_participant.call_args
+        payload = call_args[0][1]
+        assert payload["approval_status"] == APPROVAL_STATUS["APPROVED"]
+        assert payload["primary_sport"] == "Basketball - Men Team"
+        assert payload["secondary_sport"] == SPORT_UNSELECTED
+
     def test_pending_participant_no_drift_check(self, syncer):
         """Drift guard must not run for participants who are not yet approved/denied."""
         wp = _wp_participant({"approval_status": APPROVAL_STATUS["PENDING"]})

--- a/middleware/tests/test_identity_drift.py
+++ b/middleware/tests/test_identity_drift.py
@@ -537,6 +537,76 @@ class TestSyncSingleParticipantDrift:
         assert payload["primary_sport"] == "Basketball - Men Team"
         assert payload["secondary_sport"] == SPORT_UNSELECTED
 
+    def test_stripped_late_racquet_sport_is_not_treated_as_drift(self, syncer):
+        """A late racquet selection the cutoff strips must not re-detect as drift.
+
+        Real-world case (GEC, Issue #171 follow-up): a post-deadline registrant
+        adds Pickleball as a secondary sport in ChMeetings. The racquet cutoff
+        strips it from every WordPress payload, so the WordPress snapshot never
+        contains it. When the drift check compared the raw ChMeetings shape
+        (with Pickleball) against that snapshot, the same 'drift' fired on every
+        sync — 60+ times — keeping the participant stuck in reapproval_required.
+        The cutoff must run before the drift comparison.
+        """
+        syncer.late_racquet_overrides = {}
+        # Registered after the 2026-05-17 deadline; WordPress snapshot was
+        # written post-cutoff, so it has no secondary sport.
+        wp = _wp_participant({"created_at": "2026-06-20 10:00:00"})
+        chm = _make_chm_person({
+            "first_name": "Matthew",
+            "last_name": "Tran",
+            "birth_date": "2008-04-23",
+        })
+        for field in chm["additional_fields"]:
+            if field["field_name"] == "Secondary Sport":
+                field["value"] = "Pickleball"
+        _setup_syncer_for_integration(syncer, wp, chm)
+
+        syncer._sync_single_participant("4371570")
+
+        created_issues = [
+            c[0][0] for c in syncer.wordpress_connector.create_validation_issue.call_args_list
+        ]
+        assert not any(i.get("issue_type") == "approval_identity_drift" for i in created_issues)
+        assert any(i.get("issue_type") == "late_racquet_registration" for i in created_issues)
+
+        payload = syncer.wordpress_connector.update_participant.call_args[0][1]
+        assert payload["approval_status"] == APPROVAL_STATUS["APPROVED"]
+        assert payload["secondary_sport"] == SPORT_UNSELECTED
+
+    def test_cutoff_blanked_primary_self_heals_before_drift_check(self, syncer):
+        """When the cutoff blanks the primary sport, self-heal must run after it.
+
+        Live shape: primary=Pickleball (late, stripped), secondary=Basketball.
+        The healed effective shape promotes Basketball into primary, which is
+        exactly what WordPress stored on the previous sync — so no drift.
+        """
+        syncer.late_racquet_overrides = {}
+        wp = _wp_participant({"created_at": "2026-06-20 10:00:00"})
+        chm = _make_chm_person({
+            "first_name": "Matthew",
+            "last_name": "Tran",
+            "birth_date": "2008-04-23",
+        })
+        for field in chm["additional_fields"]:
+            if field["field_name"] == "Primary Sport":
+                field["value"] = "Pickleball"
+            elif field["field_name"] == "Secondary Sport":
+                field["value"] = "Basketball - Men Team"
+        _setup_syncer_for_integration(syncer, wp, chm)
+
+        syncer._sync_single_participant("4371570")
+
+        created_issues = [
+            c[0][0] for c in syncer.wordpress_connector.create_validation_issue.call_args_list
+        ]
+        assert not any(i.get("issue_type") == "approval_identity_drift" for i in created_issues)
+
+        payload = syncer.wordpress_connector.update_participant.call_args[0][1]
+        assert payload["approval_status"] == APPROVAL_STATUS["APPROVED"]
+        assert payload["primary_sport"] == "Basketball - Men Team"
+        assert payload["secondary_sport"] == SPORT_UNSELECTED
+
     def test_pending_participant_no_drift_check(self, syncer):
         """Drift guard must not run for participants who are not yet approved/denied."""
         wp = _wp_participant({"approval_status": APPROVAL_STATUS["PENDING"]})


### PR DESCRIPTION
## Summary

- `_sync_single_participant()` ran the approval identity-drift comparison (`_detect_identity_drift`) on the raw ChMeetings-mapped record *before* `_self_heal_missing_primary_sport()` had a chance to promote a populated `secondary_sport` into a blank `primary_sport`. Every sync therefore compared this run's raw shape against last run's already-healed WordPress snapshot, saw a "changed" primary/secondary sport that never actually changed, and permanently reset the participant to `reapproval_required` — no number of manual `approval-drift-accept` runs could make it stick, since the very next sync reintroduced the same false drift.
- Fix: move the self-heal call to run immediately after ChMeetings data is mapped, before the drift comparison, so both sides compare the same (healed) shape.
- Confirmed against real 2026-07-16 sync logs and production ChMeetings data. Of the 5 participants stuck in `reapproval_required` that day, 1 (chm_id `3318938`) hit this exact bug. The other 2 recurring cases (chm_id `4387145`, `4386750`) turned out to be a second, related ordering bug — see the follow-up commit below. The remaining 2 (chm_id `3618011`, `4464026`) were genuine one-time sport-drop drift, not a bug. All 5 were restored in production via `approval-drift-accept` (using its normal prior-status inference, not `--force-approved`) as an immediate unblock.

## Follow-up commit: cutoff-before-drift ordering

The same class of bug had a second instance: `_apply_new_registration_racquet_cutoff()` (which strips a late-registered racquet sport per `REGISTRATION_DEADLINE`) also ran *after* the drift comparison, not before. For GEC participants `4387145` and `4386750`, who registered after the 2026-05-17 deadline with Pickleball, the cutoff strips Pickleball from every WordPress payload — WordPress never stores it — so every sync compared raw ChMeetings (has Pickleball) against the stripped WordPress snapshot and re-fired the same false drift. This recurred **63–65 times** for these two participants since 2026-06-24, and the first commit in this PR did not fix it since the underlying cause is the cutoff running late, not the self-heal.

Fix: move the cutoff (and the self-heal it can expose, since a cutoff can blank a primary sport while a secondary remains) ahead of the drift comparison, so the pipeline is now: fetch WP row → racquet cutoff → self-heal → drift check.

## Test plan

- [x] `test_self_healed_primary_secondary_swap_is_not_treated_as_drift` in `middleware/tests/test_identity_drift.py` — reproduces the primary-sport self-heal false drift; verified it fails without the first fix and passes with it.
- [x] `test_stripped_late_racquet_sport_is_not_treated_as_drift` and `test_cutoff_blanked_primary_self_heals_before_drift_check` — reproduce the late-racquet cutoff false drift and the cutoff+self-heal interaction.
- [x] Full suite: `pytest tests/ -q` → 872 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)