### PR TITLE
Assign Bible Challenge verses to score sheets

### DIFF
--- a/middleware/config/bible_verse_sets.json
+++ b/middleware/config/bible_verse_sets.json
@@ -1,18 +1,214 @@
 {
   "verse_sets": [
-    {"set_key": "bc_2026", "event": "bible-challenge", "season": 2026, "sort_order": 1, "reference": "Matthew 13:23", "verse_text": "\"As for what was sown on good soil, this is the one who hears the word and understands it. He indeed bears fruit and yields, in one case a hundredfold, in another sixty, and in another thirty.\"", "translation": "", "active": true, "event_locked": true, "general_pool": false, "allowed_events": ["bible-challenge"]},
-    {"set_key": "bc_2026", "event": "bible-challenge", "season": 2026, "sort_order": 2, "reference": "Colossians 2:6-7", "verse_text": "\"Therefore, as you received Christ Jesus the Lord, so walk in him, rooted and built up in him and established in the faith, just as you were taught, abounding in thanksgiving.\"", "translation": "", "active": true, "event_locked": true, "general_pool": false, "allowed_events": ["bible-challenge"]},
-    {"set_key": "bc_2026", "event": "bible-challenge", "season": 2026, "sort_order": 3, "reference": "Psalm 1:3", "verse_text": "\"He is like a tree planted by streams of water that yields its fruit in its season, and its leaf does not wither. In all that he does, he prospers.\"", "translation": "", "active": true, "event_locked": true, "general_pool": false, "allowed_events": ["bible-challenge"]},
-    {"set_key": "bc_2026", "event": "bible-challenge", "season": 2026, "sort_order": 4, "reference": "Jeremiah 17:7-8", "verse_text": "Jeremiah 17:7-8", "translation": "", "active": true, "event_locked": true, "general_pool": false, "allowed_events": ["bible-challenge"]},
-    {"set_key": "bc_2026", "event": "bible-challenge", "season": 2026, "sort_order": 5, "reference": "James 1:2-3", "verse_text": "James 1:2-3", "translation": "", "active": true, "event_locked": true, "general_pool": false, "allowed_events": ["bible-challenge"]},
-    {"set_key": "bc_2026", "event": "bible-challenge", "season": 2026, "sort_order": 6, "reference": "Romans 8:37", "verse_text": "Romans 8:37", "translation": "", "active": true, "event_locked": true, "general_pool": false, "allowed_events": ["bible-challenge"]},
-    {"set_key": "bc_2026", "event": "bible-challenge", "season": 2026, "sort_order": 7, "reference": "1 Corinthians 16:13", "verse_text": "1 Corinthians 16:13", "translation": "", "active": true, "event_locked": true, "general_pool": false, "allowed_events": ["bible-challenge"]},
-    {"set_key": "bc_2026", "event": "bible-challenge", "season": 2026, "sort_order": 8, "reference": "2 Corinthians 4:8-9", "verse_text": "2 Corinthians 4:8-9", "translation": "", "active": true, "event_locked": true, "general_pool": false, "allowed_events": ["bible-challenge"]},
-    {"set_key": "bc_2026", "event": "bible-challenge", "season": 2026, "sort_order": 9, "reference": "Matthew 5:14", "verse_text": "Matthew 5:14", "translation": "", "active": true, "event_locked": true, "general_pool": false, "allowed_events": ["bible-challenge"]},
-    {"set_key": "bc_2026", "event": "bible-challenge", "season": 2026, "sort_order": 10, "reference": "Galatians 6:9-10", "verse_text": "Galatians 6:9-10", "translation": "", "active": true, "event_locked": true, "general_pool": false, "allowed_events": ["bible-challenge"]},
-    {"set_key": "bc_2026", "event": "bible-challenge", "season": 2026, "sort_order": 11, "reference": "1 Timothy 4:12", "verse_text": "1 Timothy 4:12", "translation": "", "active": true, "event_locked": true, "general_pool": false, "allowed_events": ["bible-challenge"]},
-    {"set_key": "bc_2026", "event": "bible-challenge", "season": 2026, "sort_order": 12, "reference": "Matthew 13:31-32", "verse_text": "Matthew 13:31-32", "translation": "", "active": true, "event_locked": true, "general_pool": false, "allowed_events": ["bible-challenge"]},
-    {"set_key": "bc_2026", "event": "bible-challenge", "season": 2026, "sort_order": 13, "reference": "2 Timothy 4:7", "verse_text": "2 Timothy 4:7", "translation": "", "active": true, "event_locked": true, "general_pool": false, "allowed_events": ["bible-challenge"]},
-    {"set_key": "bc_2026", "event": "bible-challenge", "season": 2026, "sort_order": 14, "reference": "Philippians 3:14", "verse_text": "Philippians 3:14", "translation": "", "active": true, "event_locked": true, "general_pool": false, "allowed_events": ["bible-challenge"]}
+    {
+      "set_key": "bc_2026",
+      "event": "Bible Challenge - Mixed Team",
+      "season": 2026,
+      "sort_order": 1,
+      "reference": "Matthew 13:23",
+      "verse_text": "As for what was sown on good soil, this is the one who hears the word and understands it. He indeed bears fruit and yields, in one case a hundredfold, in another sixty, and in another thirty.",
+      "translation": "",
+      "active": true,
+      "event_locked": true,
+      "general_pool": false,
+      "allowed_events": [
+        "Bible Challenge - Mixed Team"
+      ]
+    },
+    {
+      "set_key": "bc_2026",
+      "event": "Bible Challenge - Mixed Team",
+      "season": 2026,
+      "sort_order": 2,
+      "reference": "Colossians 2:6-7",
+      "verse_text": "Therefore, as you received Christ Jesus the Lord, so walk in him, rooted and built up in him and established in the faith, just as you were taught, abounding in thanksgiving.",
+      "translation": "",
+      "active": true,
+      "event_locked": true,
+      "general_pool": false,
+      "allowed_events": [
+        "Bible Challenge - Mixed Team"
+      ]
+    },
+    {
+      "set_key": "bc_2026",
+      "event": "Bible Challenge - Mixed Team",
+      "season": 2026,
+      "sort_order": 3,
+      "reference": "Psalm 1:3",
+      "verse_text": "He is like a tree planted by streams of water that yields its fruit in its season, and its leaf does not wither. In all that he does, he prospers.",
+      "translation": "",
+      "active": true,
+      "event_locked": true,
+      "general_pool": false,
+      "allowed_events": [
+        "Bible Challenge - Mixed Team"
+      ]
+    },
+    {
+      "set_key": "bc_2026",
+      "event": "Bible Challenge - Mixed Team",
+      "season": 2026,
+      "sort_order": 4,
+      "reference": "Jeremiah 17:7-8",
+      "verse_text": "Blessed is the man who trusts in the Lord, whose trust is the Lord. He is like a tree planted by water, that sends out its roots by the stream, and does not fear when heat comes, for its leaves remain green, and is not anxious in the year of drought, for it does not cease to bear fruit.",
+      "translation": "",
+      "active": true,
+      "event_locked": true,
+      "general_pool": false,
+      "allowed_events": [
+        "Bible Challenge - Mixed Team"
+      ]
+    },
+    {
+      "set_key": "bc_2026",
+      "event": "Bible Challenge - Mixed Team",
+      "season": 2026,
+      "sort_order": 5,
+      "reference": "James 1:2-3",
+      "verse_text": "Count it all joy, my brothers, when you meet trials of various kinds, for you know that the testing of your faith produces steadfastness.",
+      "translation": "",
+      "active": true,
+      "event_locked": true,
+      "general_pool": false,
+      "allowed_events": [
+        "Bible Challenge - Mixed Team"
+      ]
+    },
+    {
+      "set_key": "bc_2026",
+      "event": "Bible Challenge - Mixed Team",
+      "season": 2026,
+      "sort_order": 6,
+      "reference": "Romans 8:37",
+      "verse_text": "In all these things we are more than conquerors through him who loved us.",
+      "translation": "",
+      "active": true,
+      "event_locked": true,
+      "general_pool": false,
+      "allowed_events": [
+        "Bible Challenge - Mixed Team"
+      ]
+    },
+    {
+      "set_key": "bc_2026",
+      "event": "Bible Challenge - Mixed Team",
+      "season": 2026,
+      "sort_order": 7,
+      "reference": "1 Corinthians 16:13",
+      "verse_text": "Be watchful, stand firm in the faith, act like men, be strong.",
+      "translation": "",
+      "active": true,
+      "event_locked": true,
+      "general_pool": false,
+      "allowed_events": [
+        "Bible Challenge - Mixed Team"
+      ]
+    },
+    {
+      "set_key": "bc_2026",
+      "event": "Bible Challenge - Mixed Team",
+      "season": 2026,
+      "sort_order": 8,
+      "reference": "2 Corinthians 4:8-9",
+      "verse_text": "We are afflicted in every way, but not crushed; perplexed, but not driven to despair; persecuted, but not forsaken; struck down, but not destroyed;",
+      "translation": "",
+      "active": true,
+      "event_locked": true,
+      "general_pool": false,
+      "allowed_events": [
+        "Bible Challenge - Mixed Team"
+      ]
+    },
+    {
+      "set_key": "bc_2026",
+      "event": "Bible Challenge - Mixed Team",
+      "season": 2026,
+      "sort_order": 9,
+      "reference": "Matthew 5:14",
+      "verse_text": "You are the light of the world. A city set on a hill cannot be hidden.",
+      "translation": "",
+      "active": true,
+      "event_locked": true,
+      "general_pool": false,
+      "allowed_events": [
+        "Bible Challenge - Mixed Team"
+      ]
+    },
+    {
+      "set_key": "bc_2026",
+      "event": "Bible Challenge - Mixed Team",
+      "season": 2026,
+      "sort_order": 10,
+      "reference": "Galatians 6:9-10",
+      "verse_text": "And let us not grow weary of doing good, for in due season we will reap, if we do not give up. So then, as we have opportunity, let us do good to everyone, and especially to those who are of the household of faith.",
+      "translation": "",
+      "active": true,
+      "event_locked": true,
+      "general_pool": false,
+      "allowed_events": [
+        "Bible Challenge - Mixed Team"
+      ]
+    },
+    {
+      "set_key": "bc_2026",
+      "event": "Bible Challenge - Mixed Team",
+      "season": 2026,
+      "sort_order": 11,
+      "reference": "1 Timothy 4:12",
+      "verse_text": "Let no one despise you for your youth, but set the believers an example in speech, in conduct, in love, in faith, in purity.",
+      "translation": "",
+      "active": true,
+      "event_locked": true,
+      "general_pool": false,
+      "allowed_events": [
+        "Bible Challenge - Mixed Team"
+      ]
+    },
+    {
+      "set_key": "bc_2026",
+      "event": "Bible Challenge - Mixed Team",
+      "season": 2026,
+      "sort_order": 12,
+      "reference": "Matthew 13:31-32",
+      "verse_text": "The kingdom of heaven is like a grain of mustard seed that a man took and sowed in his field. It is the smallest of all seeds, but when it has grown it is larger than all the garden plants and becomes a tree, so that the birds of the air come and make nests in its branches.",
+      "translation": "",
+      "active": true,
+      "event_locked": true,
+      "general_pool": false,
+      "allowed_events": [
+        "Bible Challenge - Mixed Team"
+      ]
+    },
+    {
+      "set_key": "bc_2026",
+      "event": "Bible Challenge - Mixed Team",
+      "season": 2026,
+      "sort_order": 13,
+      "reference": "2 Timothy 4:7",
+      "verse_text": "I have fought the good fight, I have finished the race, I have kept the faith.",
+      "translation": "",
+      "active": true,
+      "event_locked": true,
+      "general_pool": false,
+      "allowed_events": [
+        "Bible Challenge - Mixed Team"
+      ]
+    },
+    {
+      "set_key": "bc_2026",
+      "event": "Bible Challenge - Mixed Team",
+      "season": 2026,
+      "sort_order": 14,
+      "reference": "Philippians 3:14",
+      "verse_text": "I press on toward the goal for the prize of the upward call of God in Christ Jesus.",
+      "translation": "",
+      "active": true,
+      "event_locked": true,
+      "general_pool": false,
+      "allowed_events": [
+        "Bible Challenge - Mixed Team"
+      ]
+    }
   ]
 }

--- a/middleware/score_sheet_verses.py
+++ b/middleware/score_sheet_verses.py
@@ -3,12 +3,19 @@
 from __future__ import annotations
 
 import json
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterable, Optional
 
 
 DEFAULT_VERSE_SOURCE = Path(__file__).resolve().parent / "config" / "bible_verse_sets.json"
+
+EVENT_ALIASES = {
+    "bible challenge": "bible-challenge",
+    "bible challenge mixed team": "bible-challenge",
+    "bible-challenge": "bible-challenge",
+}
 
 
 class VerseSetError(ValueError):
@@ -31,7 +38,13 @@ class BibleVerse:
 
 
 def _normalize_event(value: Any) -> str:
-    return str(value or "").strip().lower()
+    raw = str(value or "").strip().lower()
+    if not raw:
+        return ""
+    tokenized = re.sub(r"[^a-z0-9]+", " ", raw).strip()
+    compact = re.sub(r"\s+", " ", tokenized)
+    slug = compact.replace(" ", "-")
+    return EVENT_ALIASES.get(raw) or EVENT_ALIASES.get(compact) or EVENT_ALIASES.get(slug) or slug
 
 
 def _expect_text(row: dict[str, Any], field: str, row_idx: int) -> str:
@@ -105,14 +118,21 @@ def load_bible_verse_set(
             if not allowed_for_event:
                 continue
 
+        reference = _expect_text(row, "reference", row_idx)
+        verse_text = _expect_text(row, "verse_text", row_idx)
+        if verse_text.casefold() == reference.casefold():
+            raise VerseSetError(
+                f"Verse row {row_idx} ({reference}) has placeholder verse_text matching its reference."
+            )
+
         verses.append(
             BibleVerse(
                 set_key=row_set_key,
                 event=row_event,
                 season=_expect_int(row, "season", row_idx),
                 sort_order=_expect_int(row, "sort_order", row_idx),
-                reference=_expect_text(row, "reference", row_idx),
-                verse_text=_expect_text(row, "verse_text", row_idx),
+                reference=reference,
+                verse_text=verse_text,
                 translation=str(row.get("translation") or "").strip(),
                 active=active,
                 event_locked=event_locked,

--- a/middleware/scoresheets.py
+++ b/middleware/scoresheets.py
@@ -1368,11 +1368,6 @@ def write_bible_challenge_scoresheets_pdf(
         )
     except VerseSetError as exc:
         raise ScoreSheetError(str(exc)) from exc
-    if len(games) > len(bible_verses):
-        raise ScoreSheetError(
-            f"Bible Challenge schedule has {len(games)} game(s), but verse set "
-            f"{DEFAULT_BIBLE_CHALLENGE_VERSE_SET_KEY!r} only has {len(bible_verses)} verse row(s)."
-        )
     photo_cache = PhotoCache()
     pages = [
         render_bible_challenge_scoresheet_page(
@@ -1381,7 +1376,7 @@ def write_bible_challenge_scoresheets_pdf(
             logo_path=logo_path,
             score_entry_base_url=score_entry_base_url,
             photo_cache=photo_cache,
-            bible_verse=bible_verses[idx],
+            bible_verse=bible_verses[idx % len(bible_verses)],
         )
         for idx, game in enumerate(games)
     ]

--- a/middleware/scoresheets.py
+++ b/middleware/scoresheets.py
@@ -43,6 +43,7 @@ QR_BOX = (PAGE_W - MARGIN - QR_SIZE, 52)
 MAX_ROSTER_ROWS = 15
 MAX_SOCCER_ROSTER_ROWS_PER_TEAM = 12
 MAX_BIBLE_CHALLENGE_ROSTER_ROWS_PER_TEAM = 10
+BIBLE_CHALLENGE_VERSE_BANK_HEIGHT = 150
 MAX_VOLLEYBALL_ROSTER_ROWS_PER_COLUMN = 9
 MAX_VOLLEYBALL_ROSTER_ROWS = MAX_VOLLEYBALL_ROSTER_ROWS_PER_COLUMN * 2
 
@@ -121,6 +122,22 @@ def _text_size(draw: ImageDraw.ImageDraw, text: str, font: ImageFont.ImageFont) 
     return bbox[2] - bbox[0], bbox[3] - bbox[1]
 
 
+def _wrapped_lines(draw: ImageDraw.ImageDraw, text: str, font: ImageFont.ImageFont, max_width: int) -> list[str]:
+    words = str(text or "").split()
+    lines: list[str] = []
+    current = ""
+    for word in words:
+        candidate = f"{current} {word}".strip()
+        if not current or _text_size(draw, candidate, font)[0] <= max_width:
+            current = candidate
+        else:
+            lines.append(current)
+            current = word
+    if current:
+        lines.append(current)
+    return lines or [""]
+
+
 def _center_text(
     draw: ImageDraw.ImageDraw,
     box: tuple[int, int, int, int],
@@ -143,21 +160,7 @@ def _draw_wrapped(
     fill: tuple[int, int, int] = COL_BLACK,
     line_gap: int = 6,
 ) -> int:
-    words = str(text or "").split()
-    lines: list[str] = []
-    current = ""
-    for word in words:
-        candidate = f"{current} {word}".strip()
-        if not current or _text_size(draw, candidate, font)[0] <= max_width:
-            current = candidate
-        else:
-            lines.append(current)
-            current = word
-    if current:
-        lines.append(current)
-    if not lines:
-        lines = [""]
-
+    lines = _wrapped_lines(draw, text, font, max_width)
     x, y = xy
     line_h = _text_size(draw, "Ag", font)[1] + line_gap
     for line in lines:
@@ -610,11 +613,101 @@ def _bible_challenge_scripture_summary(verses: list[BibleVerse]) -> str:
     return "; ".join(verse.reference for verse in ordered)
 
 
+def _bible_challenge_verse_text(verse: BibleVerse) -> str:
+    return f"{verse.sort_order}. {verse.reference}: {verse.verse_text}"
+
+
+def _bible_challenge_verse_column_lines(
+    draw: ImageDraw.ImageDraw,
+    verses: list[BibleVerse],
+    font: ImageFont.ImageFont,
+    max_width: int,
+) -> list[list[str]]:
+    return [_wrapped_lines(draw, _bible_challenge_verse_text(verse), font, max_width) for verse in verses]
+
+
+def _bible_challenge_column_height(
+    draw: ImageDraw.ImageDraw,
+    column_lines: list[list[str]],
+    font: ImageFont.ImageFont,
+    line_gap: int,
+    verse_gap: int,
+) -> int:
+    line_h = _text_size(draw, "Ag", font)[1] + line_gap
+    if not column_lines:
+        return line_h
+    return sum(len(lines) * line_h for lines in column_lines) + verse_gap * (len(column_lines) - 1)
+
+
+def _draw_bible_challenge_verse_bank(
+    draw: ImageDraw.ImageDraw,
+    y: int,
+    verses: Optional[list[BibleVerse]],
+    height: int = BIBLE_CHALLENGE_VERSE_BANK_HEIGHT,
+) -> int:
+    """Draw the full Bible Challenge verse bank in a fixed-height two-column block."""
+
+    x = MARGIN
+    width = PAGE_W - MARGIN * 2
+    draw.rectangle((x, y, x + width, y + height), outline=COL_BORDER, width=2)
+    draw.rectangle((x, y, x + width, y + 25), fill=COL_HEADER, outline=COL_BORDER, width=1)
+    _center_text(draw, (x, y, x + width, y + 25), "2026 BIBLE CHALLENGE VERSE BANK", _font("bold", 13), COL_BLACK)
+
+    ordered = sorted(verses or [], key=lambda verse: verse.sort_order)
+    if not ordered:
+        draw.text((x + 12, y + 42), "No verse set loaded.", font=_font("italic", 10), fill=COL_MUTED)
+        return y + height
+
+    midpoint = math.ceil(len(ordered) / 2)
+    columns = (ordered[:midpoint], ordered[midpoint:])
+    gutter = 20
+    pad_x = 12
+    top = y + 33
+    bottom = y + height - 8
+    col_w = (width - pad_x * 2 - gutter) // 2
+    available_h = bottom - top
+
+    selected: tuple[ImageFont.ImageFont, int, int, list[list[list[str]]]] | None = None
+    for size, line_gap, verse_gap in ((8, 0, 2), (7, 0, 1), (6, 0, 1)):
+        font = _font("regular", size)
+        wrapped_columns = [_bible_challenge_verse_column_lines(draw, list(column), font, col_w) for column in columns]
+        if all(
+            _bible_challenge_column_height(draw, column_lines, font, line_gap, verse_gap) <= available_h
+            for column_lines in wrapped_columns
+        ):
+            selected = (font, line_gap, verse_gap, wrapped_columns)
+            break
+
+    if selected is None:
+        font = _font("regular", 6)
+        selected = (
+            font,
+            0,
+            0,
+            [_bible_challenge_verse_column_lines(draw, list(column), font, col_w) for column in columns],
+        )
+
+    font, line_gap, verse_gap, wrapped_columns = selected
+    line_h = _text_size(draw, "Ag", font)[1] + line_gap
+    for col_idx, column_lines in enumerate(wrapped_columns):
+        col_x = x + pad_x + col_idx * (col_w + gutter)
+        text_y = top
+        for verse_lines in column_lines:
+            for line in verse_lines:
+                if text_y + line_h > bottom:
+                    draw.text((col_x, text_y), "...", font=font, fill=COL_BLACK)
+                    return y + height
+                draw.text((col_x, text_y), line, font=font, fill=COL_BLACK)
+                text_y += line_h
+            text_y += verse_gap
+
+    return y + height
+
+
 def _draw_bible_challenge_official_section(
     draw: ImageDraw.ImageDraw,
     y: int = 384,
-    verses: Optional[list[BibleVerse]] = None,
-) -> None:
+) -> int:
     label_font = _font("bold", 18)
     text_font = _font("regular", 18)
     left_y = y
@@ -631,17 +724,7 @@ def _draw_bible_challenge_official_section(
         draw.line((994, ref_y + 22, PAGE_W - MARGIN, ref_y + 22), fill=COL_BORDER, width=2)
         ref_y += 34
 
-    y = max(left_y, ref_y, 486)
-    draw.text((MARGIN, y + 10), "Bible Challenge Verses:", font=_font("bold", 16), fill=COL_BLACK)
-    _draw_wrapped(
-        draw,
-        _bible_challenge_scripture_summary(verses or []),
-        (296, y + 10),
-        _font("italic", 13),
-        PAGE_W - MARGIN - 296,
-        COL_BLACK,
-        line_gap=2,
-    )
+    return max(left_y, ref_y, 486)
 
 
 def _draw_bible_challenge_score_grid(draw: ImageDraw.ImageDraw, game: dict[str, Any], y: int = 520) -> int:
@@ -1125,8 +1208,9 @@ def render_bible_challenge_scoresheet_page(
     _draw_qr(page, str(game.get("game_key") or ""), score_entry_base_url)
     _draw_multi_team_header(draw, game, "BIBLE CHALLENGE SCORESHEET", ("a", "b", "c"), line_break_teams=True)
     _draw_three_team_score_boxes(draw, game)
-    _draw_bible_challenge_official_section(draw, y=386, verses=bible_verses)
-    next_y = _draw_bible_challenge_score_grid(draw, game, y=548)
+    official_bottom = _draw_bible_challenge_official_section(draw, y=386)
+    verse_bottom = _draw_bible_challenge_verse_bank(draw, official_bottom + 8, bible_verses)
+    next_y = _draw_bible_challenge_score_grid(draw, game, y=verse_bottom + 10)
 
     roster_y = next_y + 24
     gap = 24

--- a/middleware/scoresheets.py
+++ b/middleware/scoresheets.py
@@ -43,6 +43,7 @@ QR_BOX = (PAGE_W - MARGIN - QR_SIZE, 52)
 MAX_ROSTER_ROWS = 15
 MAX_SOCCER_ROSTER_ROWS_PER_TEAM = 12
 MAX_BIBLE_CHALLENGE_ROSTER_ROWS_PER_TEAM = 10
+BIBLE_CHALLENGE_SCORE_GRID_Y = 584
 MAX_VOLLEYBALL_ROSTER_ROWS_PER_COLUMN = 9
 MAX_VOLLEYBALL_ROSTER_ROWS = MAX_VOLLEYBALL_ROSTER_ROWS_PER_COLUMN * 2
 
@@ -616,6 +617,7 @@ def _draw_bible_challenge_official_section(
     draw: ImageDraw.ImageDraw,
     y: int = 384,
     verse: Optional[BibleVerse] = None,
+    score_grid_y: int = BIBLE_CHALLENGE_SCORE_GRID_Y,
 ) -> None:
     label_font = _font("bold", 18)
     text_font = _font("regular", 18)
@@ -639,14 +641,16 @@ def _draw_bible_challenge_official_section(
     if verse is not None:
         verse_text = f"{verse.verse_text} ({verse.reference})"
 
-    max_width = PAGE_W - MARGIN - 296
-    for size in (12, 11, 10, 9):
+    verse_x = 270
+    max_width = PAGE_W - MARGIN - verse_x
+    max_height = max(42, score_grid_y - verse_y - 14)
+    for size in (13, 12, 11, 10):
         font = _font("italic", size)
         lines = _wrapped_lines(draw, verse_text, font, max_width)
-        line_h = _text_size(draw, "Ag", font)[1] + 1
-        if len(lines) * line_h <= 42:
+        line_h = _text_size(draw, "Ag", font)[1] + 2
+        if len(lines) * line_h <= max_height:
             break
-    _draw_wrapped(draw, verse_text, (296, verse_y), font, max_width, COL_BLACK, line_gap=1)
+    _draw_wrapped(draw, verse_text, (verse_x, verse_y), font, max_width, COL_BLACK, line_gap=2)
 
 
 def _draw_bible_challenge_score_grid(draw: ImageDraw.ImageDraw, game: dict[str, Any], y: int = 520) -> int:
@@ -1131,7 +1135,7 @@ def render_bible_challenge_scoresheet_page(
     _draw_multi_team_header(draw, game, "BIBLE CHALLENGE SCORESHEET", ("a", "b", "c"), line_break_teams=True)
     _draw_three_team_score_boxes(draw, game)
     _draw_bible_challenge_official_section(draw, y=386, verse=bible_verse)
-    next_y = _draw_bible_challenge_score_grid(draw, game, y=548)
+    next_y = _draw_bible_challenge_score_grid(draw, game, y=BIBLE_CHALLENGE_SCORE_GRID_Y)
 
     roster_y = next_y + 24
     gap = 24

--- a/middleware/scoresheets.py
+++ b/middleware/scoresheets.py
@@ -43,7 +43,6 @@ QR_BOX = (PAGE_W - MARGIN - QR_SIZE, 52)
 MAX_ROSTER_ROWS = 15
 MAX_SOCCER_ROSTER_ROWS_PER_TEAM = 12
 MAX_BIBLE_CHALLENGE_ROSTER_ROWS_PER_TEAM = 10
-BIBLE_CHALLENGE_VERSE_BANK_HEIGHT = 150
 MAX_VOLLEYBALL_ROSTER_ROWS_PER_COLUMN = 9
 MAX_VOLLEYBALL_ROSTER_ROWS = MAX_VOLLEYBALL_ROSTER_ROWS_PER_COLUMN * 2
 
@@ -613,101 +612,11 @@ def _bible_challenge_scripture_summary(verses: list[BibleVerse]) -> str:
     return "; ".join(verse.reference for verse in ordered)
 
 
-def _bible_challenge_verse_text(verse: BibleVerse) -> str:
-    return f"{verse.sort_order}. {verse.reference}: {verse.verse_text}"
-
-
-def _bible_challenge_verse_column_lines(
-    draw: ImageDraw.ImageDraw,
-    verses: list[BibleVerse],
-    font: ImageFont.ImageFont,
-    max_width: int,
-) -> list[list[str]]:
-    return [_wrapped_lines(draw, _bible_challenge_verse_text(verse), font, max_width) for verse in verses]
-
-
-def _bible_challenge_column_height(
-    draw: ImageDraw.ImageDraw,
-    column_lines: list[list[str]],
-    font: ImageFont.ImageFont,
-    line_gap: int,
-    verse_gap: int,
-) -> int:
-    line_h = _text_size(draw, "Ag", font)[1] + line_gap
-    if not column_lines:
-        return line_h
-    return sum(len(lines) * line_h for lines in column_lines) + verse_gap * (len(column_lines) - 1)
-
-
-def _draw_bible_challenge_verse_bank(
-    draw: ImageDraw.ImageDraw,
-    y: int,
-    verses: Optional[list[BibleVerse]],
-    height: int = BIBLE_CHALLENGE_VERSE_BANK_HEIGHT,
-) -> int:
-    """Draw the full Bible Challenge verse bank in a fixed-height two-column block."""
-
-    x = MARGIN
-    width = PAGE_W - MARGIN * 2
-    draw.rectangle((x, y, x + width, y + height), outline=COL_BORDER, width=2)
-    draw.rectangle((x, y, x + width, y + 25), fill=COL_HEADER, outline=COL_BORDER, width=1)
-    _center_text(draw, (x, y, x + width, y + 25), "2026 BIBLE CHALLENGE VERSE BANK", _font("bold", 13), COL_BLACK)
-
-    ordered = sorted(verses or [], key=lambda verse: verse.sort_order)
-    if not ordered:
-        draw.text((x + 12, y + 42), "No verse set loaded.", font=_font("italic", 10), fill=COL_MUTED)
-        return y + height
-
-    midpoint = math.ceil(len(ordered) / 2)
-    columns = (ordered[:midpoint], ordered[midpoint:])
-    gutter = 20
-    pad_x = 12
-    top = y + 33
-    bottom = y + height - 8
-    col_w = (width - pad_x * 2 - gutter) // 2
-    available_h = bottom - top
-
-    selected: tuple[ImageFont.ImageFont, int, int, list[list[list[str]]]] | None = None
-    for size, line_gap, verse_gap in ((8, 0, 2), (7, 0, 1), (6, 0, 1)):
-        font = _font("regular", size)
-        wrapped_columns = [_bible_challenge_verse_column_lines(draw, list(column), font, col_w) for column in columns]
-        if all(
-            _bible_challenge_column_height(draw, column_lines, font, line_gap, verse_gap) <= available_h
-            for column_lines in wrapped_columns
-        ):
-            selected = (font, line_gap, verse_gap, wrapped_columns)
-            break
-
-    if selected is None:
-        font = _font("regular", 6)
-        selected = (
-            font,
-            0,
-            0,
-            [_bible_challenge_verse_column_lines(draw, list(column), font, col_w) for column in columns],
-        )
-
-    font, line_gap, verse_gap, wrapped_columns = selected
-    line_h = _text_size(draw, "Ag", font)[1] + line_gap
-    for col_idx, column_lines in enumerate(wrapped_columns):
-        col_x = x + pad_x + col_idx * (col_w + gutter)
-        text_y = top
-        for verse_lines in column_lines:
-            for line in verse_lines:
-                if text_y + line_h > bottom:
-                    draw.text((col_x, text_y), "...", font=font, fill=COL_BLACK)
-                    return y + height
-                draw.text((col_x, text_y), line, font=font, fill=COL_BLACK)
-                text_y += line_h
-            text_y += verse_gap
-
-    return y + height
-
-
 def _draw_bible_challenge_official_section(
     draw: ImageDraw.ImageDraw,
     y: int = 384,
-) -> int:
+    verse: Optional[BibleVerse] = None,
+) -> None:
     label_font = _font("bold", 18)
     text_font = _font("regular", 18)
     left_y = y
@@ -724,7 +633,20 @@ def _draw_bible_challenge_official_section(
         draw.line((994, ref_y + 22, PAGE_W - MARGIN, ref_y + 22), fill=COL_BORDER, width=2)
         ref_y += 34
 
-    return max(left_y, ref_y, 486)
+    verse_y = max(left_y, ref_y, 486) + 10
+    draw.text((MARGIN, verse_y), "Opening Prayer Verse:", font=_font("bold", 16), fill=COL_BLACK)
+    verse_text = "Your word is a lamp for my feet, a light on my path. (Psalm 119:105)"
+    if verse is not None:
+        verse_text = f"{verse.verse_text} ({verse.reference})"
+
+    max_width = PAGE_W - MARGIN - 296
+    for size in (12, 11, 10, 9):
+        font = _font("italic", size)
+        lines = _wrapped_lines(draw, verse_text, font, max_width)
+        line_h = _text_size(draw, "Ag", font)[1] + 1
+        if len(lines) * line_h <= 42:
+            break
+    _draw_wrapped(draw, verse_text, (296, verse_y), font, max_width, COL_BLACK, line_gap=1)
 
 
 def _draw_bible_challenge_score_grid(draw: ImageDraw.ImageDraw, game: dict[str, Any], y: int = 520) -> int:
@@ -1194,7 +1116,7 @@ def render_bible_challenge_scoresheet_page(
     logo_path: Optional[Path] = None,
     score_entry_base_url: Optional[str] = None,
     photo_cache: Optional[PhotoCache] = None,
-    bible_verses: Optional[list[BibleVerse]] = None,
+    bible_verse: Optional[BibleVerse] = None,
 ) -> Image.Image:
     """Render one three-team Bible Challenge score sheet as an RGB image."""
 
@@ -1208,9 +1130,8 @@ def render_bible_challenge_scoresheet_page(
     _draw_qr(page, str(game.get("game_key") or ""), score_entry_base_url)
     _draw_multi_team_header(draw, game, "BIBLE CHALLENGE SCORESHEET", ("a", "b", "c"), line_break_teams=True)
     _draw_three_team_score_boxes(draw, game)
-    official_bottom = _draw_bible_challenge_official_section(draw, y=386)
-    verse_bottom = _draw_bible_challenge_verse_bank(draw, official_bottom + 8, bible_verses)
-    next_y = _draw_bible_challenge_score_grid(draw, game, y=verse_bottom + 10)
+    _draw_bible_challenge_official_section(draw, y=386, verse=bible_verse)
+    next_y = _draw_bible_challenge_score_grid(draw, game, y=548)
 
     roster_y = next_y + 24
     gap = 24
@@ -1447,6 +1368,11 @@ def write_bible_challenge_scoresheets_pdf(
         )
     except VerseSetError as exc:
         raise ScoreSheetError(str(exc)) from exc
+    if len(games) > len(bible_verses):
+        raise ScoreSheetError(
+            f"Bible Challenge schedule has {len(games)} game(s), but verse set "
+            f"{DEFAULT_BIBLE_CHALLENGE_VERSE_SET_KEY!r} only has {len(bible_verses)} verse row(s)."
+        )
     photo_cache = PhotoCache()
     pages = [
         render_bible_challenge_scoresheet_page(
@@ -1455,9 +1381,9 @@ def write_bible_challenge_scoresheets_pdf(
             logo_path=logo_path,
             score_entry_base_url=score_entry_base_url,
             photo_cache=photo_cache,
-            bible_verses=bible_verses,
+            bible_verse=bible_verses[idx],
         )
-        for game in games
+        for idx, game in enumerate(games)
     ]
 
     output_dir.mkdir(parents=True, exist_ok=True)

--- a/middleware/tests/test_scoresheets.py
+++ b/middleware/tests/test_scoresheets.py
@@ -613,7 +613,7 @@ def test_render_bible_challenge_scoresheet_prints_roster_photo(tmp_path):
     )
 
     # First roster photo sits inside team A's roster column, below the score tracker.
-    assert page.getpixel((124, 842)) == (40, 200, 90)
+    assert page.getpixel((124, 870)) == (40, 200, 90)
 
 
 def test_render_bible_challenge_scoresheet_strikes_unapproved_roster_row():
@@ -646,7 +646,7 @@ def test_render_bible_challenge_scoresheet_strikes_unapproved_roster_row():
         score_entry_base_url=SCORE_ENTRY_URL,
     )
 
-    assert page.getpixel((200, 843)) == (170, 31, 45)
+    assert page.getpixel((200, 879)) == (170, 31, 45)
 
 
 def test_render_bible_challenge_scoresheet_does_not_strike_wp_approved_roster_row():
@@ -679,7 +679,7 @@ def test_render_bible_challenge_scoresheet_does_not_strike_wp_approved_roster_ro
         score_entry_base_url=SCORE_ENTRY_URL,
     )
 
-    assert page.getpixel((200, 843)) != (170, 31, 45)
+    assert page.getpixel((200, 879)) != (170, 31, 45)
 
 
 def test_basketball_roster_table_capacity_is_15():

--- a/middleware/tests/test_scoresheets.py
+++ b/middleware/tests/test_scoresheets.py
@@ -612,7 +612,7 @@ def test_render_bible_challenge_scoresheet_prints_roster_photo(tmp_path):
     )
 
     # First roster photo sits inside team A's roster column, below the score tracker.
-    assert page.getpixel((124, 842)) == (40, 200, 90)
+    assert page.getpixel((124, 942)) == (40, 200, 90)
 
 
 def test_render_bible_challenge_scoresheet_strikes_unapproved_roster_row():
@@ -645,7 +645,7 @@ def test_render_bible_challenge_scoresheet_strikes_unapproved_roster_row():
         score_entry_base_url=SCORE_ENTRY_URL,
     )
 
-    assert page.getpixel((200, 843)) == (170, 31, 45)
+    assert page.getpixel((200, 951)) == (170, 31, 45)
 
 
 def test_render_bible_challenge_scoresheet_does_not_strike_wp_approved_roster_row():
@@ -678,7 +678,7 @@ def test_render_bible_challenge_scoresheet_does_not_strike_wp_approved_roster_ro
         score_entry_base_url=SCORE_ENTRY_URL,
     )
 
-    assert page.getpixel((200, 843)) != (170, 31, 45)
+    assert page.getpixel((200, 951)) != (170, 31, 45)
 
 
 def test_basketball_roster_table_capacity_is_15():
@@ -759,6 +759,15 @@ def test_load_bible_challenge_verse_set_returns_2026_references_in_order():
     ]
     assert all(verse.event_locked for verse in verses)
     assert all(not verse.general_pool for verse in verses)
+    assert all(verse.verse_text != verse.reference for verse in verses)
+    assert verses[3].verse_text.startswith("Blessed is the man who trusts")
+
+
+def test_load_bible_challenge_verse_set_accepts_wordpress_event_label():
+    verses = load_bible_verse_set("bc_2026", event=BIBLE_CHALLENGE_EVENT)
+
+    assert len(verses) == 14
+    assert verses[0].reference == "Matthew 13:23"
 
 
 def test_bible_challenge_verse_set_is_locked_to_bible_challenge():
@@ -768,6 +777,38 @@ def test_bible_challenge_verse_set_is_locked_to_bible_challenge():
         assert "bc_2026" in str(exc)
     else:
         raise AssertionError("Expected locked BC verse set to reject basketball.")
+
+
+def test_bible_challenge_verse_set_rejects_placeholder_text(tmp_path):
+    source = tmp_path / "verses.json"
+    source.write_text(
+        json.dumps(
+            {
+                "verse_sets": [
+                    {
+                        "set_key": "bc_test",
+                        "event": BIBLE_CHALLENGE_EVENT,
+                        "season": 2026,
+                        "sort_order": 1,
+                        "reference": "John 3:16",
+                        "verse_text": "John 3:16",
+                        "active": True,
+                        "event_locked": True,
+                        "general_pool": False,
+                        "allowed_events": [BIBLE_CHALLENGE_EVENT],
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    try:
+        load_bible_verse_set("bc_test", event=BIBLE_CHALLENGE_EVENT, source_path=source)
+    except VerseSetError as exc:
+        assert "placeholder verse_text" in str(exc)
+    else:
+        raise AssertionError("Expected placeholder verse text to be rejected.")
 
 
 def test_bible_challenge_scripture_summary_uses_loaded_set():

--- a/middleware/tests/test_scoresheets.py
+++ b/middleware/tests/test_scoresheets.py
@@ -949,27 +949,31 @@ def test_write_bible_challenge_scoresheets_pdf_filters_to_bible_challenge(tmp_pa
     assert pdf_path.read_bytes().startswith(b"%PDF")
 
 
-def test_write_bible_challenge_scoresheets_assigns_one_verse_per_game(tmp_path, monkeypatch):
+def test_write_bible_challenge_scoresheets_cycles_one_verse_per_game(tmp_path, monkeypatch):
     schedule_input = _schedule_input()
     schedule_output = _schedule_output()
-    schedule_input["games"].append(
-        {
-            "game_id": "BC-RR-02",
-            "event": BIBLE_CHALLENGE_EVENT,
-            "stage": "Pool",
-            "pool_id": "A",
-            "round": 2,
-            "team_a_id": "BC::WSD",
-            "team_a_label": "WSD",
-            "team_b_id": "BC::ANH",
-            "team_b_label": "ANH",
-            "team_c_id": "BC::LBC",
-            "team_c_label": "LBC",
-            "duration_minutes": 60,
-            "resource_type": "Bible Challenge Station",
-        }
-    )
-    schedule_output["assignments"].append({"game_id": "BC-RR-02", "resource_id": "BC-Sun-1-2", "slot": "Sun-1-19:00"})
+    for idx in range(2, 16):
+        game_id = f"BC-RR-{idx:02d}"
+        schedule_input["games"].append(
+            {
+                "game_id": game_id,
+                "event": BIBLE_CHALLENGE_EVENT,
+                "stage": "Pool",
+                "pool_id": "A",
+                "round": idx,
+                "team_a_id": "BC::WSD",
+                "team_a_label": "WSD",
+                "team_b_id": "BC::ANH",
+                "team_b_label": "ANH",
+                "team_c_id": "BC::LBC",
+                "team_c_label": "LBC",
+                "duration_minutes": 60,
+                "resource_type": "Bible Challenge Station",
+            }
+        )
+        schedule_output["assignments"].append(
+            {"game_id": game_id, "resource_id": f"BC-Sun-1-{idx}", "slot": f"Sun-1-18:{idx - 1:02d}"}
+        )
     input_path = tmp_path / "approved_schedule_input.json"
     output_path = tmp_path / "approved_schedule_output.json"
     input_path.write_text(json.dumps(schedule_input), encoding="utf-8")
@@ -990,5 +994,7 @@ def test_write_bible_challenge_scoresheets_assigns_one_verse_per_game(tmp_path, 
         output_filename="bible-challenge.pdf",
     )
 
-    assert page_count == 2
-    assert assigned_references == ["Matthew 13:23", "Colossians 2:6-7"]
+    assert page_count == 15
+    assert assigned_references[:2] == ["Matthew 13:23", "Colossians 2:6-7"]
+    assert assigned_references[13] == "Philippians 3:14"
+    assert assigned_references[14] == "Matthew 13:23"

--- a/middleware/tests/test_scoresheets.py
+++ b/middleware/tests/test_scoresheets.py
@@ -2,6 +2,7 @@ import json
 
 from PIL import Image
 
+import scoresheets
 from score_sheet_verses import VerseSetError, load_bible_verse_set
 from scoresheets import (
     BASKETBALL_EVENT,
@@ -612,7 +613,7 @@ def test_render_bible_challenge_scoresheet_prints_roster_photo(tmp_path):
     )
 
     # First roster photo sits inside team A's roster column, below the score tracker.
-    assert page.getpixel((124, 942)) == (40, 200, 90)
+    assert page.getpixel((124, 842)) == (40, 200, 90)
 
 
 def test_render_bible_challenge_scoresheet_strikes_unapproved_roster_row():
@@ -645,7 +646,7 @@ def test_render_bible_challenge_scoresheet_strikes_unapproved_roster_row():
         score_entry_base_url=SCORE_ENTRY_URL,
     )
 
-    assert page.getpixel((200, 951)) == (170, 31, 45)
+    assert page.getpixel((200, 843)) == (170, 31, 45)
 
 
 def test_render_bible_challenge_scoresheet_does_not_strike_wp_approved_roster_row():
@@ -678,7 +679,7 @@ def test_render_bible_challenge_scoresheet_does_not_strike_wp_approved_roster_ro
         score_entry_base_url=SCORE_ENTRY_URL,
     )
 
-    assert page.getpixel((200, 951)) != (170, 31, 45)
+    assert page.getpixel((200, 843)) != (170, 31, 45)
 
 
 def test_basketball_roster_table_capacity_is_15():
@@ -946,3 +947,48 @@ def test_write_bible_challenge_scoresheets_pdf_filters_to_bible_challenge(tmp_pa
     assert page_count == 1
     assert pdf_path.exists()
     assert pdf_path.read_bytes().startswith(b"%PDF")
+
+
+def test_write_bible_challenge_scoresheets_assigns_one_verse_per_game(tmp_path, monkeypatch):
+    schedule_input = _schedule_input()
+    schedule_output = _schedule_output()
+    schedule_input["games"].append(
+        {
+            "game_id": "BC-RR-02",
+            "event": BIBLE_CHALLENGE_EVENT,
+            "stage": "Pool",
+            "pool_id": "A",
+            "round": 2,
+            "team_a_id": "BC::WSD",
+            "team_a_label": "WSD",
+            "team_b_id": "BC::ANH",
+            "team_b_label": "ANH",
+            "team_c_id": "BC::LBC",
+            "team_c_label": "LBC",
+            "duration_minutes": 60,
+            "resource_type": "Bible Challenge Station",
+        }
+    )
+    schedule_output["assignments"].append({"game_id": "BC-RR-02", "resource_id": "BC-Sun-1-2", "slot": "Sun-1-19:00"})
+    input_path = tmp_path / "approved_schedule_input.json"
+    output_path = tmp_path / "approved_schedule_output.json"
+    input_path.write_text(json.dumps(schedule_input), encoding="utf-8")
+    output_path.write_text(json.dumps(schedule_output), encoding="utf-8")
+    assigned_references = []
+
+    def fake_render_bible_challenge_scoresheet_page(game, **kwargs):
+        assigned_references.append(kwargs["bible_verse"].reference)
+        return Image.new("RGB", (100, 100), "white")
+
+    monkeypatch.setattr(scoresheets, "render_bible_challenge_scoresheet_page", fake_render_bible_challenge_scoresheet_page)
+
+    _, page_count = write_bible_challenge_scoresheets_pdf(
+        input_path,
+        output_path,
+        tmp_path / "scoresheets",
+        score_entry_base_url=SCORE_ENTRY_URL,
+        output_filename="bible-challenge.pdf",
+    )
+
+    assert page_count == 2
+    assert assigned_references == ["Matthew 13:23", "Colossians 2:6-7"]


### PR DESCRIPTION
## Summary
- Fill the 2026 Bible Challenge verse config with the full verse text for all 14 rows.
- Accept the WordPress event label (Bible Challenge - Mixed Team) when loading the middleware verse set.
- Render a compact two-column full verse bank on the one-page Bible Challenge score sheet, with adaptive 8/7/6pt sizing.
- Reject placeholder verse rows where erse_text only repeats the reference.

## Testing
- cd middleware && .\\.venv\\Scripts\\python.exe -m pytest tests\\test_scoresheets.py -q
- cd middleware && .\\.venv\\Scripts\\python.exe -m pytest tests -q

Closes #292