### PR TITLE
RFCs: Canonical ChMeetings Identity + Registrant Trust (epic #307)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,8 @@ vaysf/
 │   ├── SCHEDULE-HOW-TO.md           # operator how-to for schedule production
 │   ├── PRD.md
 │   ├── PRD_SCHEDULING_HELPER.md     # 2027 Scheduling Helper GUI PRD (epic #272)
+│   ├── CANONICAL_IDENTITY_RFC.md    # duplicate-people repair layer (epic #307, Track A)
+│   ├── REGISTRANT_TRUST_RFC.md      # roles/verification/minor-consent (epic #307, Track T)
 │   ├── EVENT_DAY_RESULTS_WORKFLOW_RFC.md
 │   ├── SEASON_TRANSITION.md
 │   ├── CHMEETINGS_API_MIGRATION.md

--- a/docs/CANONICAL_IDENTITY_RFC.md
+++ b/docs/CANONICAL_IDENTITY_RFC.md
@@ -1,0 +1,272 @@
+# RFC: Canonical Person Identity — untangling the duplicate-people problem
+
+*Written the night before Sports Fest 2026, after two seasons of living with
+duplicate "Justin Nguyen" scoresheets and twin "Ngoc Le / Khoa Le" badges.
+This is a design document, not code. Nothing described here exists yet.
+Read it with coffee; decide at leisure. The event-day workaround in §6 is
+the only part relevant before Monday.*
+
+---
+
+## 1. The feeling you couldn't name
+
+You said the system feels entangled — that merging duplicates makes it
+worse, that deleted players reincarnate, that re-registrations haunt the
+scoresheets. Here is the sentence underneath all of it:
+
+> **The system has no concept of a *person*. It only has a concept of a
+> *ChMeetings ID* — and ChMeetings IDs are not people.**
+
+A ChMeetings ID is an *identifier*: a label the vendor mints when a record
+is created. A *person* is the human who may, over two seasons, accumulate
+several of those labels — because they re-registered to change sports,
+because a church rep deleted them and they re-applied, because you merged
+two profiles in ChMeetings and the merge retired one ID.
+
+Every tier of vaysf treats the identifier as if it were the person:
+
+- **Sync** looks up WordPress participants by `chmeetings_id` and creates
+  a new row when it finds nothing (`middleware/sync/participants.py`,
+  the lookup inside `_sync_single_participant`).
+- **WordPress** enforces `UNIQUE KEY chmeetings_id`
+  (`plugins/vaysf/vaysf.php`) — which *sounds* like duplicate prevention
+  but is actually duplicate *manufacturing*: a second ID for the same
+  human sails through the uniqueness check as a brand-new person.
+- **Rosters** hang off the participant row; **badges** are one PNG per
+  `chmeetings_id`; **scoresheets** append every roster row with no dedup.
+
+So when ChMeetings mints a second ID for one human, the system doesn't
+make an error — it does exactly what it was built to do, twice. That is
+why the symptoms feel scattered (a duplicate on a Basketball scoresheet
+here, twin badges there, a 404 during approval sync somewhere else) while
+being one disease. And it is why the entanglement never yields to local
+fixes: each artifact is faithfully printing the duplicate identity it was
+handed.
+
+## 2. Why everything you built so far detects but never cures
+
+Two seasons of tooling have grown around this problem, and an honest
+audit shows a pattern:
+
+| Tool | What it does | What it doesn't do |
+|---|---|---|
+| `investigate-consent-404s` | Scores stale IDs against live people (birthdate/email/phone/name) and classifies: *likely re-registered*, *likely deleted*… | Read-only. Writes an Excel report. Merges nothing. |
+| `audit-team-groups --remove-orphans` | Removes group memberships whose person ID 404s | ChMeetings-side only. The WordPress row lives on. |
+| Identity-drift detection (#171) | Catches when the *same* ID's name/church/sport changes; forces re-approval | Never fires across two IDs — a re-registration looks like a brand-new person, not drift. |
+| `repair_form_people` | Blocks creating people from duplicate form submissions | Pre-sync only; can't see duplicates already live. |
+| Troubleshooting playbooks | Classify a 404 as stale-merge vs needs-investigation | Manual, case-by-case, after the haunting has begun. |
+
+Every one of these is **detection and classification**. None of them is
+**resolution** — nothing anywhere says "these two IDs are the same human,
+and from now on the system should behave accordingly." The stale
+WordPress row is never reconciled, so it reincarnates through every
+export until someone hand-edits it. Your instinct that "fixing them
+sometimes makes it worse" is correct: merging in ChMeetings retires an ID
+that WordPress still holds, which *creates* a 404 where there wasn't one.
+The cure at the wrong layer deepens the disease.
+
+## 3. The missing concept: canonical identity
+
+The elegant fix is not to chase duplicates through four subsystems. It is
+to introduce the one concept that's missing — **a canonical identity
+layer** — at the one place all data already flows through.
+
+The idea in one sentence:
+
+> **Keep a small, human-confirmed map of "stale ID → canonical ID," and
+> apply it once, at the front door of the sync, so the rest of the system
+> never sees a duplicate identity again.**
+
+Three properties make this elegant rather than clever:
+
+1. **It doesn't fight ChMeetings.** ChMeetings will keep minting IDs;
+   church reps will keep deleting people; players will keep
+   re-registering. The design accepts that as weather, and puts up an
+   umbrella at the single doorway instead of chasing raindrops through
+   the house.
+2. **One concept, one file, one choke point.** Every participant already
+   passes through `_sync_single_participant()`. Resolution is three lines
+   at the top of it. Everything downstream — validation, rosters, badges,
+   scoresheets, approval sync — stays exactly as simple as it is today,
+   because it now receives only canonical identities.
+3. **The empty map is today's system.** With no alias entries, behavior
+   is byte-for-byte unchanged. Risk of landing it: near zero.
+
+## 4. The design, in five parts
+
+### 4.1 The alias map — `person_aliases.json`
+
+An operator-maintained JSON file mapping stale IDs to canonical ones,
+following the exact pattern of the existing `late_racquet_overrides.json`
+(committed example file; real entries in a git-ignored `.local.json`;
+path overridable in `.env`):
+
+```json
+{
+  "3634001": "3633885",
+  "3634002": {
+    "canonical_chm_id": "3633885",
+    "reason": "re-registered to change sports; old profile deleted by rep",
+    "confirmed_by": "Bumble",
+    "confirmed_on": "2026-07-20",
+    "note": "Ngoc Le / Khoa Le"
+  }
+}
+```
+
+You are the only writer of this file. The code never edits it. That keeps
+the merge decision — a pastoral, human judgment about who is who — in
+human hands, permanently.
+
+### 4.2 Resolution at the choke point
+
+At the top of `_sync_single_participant()` in
+`middleware/sync/participants.py`:
+
+```python
+canonical_id = resolve_chm_id(chm_id, self.person_aliases)
+if canonical_id != chm_id:
+    logger.info("[VAY SM] Alias: stale chm_id %s resolved to canonical %s", chm_id, canonical_id)
+    chm_id = canonical_id
+```
+
+From that line on, the ChMeetings fetch, the WordPress lookup, the
+create/update decision, drift detection, roster sync — all of it operates
+on the canonical identity. The stale WordPress row is never touched
+again; the duplicate can no longer be *re-created*. This also quietly
+fixes the ChMeetings-merge case: the retired ID resolves to its
+replacement *before* the fetch that would have 404'd.
+
+### 4.3 Retire, don't delete — `apply-aliases`
+
+Resolution stops new hauntings; the *existing* stale WordPress row still
+needs an exorcism. A new `apply-aliases` command (report-only by default,
+`--execute` to act, mirroring `audit-team-groups --remove-orphans`)
+retires each aliased row in place:
+
+1. Delete its roster rows (existing `delete_roster` API) — this is what
+   actually removes the duplicate from scoresheets and exports, which
+   read rosters.
+2. Set its `approval_status` to `merged` — a tombstone. The status column
+   is a plain VARCHAR, so this needs **zero plugin changes**, and every
+   consumer that filters (badges: approved-only; approval sync:
+   approved-only; pending queues) now ignores the row.
+3. Tombstone its approval row the same way, so an old email token can't
+   resurrect it.
+4. Resolve its open validation issues.
+5. If the *stale* row was pastor-approved but the *canonical* row isn't:
+   warn loudly and do **not** auto-copy the approval. An identity change
+   invalidates approval — the same philosophy as the drift guard (#171).
+
+Why not just delete the row? Because there is no participant DELETE
+route in the plugin, and — more importantly — `sf_approvals` and
+`sf_validation_issues` have **no cascading foreign keys** to
+participants. A hard delete would strand orphaned rows pointing at a dead
+`participant_id`: a brand-new species of ghost. The tombstone keeps
+referential integrity, keeps the audit trail, and is reversible if an
+alias entry turns out to be a mistake.
+
+### 4.4 A duplicate finder that proposes, never merges — `find-duplicates`
+
+Maintaining the alias map shouldn't require detective work. A new
+`find-duplicates` command reuses the identity scoring you already trust
+from the consent-404 investigator — birthdate 33, email 27, phone 24,
+name 16, with the "strong match needs a birthdate-or-exact-name anchor"
+rule that protects family members who share phones — and runs it across
+**all** live participants, not just 404 cases. Output: an Excel workbook
+of candidate pairs with scores, evidence, and a ready-to-paste JSON
+snippet column. You review, confirm, paste into the alias map.
+
+Worth savoring: **the Ngoc Le / Khoa Le case is already solved by your
+existing weights.** Same birthdate + email + phone scores 84 — a strong
+match — with *zero* points from the name. The scoring you built for
+consent 404s was always the right instrument; it was just pointed at too
+narrow a target.
+
+### 4.5 Tripwires downstream
+
+Sync-level resolution is the cure; downstream gets cheap smoke alarms.
+Warning-only detectors (never filters — paper must match data) in
+scoresheet, badge, and church-team-export generation: two rows on one
+team sharing a normalized name and birthdate logs a WARNING. That catches
+*new* duplicates — ones with no alias entry yet — before an operator sees
+them on paper at 7 a.m. This is also the honest fix for issue #40
+("duplicate names in export-church-teams").
+
+## 5. What this deliberately does not do
+
+- **No ChMeetings-side writes** beyond what already exists. The diocese
+  data stays under human control.
+- **No WordPress plugin changes, no schema migration.** The tombstone
+  rides an existing VARCHAR column.
+- **No auto-merge, ever.** The code proposes; you decide. A wrong
+  automatic merge of two *actual* different people named Justin Nguyen
+  would be far worse than a duplicate badge.
+- **No new database, no new service.** One JSON file, four small Python
+  modules, three lines in the syncer.
+
+## 6. The event-day playbook (usable tomorrow, no new code)
+
+For tonight's Justin Nguyen and Ngoc/Khoa Le — with existing tools only:
+
+1. `python main.py inspect-person <id>` on both IDs to confirm which is
+   the stale twin (the one with no live ChMeetings record, or the older
+   registration).
+2. In ChMeetings, remove the stale person from their `Team ...` group so
+   the next sync stops promoting them.
+3. Via the WordPress connector (interactive Python):
+   `get_rosters({"participant_id": <stale_wp_id>})`, then
+   `delete_roster(roster_id)` for each; then
+   `update_participant(<stale_wp_id>, {"approval_status": "denied"})`.
+4. Rerun `generate-scoresheets` and `generate-badges --church-code <X>`.
+   Delete the stale badge PNG — its filename contains the stale
+   ChMeetings ID, so it's easy to find.
+
+Ten minutes per ghost. §4 is how we make it the last ten minutes you ever
+spend this way.
+
+## 7. Decisions that are yours
+
+1. **Re-approval policy.** When an alias retires a pastor-approved row
+   and the canonical row isn't approved: force re-approval (my
+   recommendation, consistent with #171) or carry the approval over?
+2. **Scope of `apply-aliases`.** WordPress-only, or also remove the stale
+   person from ChMeetings Team groups via the existing membership API?
+3. **Where real alias entries live.** Git-ignored `.local.json` (my
+   lean — the notes column carries names) or committed to the repo?
+4. **The `merged` status value.** Confirm no WordPress dashboard or
+   pastor UI chokes on an unfamiliar status string (to be verified
+   against `class-vaysf-rest-approvals.php` during implementation).
+
+## 8. Implementation sketch (post-event, one focused week)
+
+| Phase | What | New files |
+|---|---|---|
+| 1 | Alias map + loader + resolution at choke point | `middleware/sync/person_aliases.py`, `middleware/data/person_aliases.json` (example) |
+| 2 | `apply-aliases` reconciliation command | `middleware/sync/alias_reconciler.py` |
+| 3 | `find-duplicates` proposal command; extract shared scoring | `middleware/sync/duplicate_finder.py`, `middleware/sync/identity_scoring.py` |
+| 4 | Downstream warning tripwires (#40) | — (edits to scoresheets/badges/export) |
+
+Config lands beside the late-racquet precedent in `middleware/config.py`;
+CLI subcommands in `middleware/main.py`; mock-mode tests for the loader,
+sync resolution (including the empty-map regression guard), reconciler
+idempotency, and finder scoring; docs in `USAGE.md` and a "duplicate
+person" playbook in `TROUBLESHOOTING.md`. Phase 1 alone stops the
+bleeding; each later phase is independently shippable.
+
+## 9. The verge of something great
+
+What you sensed is real, and it's this: **the entanglement was never many
+problems.** Two seasons of scattered symptoms — 404s, ghosts, twins,
+re-approval confusion — trace to a single missing abstraction, and that
+abstraction costs one JSON file and three lines at a door the data
+already walks through. The system underneath is sound; it has been
+faithfully amplifying an identity error it was never given the vocabulary
+to express. Give it the word *person*, and the haunting ends.
+
+---
+
+*Companion reading: `docs/ARCHITECTURE_REVIEW_2026.md` (state of the
+system at v1.12), `docs/TROUBLESHOOTING.md` §"Approval Sync Returns 404"
+(today's manual classification of stale IDs), issue #40 (duplicate names
+in exports), issue #171 (identity drift).*

--- a/docs/CANONICAL_IDENTITY_RFC.md
+++ b/docs/CANONICAL_IDENTITY_RFC.md
@@ -1,10 +1,16 @@
-# RFC: Canonical Person Identity — untangling the duplicate-people problem
+# RFC: Canonical ChMeetings Identity — untangling the duplicate-people problem
 
 *Written the night before Sports Fest 2026, after two seasons of living with
 duplicate "Justin Nguyen" scoresheets and twin "Ngoc Le / Khoa Le" badges.
 This is a design document, not code. Nothing described here exists yet.
-Read it with coffee; decide at leisure. The event-day workaround in §6 is
-the only part relevant before Monday.*
+The event-day workaround in §7 is the only part relevant before Monday.*
+
+**Status: Approved** — maintainer review, the morning of the event.
+Approved as the post-event architecture direction, with one precision
+(this is a canonical *ChMeetings-ID* layer, not yet a full person entity —
+see §3.1 and §10) and five binding guardrails (§5). In the maintainer's
+words: *"a pragmatic canonical-ID layer, not the final theology of
+personhood."*
 
 ---
 
@@ -30,8 +36,9 @@ Every tier of vaysf treats the identifier as if it were the person:
   the lookup inside `_sync_single_participant`).
 - **WordPress** enforces `UNIQUE KEY chmeetings_id`
   (`plugins/vaysf/vaysf.php`) — which *sounds* like duplicate prevention
-  but is actually duplicate *manufacturing*: a second ID for the same
-  human sails through the uniqueness check as a brand-new person.
+  but is actually duplicate *manufacturing*: it prevents two rows for the
+  same ChMeetings ID while giving the system a clean excuse to treat a
+  second ID for the same human as a brand-new person.
 - **Rosters** hang off the participant row; **badges** are one PNG per
   `chmeetings_id`; **scoresheets** append every roster row with no dedup.
 
@@ -92,6 +99,18 @@ Three properties make this elegant rather than clever:
 3. **The empty map is today's system.** With no alias entries, behavior
    is byte-for-byte unchanged. Risk of landing it: near zero.
 
+### 3.1 Naming precision (maintainer review)
+
+To be exact about what this is: the map resolves **one ChMeetings ID to
+another ChMeetings ID**. It is a *canonical ChMeetings identity* layer,
+not yet a true *person* entity. A fuller future version would introduce
+something like an `sf_person_id` that owns many ChMeetings IDs and
+WordPress submissions over the years — that is the cathedral. This RFC
+builds the strong bridge instead, which is the right trade-off for the
+real situation: it solves this year's haunting with one JSON file and
+three lines of code, and it does not preclude the cathedral later
+(§10). **Do not build a cathedral when a strong bridge will do.**
+
 ## 4. The design, in five parts
 
 ### 4.1 The alias map — `person_aliases.json`
@@ -121,7 +140,8 @@ human hands, permanently.
 ### 4.2 Resolution at the choke point
 
 At the top of `_sync_single_participant()` in
-`middleware/sync/participants.py`:
+`middleware/sync/participants.py`, **before anything else — including the
+`get_person(chm_id)` fetch** (see guardrail G1):
 
 ```python
 canonical_id = resolve_chm_id(chm_id, self.person_aliases)
@@ -150,7 +170,8 @@ retires each aliased row in place:
 2. Set its `approval_status` to `merged` — a tombstone. The status column
    is a plain VARCHAR, so this needs **zero plugin changes**, and every
    consumer that filters (badges: approved-only; approval sync:
-   approved-only; pending queues) now ignores the row.
+   approved-only; pending queues) now ignores the row. (Subject to
+   guardrail G4: verify every consumer tolerates the unfamiliar status.)
 3. Tombstone its approval row the same way, so an old email token can't
    resurrect it.
 4. Resolve its open validation issues.
@@ -159,9 +180,10 @@ retires each aliased row in place:
    invalidates approval — the same philosophy as the drift guard (#171).
 
 Why not just delete the row? Because there is no participant DELETE
-route in the plugin, and — more importantly — `sf_approvals` and
-`sf_validation_issues` have **no cascading foreign keys** to
-participants. A hard delete would strand orphaned rows pointing at a dead
+route in the plugin, and — more importantly — while `sf_rosters` has an
+`ON DELETE CASCADE` foreign key to participants, `sf_approvals` and
+`sf_validation_issues` have **no cascading participant foreign keys at
+all**. A hard delete would strand orphaned rows pointing at a dead
 `participant_id`: a brand-new species of ghost. The tombstone keeps
 referential integrity, keeps the audit trail, and is reversible if an
 alias entry turns out to be a mistake.
@@ -193,21 +215,51 @@ team sharing a normalized name and birthdate logs a WARNING. That catches
 them on paper at 7 a.m. This is also the honest fix for issue #40
 ("duplicate names in export-church-teams").
 
-## 5. What this deliberately does not do
+## 5. Guardrails (binding, from maintainer review)
+
+These are conditions of the approval, not suggestions:
+
+- **G1 — Resolve before `get_person()`.** The alias lookup is the *first*
+  statement of `_sync_single_participant()`, ahead of the ChMeetings
+  fetch. A stale ID that has already been merged/deleted in ChMeetings
+  404s on fetch — resolution after the fetch would arrive too late to
+  help. Tests must cover the "stale ID 404s, canonical resolves" path.
+- **G2 — Alias chains resolve; cycles hard-fail.** `A → B` then later
+  `B → C` must end at `C` (transitive resolution with a visited set).
+  But `A → B → A` is a **hard failure with a loud error** — not a
+  warn-and-drop. A cyclic map is operator error and the sync must refuse
+  to run on it rather than guess.
+- **G3 — Never auto-merge.** The duplicate finder proposes; Bumble
+  decides. No code path ever writes the alias map or merges rows on its
+  own initiative. A duplicate badge is annoying; auto-merging two
+  *actual different* Justin Nguyens is a nightmare.
+- **G4 — Verify `merged` everywhere before relying on it.** The VARCHAR
+  column accepts the value, but every consumer must be checked for
+  tolerance of an unfamiliar status before Phase 2 ships: WordPress
+  dashboards, shortcodes, pastor approval UI, `process-token` handling
+  (`class-vaysf-rest-approvals.php`), badge generation, approval sync,
+  pending queues, and exports. Anything that whitelists statuses gets a
+  test.
+- **G5 — The real alias map stays private.** Committed example file only;
+  real entries live in the git-ignored `person_aliases.local.json`. Real
+  entries carry names, birth years, reasons, and pastoral judgment — that
+  is not casual commit material. (This resolves what was previously an
+  open question.)
+
+## 6. What this deliberately does not do
 
 - **No ChMeetings-side writes** beyond what already exists. The diocese
   data stays under human control.
 - **No WordPress plugin changes, no schema migration.** The tombstone
   rides an existing VARCHAR column.
-- **No auto-merge, ever.** The code proposes; you decide. A wrong
-  automatic merge of two *actual* different people named Justin Nguyen
-  would be far worse than a duplicate badge.
+- **No auto-merge, ever** (guardrail G3).
 - **No new database, no new service.** One JSON file, four small Python
   modules, three lines in the syncer.
 
-## 6. The event-day playbook (usable tomorrow, no new code)
+## 7. The event-day playbook (usable today, no new code)
 
-For tonight's Justin Nguyen and Ngoc/Khoa Le — with existing tools only:
+For the Justin Nguyen and Ngoc/Khoa Le twins — with existing tools only.
+This, and only this, is in scope during the event:
 
 1. `python main.py inspect-person <id>` on both IDs to confirm which is
    the stale twin (the one with no live ChMeetings record, or the older
@@ -225,36 +277,38 @@ For tonight's Justin Nguyen and Ngoc/Khoa Le — with existing tools only:
 Ten minutes per ghost. §4 is how we make it the last ten minutes you ever
 spend this way.
 
-## 7. Decisions that are yours
+## 8. Remaining open decisions
+
+Resolved by the maintainer review: the alias map lives in the git-ignored
+`.local.json` (G5), and the `merged` status is acceptable *pending* the
+G4 verification sweep.
+
+Still open, to settle before Phase 2:
 
 1. **Re-approval policy.** When an alias retires a pastor-approved row
-   and the canonical row isn't approved: force re-approval (my
-   recommendation, consistent with #171) or carry the approval over?
+   and the canonical row isn't approved: force re-approval
+   (recommendation, consistent with #171) or carry the approval over?
 2. **Scope of `apply-aliases`.** WordPress-only, or also remove the stale
    person from ChMeetings Team groups via the existing membership API?
-3. **Where real alias entries live.** Git-ignored `.local.json` (my
-   lean — the notes column carries names) or committed to the repo?
-4. **The `merged` status value.** Confirm no WordPress dashboard or
-   pastor UI chokes on an unfamiliar status string (to be verified
-   against `class-vaysf-rest-approvals.php` during implementation).
 
-## 8. Implementation sketch (post-event, one focused week)
+## 9. Implementation sketch (post-event, one focused week)
 
 | Phase | What | New files |
 |---|---|---|
-| 1 | Alias map + loader + resolution at choke point | `middleware/sync/person_aliases.py`, `middleware/data/person_aliases.json` (example) |
-| 2 | `apply-aliases` reconciliation command | `middleware/sync/alias_reconciler.py` |
-| 3 | `find-duplicates` proposal command; extract shared scoring | `middleware/sync/duplicate_finder.py`, `middleware/sync/identity_scoring.py` |
+| 1 | Alias map + loader + resolution at choke point (G1, G2) | `middleware/sync/person_aliases.py`, `middleware/data/person_aliases.json` (example) |
+| 2 | `apply-aliases` reconciliation command (after G4 sweep) | `middleware/sync/alias_reconciler.py` |
+| 3 | `find-duplicates` proposal command; extract shared scoring (G3) | `middleware/sync/duplicate_finder.py`, `middleware/sync/identity_scoring.py` |
 | 4 | Downstream warning tripwires (#40) | — (edits to scoresheets/badges/export) |
 
 Config lands beside the late-racquet precedent in `middleware/config.py`;
-CLI subcommands in `middleware/main.py`; mock-mode tests for the loader,
-sync resolution (including the empty-map regression guard), reconciler
+CLI subcommands in `middleware/main.py`; mock-mode tests for the loader
+(chains, cycle hard-fail, empty-map identity), sync resolution (including
+the empty-map regression guard and the G1 404 path), reconciler
 idempotency, and finder scoring; docs in `USAGE.md` and a "duplicate
 person" playbook in `TROUBLESHOOTING.md`. Phase 1 alone stops the
 bleeding; each later phase is independently shippable.
 
-## 9. The verge of something great
+## 10. The verge of something great — and the road past the bridge
 
 What you sensed is real, and it's this: **the entanglement was never many
 problems.** Two seasons of scattered symptoms — 404s, ghosts, twins,
@@ -262,7 +316,17 @@ re-approval confusion — trace to a single missing abstraction, and that
 abstraction costs one JSON file and three lines at a door the data
 already walks through. The system underneath is sound; it has been
 faithfully amplifying an identity error it was never given the vocabulary
-to express. Give it the word *person*, and the haunting ends.
+to express.
+
+The bridge built here gives it a first word for *person*: "these IDs are
+one human." If, after a season of use, the alias map proves too light —
+if you find yourself wanting year-over-year continuity, one lifetime
+Sports Fest identity across registrations, churches, and seasons — the
+cathedral version is a natural extension, not a rewrite: an
+`sf_person_id` entity that owns many ChMeetings IDs, with the alias map
+becoming its first migration source. Nothing in this design has to be
+undone to get there. But that is a decision for a future off-season,
+made from experience rather than anticipation.
 
 ---
 

--- a/docs/CANONICAL_IDENTITY_RFC.md
+++ b/docs/CANONICAL_IDENTITY_RFC.md
@@ -328,9 +328,50 @@ becoming its first migration source. Nothing in this design has to be
 undone to get there. But that is a decision for a future off-season,
 made from experience rather than anticipation.
 
+## 11. Implementation issues (Track A)
+
+*To be created as sub-issues of the Identity & Registrant Trust epic, in
+the dependency order below. Each is independently shippable and testable
+in mock mode. Issue numbers backfilled after filing.*
+
+### A1 — `middleware: person alias map + resolution at sync choke point`
+Phase 1 (§4.1–§4.2): `person_aliases.py` loader (late-racquet pattern;
+committed example + git-ignored `.local.json` per G5), transitive
+`resolve_chm_id` with cycle hard-fail (G2), resolution as the first
+statement of `_sync_single_participant()` before `get_person()` (G1).
+Tests: loader edge cases, empty-map regression guard, stale-ID-404s path.
+**Dependencies:** none. The foundation issue — must land first.
+
+### A2 — `middleware/wordpress: verify merged-status tolerance across consumers`
+The G4 sweep: audit every consumer of `approval_status` — dashboards,
+shortcodes, pastor UI, `process-token` (`class-vaysf-rest-approvals.php`),
+badge generation, approval sync, pending queues, exports — for tolerance of
+the `merged` value; add tests for anything that whitelists statuses.
+**Dependencies:** none (parallel with A1). Gates A3.
+
+### A3 — `middleware: apply-aliases reconciliation command`
+Phase 2 (§4.3): report-only default + `--execute`; delete stale roster
+rows, tombstone participant + approval as `merged`, resolve open validation
+issues, loud warning on stale-approved/canonical-unapproved (§8 decision 1).
+Idempotent. **Dependencies:** A1, A2, §8 decisions.
+
+### A4 — `middleware: find-duplicates proposal command + shared identity_scoring`
+Phase 3 (§4.4): extract consent-404 scoring into `identity_scoring.py`
+(investigator behavior unchanged), all-participants pair scan with the
+family-share anchor rule, Excel audit with paste-ready alias snippets.
+Never writes the alias map (G3). **Dependencies:** A1.
+
+### A5 — `middleware: duplicate warning tripwires in scoresheets/badges/exports`
+Phase 4 (§4.5): warning-only detectors (same team + normalized name +
+birthdate) in scoresheet, badge, and church-team-export generation.
+Addresses issue #40's symptom directly. **Dependencies:** none (any time
+after A1 merges its test fixtures).
+
 ---
 
 *Companion reading: `docs/ARCHITECTURE_REVIEW_2026.md` (state of the
-system at v1.12), `docs/TROUBLESHOOTING.md` §"Approval Sync Returns 404"
-(today's manual classification of stale IDs), issue #40 (duplicate names
-in exports), issue #171 (identity drift).*
+system at v1.12), `docs/REGISTRANT_TRUST_RFC.md` (upstream prevention:
+explicit roles, verified contacts, minor consent — Track T of the same
+epic), `docs/TROUBLESHOOTING.md` §"Approval Sync Returns 404" (today's
+manual classification of stale IDs), issue #40 (duplicate names in
+exports), issue #171 (identity drift).*

--- a/docs/CANONICAL_IDENTITY_RFC.md
+++ b/docs/CANONICAL_IDENTITY_RFC.md
@@ -330,38 +330,37 @@ made from experience rather than anticipation.
 
 ## 11. Implementation issues (Track A)
 
-*To be created as sub-issues of the Identity & Registrant Trust epic, in
-the dependency order below. Each is independently shippable and testable
-in mock mode. Issue numbers backfilled after filing.*
+*Sub-issues of epic #307, in the dependency order below. Each is
+independently shippable and testable in mock mode.*
 
-### A1 — `middleware: person alias map + resolution at sync choke point`
+### A1 (#308) — `middleware: person alias map + resolution at sync choke point`
 Phase 1 (§4.1–§4.2): `person_aliases.py` loader (late-racquet pattern;
 committed example + git-ignored `.local.json` per G5), transitive
 `resolve_chm_id` with cycle hard-fail (G2), resolution as the first
 statement of `_sync_single_participant()` before `get_person()` (G1).
 Tests: loader edge cases, empty-map regression guard, stale-ID-404s path.
-**Dependencies:** none. The foundation issue — must land first.
+**Dependencies:** none. The foundation issue — must land first. (#308)
 
-### A2 — `middleware/wordpress: verify merged-status tolerance across consumers`
+### A2 (#309) — `middleware/wordpress: verify merged-status tolerance across consumers`
 The G4 sweep: audit every consumer of `approval_status` — dashboards,
 shortcodes, pastor UI, `process-token` (`class-vaysf-rest-approvals.php`),
 badge generation, approval sync, pending queues, exports — for tolerance of
 the `merged` value; add tests for anything that whitelists statuses.
 **Dependencies:** none (parallel with A1). Gates A3.
 
-### A3 — `middleware: apply-aliases reconciliation command`
+### A3 (#310) — `middleware: apply-aliases reconciliation command`
 Phase 2 (§4.3): report-only default + `--execute`; delete stale roster
 rows, tombstone participant + approval as `merged`, resolve open validation
 issues, loud warning on stale-approved/canonical-unapproved (§8 decision 1).
 Idempotent. **Dependencies:** A1, A2, §8 decisions.
 
-### A4 — `middleware: find-duplicates proposal command + shared identity_scoring`
+### A4 (#311) — `middleware: find-duplicates proposal command + shared identity_scoring`
 Phase 3 (§4.4): extract consent-404 scoring into `identity_scoring.py`
 (investigator behavior unchanged), all-participants pair scan with the
 family-share anchor rule, Excel audit with paste-ready alias snippets.
 Never writes the alias map (G3). **Dependencies:** A1.
 
-### A5 — `middleware: duplicate warning tripwires in scoresheets/badges/exports`
+### A5 (#312) — `middleware: duplicate warning tripwires in scoresheets/badges/exports`
 Phase 4 (§4.5): warning-only detectors (same team + normalized name +
 birthdate) in scoresheet, badge, and church-team-export generation.
 Addresses issue #40's symptom directly. **Dependencies:** none (any time

--- a/docs/REGISTRANT_TRUST_RFC.md
+++ b/docs/REGISTRANT_TRUST_RFC.md
@@ -215,14 +215,22 @@ Deliverable: recommendation + cost model. **Dependencies:** none.
 
 ### T2 (#314) — `spike: contact verification page (token-page pattern)`
 Prototype a `[contact_verify]`-style page on the insurance-upload pattern:
-request-code → token → verified; verified contact stored on the participant.
-Answers Q2 with a working prototype; feeds `find-duplicates` a strong
-anchor. **Dependencies:** T1 (channel).
+request-code → token → verified. Prototype storage must explicitly
+distinguish whether the verified contact belongs to the **athlete,
+registrant, or guardian**; temporary `sf_participants` storage is
+acceptable for the spike, but the deliverable must recommend the final
+role/contact schema shape before any production implementation —
+role-scoped trust data must not be stuffed into the athlete row (that is
+how `parent_info` became a flat-text junk drawer). Answers Q2 with a
+working prototype; feeds `find-duplicates` a strong anchor.
+**Dependencies:** T1 (channel).
 
 ### T3 (#315) — `spike: minor registration → parent notification & consent capture`
 Design the trigger (sync-time, `age_at_event < 18`, new registration), the
 guardian notification (T1 channel), and the consent-capture page (token-page
 pattern) as complement or replacement for the ChMeetings consent form.
+Consent-capture and guardian-contact storage follow the role/contact schema
+recommendation from T2 — no ad-hoc fields on the participant row.
 Answers Q3, informs Q4. **Dependencies:** T1, T2.
 
 ### T4 (#316) — `spike: ChMeetings /families API evaluation`

--- a/docs/REGISTRANT_TRUST_RFC.md
+++ b/docs/REGISTRANT_TRUST_RFC.md
@@ -1,0 +1,270 @@
+# RFC: Registrant Trust — explicit roles, verified contacts, and minor consent
+
+**Status: Draft for review** · Target: 2027 season · Scope: design only, no
+production code changes.
+
+*Companion to `docs/CANONICAL_IDENTITY_RFC.md` (approved). That RFC fixes
+duplicate identities after they exist; this one is about preventing them at
+the source and making the humans around each athlete — parent, Church Rep,
+pastor — explicit in the system instead of implicit in text fields. The
+onboarding journey in §1 and the six design questions in §5 were supplied by
+the maintainer from two seasons of operating the event.*
+
+---
+
+## 1. The current athlete onboarding journey (as-is, 2026)
+
+1. **Church enters Sports Fest first.** The Church Rep fills out the
+   ChMeetings Church Application Form from the website. The Senior Pastor
+   approves and appoints an official Church Representative, who becomes the
+   main liaison between VAY-SM, the pastor, the church, and the athletes —
+   responsible for communication, athlete coordination, forms, fees, and
+   pastor signoff.
+2. **Athlete registers online** through the ChMeetings Individual Application
+   Form on the Sports Fest website/WordPress flow: name, church/team,
+   birthdate, photo/headshot for the ID badge, church membership claim,
+   sports selections, and required acknowledgments/releases. Athletes must
+   generally be at least 13 and under 35, with exceptions for events like
+   Scripture Memorization and Tug-of-War.
+3. **Athlete chooses sports/events.** Up to two main events (Primary and
+   Secondary), not counting Track and Field and Scripture Memorization. Team
+   events allow unlimited athletes within reason; individual events have
+   limits Church Reps help enforce.
+4. **The system stores/syncs the athlete** through ChMeetings and WordPress.
+   ChMeetings holds the person/application identity; WordPress keeps its own
+   participant records for workflow, approvals, rosters, badges, scoresheets,
+   and views. *This is where duplicate identities enter* — re-registration,
+   changing sports by submitting again, delete/re-add.
+5. **Church Rep reviews and coordinates corrections** before
+   forwarding/signoff — team rules, registration requirements, fees, event
+   limits.
+6. **Pastor verifies eligibility and church membership.** Every athlete is
+   signed off by the Senior Pastor or designee. Non-member participation is
+   allowed only within limits and with pastoral endorsement/outreach intent.
+7. **If the athlete is under 18, parent/guardian consent is required.** The
+   Handbook says the parent/guardian signs the release for athletes under 18,
+   and the electronic approval process should send registration to
+   parents/guardians when applicable.
+8. **Required releases and ID/photo must be complete** — liability release,
+   medical release, passport-like headshot for the electronic ID badge,
+   media/image rights.
+9. **Approved athletes flow into operational outputs** — rosters, badges,
+   scoresheets, church team exports, event-day check-in.
+10. **Current pain point: identity changes are not cleanly reconciled.**
+    Re-registration, sport changes via resubmission, delete/re-add by a rep,
+    or a ChMeetings merge leave stale WordPress rows that leak into badges,
+    rosters, and scoresheets unless manually cleaned.
+
+## 2. Problem statement
+
+> The current journey assumes **"one athlete registration = one real
+> person,"** and real life breaks that assumption. The process is
+> church-centered with athlete self-registration, plus pastor approval and
+> parent consent layered afterward. The future system should make those
+> roles explicit instead of treating everyone as just another "participant
+> row."
+
+Concretely, three gaps:
+
+- **Identity**: nothing verifies that a registrant controls the contact
+  info they submit, so nothing anchors a person across registrations.
+  (The Canonical Identity RFC repairs duplicates; this RFC is upstream
+  prevention.)
+- **Roles**: the parent/guardian exists only as flat text
+  (`parent_info` on the WordPress participant; three ChMeetings custom
+  fields). The Church Rep and pastor exist as church-level contacts. No
+  relationship connects an athlete to their guardian.
+- **Consent for minors**: the Handbook *requires* guardian signature for
+  under-18, but the system treats consent as a WARNING for everyone, never
+  checks that a minor's consent was guardian-signed (a 14-year-old
+  self-signing raises no flag), and has no way to notify a parent when a
+  minor registers.
+
+## 3. Goals and non-goals
+
+**Goals**
+
+1. A registrant's key contact (phone and/or email) can be verified, and a
+   verified contact becomes a durable identity anchor for duplicate
+   prevention and season-over-season continuity.
+2. A self-service path lets an athlete *change* their registration (sports,
+   corrections) without re-registering — removing the single largest
+   duplicate generator.
+3. Parents/guardians of minors are notified at registration and can complete
+   consent electronically; consent state is enforced according to the
+   Handbook, not merely advised.
+4. Athlete, Parent/Guardian, Church Rep, and Pastor are explicit roles with
+   defined powers, not inferences from text fields.
+
+**Non-goals**
+
+- Replacing ChMeetings registration forms. Registration stays in ChMeetings;
+  everything here attaches after or alongside it.
+- Payments, accounting, contributions (out of scope for vaysf, per CLAUDE.md).
+- Auto-merging identities — inherits guardrail G3 from the Canonical Identity
+  RFC verbatim.
+- Building for "any church." This stays VAY-specific.
+
+## 4. The explicit role model
+
+| Role | Today | Future |
+|---|---|---|
+| **Athlete** | The participant row | The person competing; may or may not be the registrant; owns (or shares) a verified contact |
+| **Parent / Guardian** | Flat text (`parent_info`; ChM fields 1283265-67) | A linked actor for each minor: notified at registration, signs consent, may be the registrant and the phone owner |
+| **Church Rep** | Church-level contact (`church_rep_phone` etc.); operational glue | Unchanged in authority, but the system should distinguish "rep registered/edited this athlete" from athlete self-action |
+| **Pastor** | Approval workflow (tokens, email) | Unchanged; approval invalidation rules extended to cover consent-relevant changes |
+
+The load-bearing distinction: **registrant ≠ athlete.** A parent registering
+their child and a rep fixing a record are legitimate, common, and currently
+indistinguishable from the athlete acting. Making the actor explicit is what
+lets verification, consent, and duplicate prevention each attach to the
+right person.
+
+## 5. The six open design questions
+
+Each question below is the maintainer's, verbatim in intent; the notes are
+what the codebase already tells us, and recommendations where evidence
+exists. Final answers belong to the spikes (§7) and decisions (§8).
+
+**Q1 — Who is the actual registrant: athlete, parent, or Church Rep?**
+All three occur. The consent pipeline already half-knows this: the consent
+form's "Select one:" field distinguishes self vs guardian signer, and the
+matcher applies a *lower* confidence threshold to guardian-signed forms
+because parents routinely fill the athlete's phone/email fields with their
+own contact info. The role model (§4) makes the registrant a recorded fact
+instead of an inference.
+
+**Q2 — Should SMS/email verify the athlete, the parent, or both?**
+Open — and the guardian-phone wrinkle above means "verify the athlete's
+phone" often actually verifies the *parent's* phone. Recommendation: verify
+**the registrant's contact** (whoever is acting), and for minors always
+include the guardian contact. Spikes T1/T2 answer feasibility; note there is
+no SMS capability today anywhere in the system, ChMeetings' API has no
+messaging endpoints, and the 2026 Event-Day RFC already evaluated and
+deferred SMS magic-links — so this is an external gateway (e.g., Twilio)
+attached to the WordPress token-page pattern, with email as the fallback
+channel that costs nothing and needs no carrier registration.
+
+**Q3 — When a minor self-registers, when and how is the parent notified?**
+Recommendation: at sync time — the middleware already computes
+`age_at_event` for every participant, so the moment a new registration under
+18 syncs in, a notification (T1 channel) goes to the guardian contact with a
+consent link (T3). "At sync" beats "at form submission" because we don't
+control the ChMeetings form, and sync runs nightly or on demand.
+
+**Q4 — Does parent consent attach to the person, the registration, or the
+exact sports selected?**
+Recommendation: **the registration + its sports**, not the person. The
+consent release is about what the child will actually do; a consent signed
+when the child registered for Scripture Memorization shouldn't silently
+cover a later switch to Basketball. This makes consent behave like pastor
+approval already behaves under the drift framework.
+
+**Q5 — What changes require renewed pastor approval or parent consent?**
+The system already answers half of this: identity drift
+(`approval_identity_drift`: name/gender/church) and registration drift
+(`approval_registration_drift`: sports/events) invalidate pastor approval
+(#171, #212). Recommendation: add **consent drift** as a sibling — the same
+detected changes, evaluated against consent for minors. One framework, two
+authorities (pastor, guardian), consistent invalidation rules.
+
+**Q6 — How do we prevent duplicate registrations without blocking siblings,
+shared phones, or parent-managed signups?**
+The answer already exists in miniature: the consent-404 scorer refuses to
+call a match "strong" on shared phone/email alone — it requires a birthdate
+or exact-name anchor, precisely because family members share contacts. The
+`find-duplicates` command (Canonical Identity RFC §4.4) inherits that anchor
+rule, and verified contacts (Q2) raise confidence without ever auto-acting
+(guardrail G3: propose, never merge).
+
+## 6. Foundations already in the codebase
+
+Nothing in this RFC starts from zero:
+
+- **Token-page pattern** — the insurance-upload flow is the template: a
+  shortcode page with request-link and act states, public REST endpoint
+  pair, 64-hex single-purpose tokens with configurable expiry. Phone
+  verification, "My Registration," and parent-consent capture are all
+  instances of this shape. Pastor approval tokens prove the email-link
+  variant.
+- **Drift framework** — `_detect_identity_drift` + the
+  `approval_identity_drift` / `approval_registration_drift` split, with the
+  operator `approval-drift-accept` workflow. Consent drift (Q5) is a third
+  issue type in an existing machine, not a new machine.
+- **Identity scoring** — consent-404 weights (birthdate 33 / email 27 /
+  phone 24 / name 16) and the family-share anchor rule; being extracted into
+  a shared `identity_scoring` module by Canonical Identity Track A.
+- **Age machinery** — `age_at_event` computed in sync; minor = under 18 at
+  event (badges already use this).
+- **ChMeetings `/families` API** — full household CRUD exists in the API and
+  is entirely unused; data quality for VAY SM is unknown (spike T4).
+- **Signer-type capture** — the consent form already records self vs
+  guardian; it has simply never been cross-checked against age (T5 closes
+  that today, no new infrastructure).
+
+## 7. Implementation issues (Track T)
+
+*To be created as sub-issues of the Identity & Registrant Trust epic.
+Spikes are discovery: their deliverable is a written recommendation, not
+production code. Issue numbers backfilled after filing.*
+
+### T1 — `spike: SMS/notification gateway evaluation`
+Evaluate Twilio and alternatives for cost, nonprofit A2P 10DLC registration
+lead time (weeks — a start-early item), sender identity, and operational
+ownership; define the email fallback that works with zero gateway setup.
+Deliverable: recommendation + cost model. **Dependencies:** none.
+
+### T2 — `spike: contact verification page (token-page pattern)`
+Prototype a `[contact_verify]`-style page on the insurance-upload pattern:
+request-code → token → verified; verified contact stored on the participant.
+Answers Q2 with a working prototype; feeds `find-duplicates` a strong
+anchor. **Dependencies:** T1 (channel).
+
+### T3 — `spike: minor registration → parent notification & consent capture`
+Design the trigger (sync-time, `age_at_event < 18`, new registration), the
+guardian notification (T1 channel), and the consent-capture page (token-page
+pattern) as complement or replacement for the ChMeetings consent form.
+Answers Q3, informs Q4. **Dependencies:** T1, T2.
+
+### T4 — `spike: ChMeetings /families API evaluation`
+Determine whether households are reliably populated for VAY SM families and
+whether the API supports a guardian link worth trusting; recommend family
+model (ChMeetings households vs WordPress-side guardian link vs flat text).
+**Dependencies:** none.
+
+### T5 — `middleware: flag minor + self-signed consent mismatch`
+Buildable now: cross-check signer-type against `age_at_event` during consent
+processing; WARNING-severity validation issue first, severity revisited with
+T6. **Dependencies:** none.
+
+### T6 — `validation: consent enforcement level for minors`
+Rules-JSON change raising missing/self-signed consent for minors to ERROR
+(Handbook-aligned), adults stay WARNING. **Dependencies:** §8 decision, T5.
+
+### T7 — `middleware: consent drift — changes that invalidate consent`
+Extend the drift framework with consent-drift for minors per Q4/Q5
+(registration+sports attachment). **Dependencies:** T3 outcome, T6.
+
+## 8. Open decisions
+
+1. **Consent enforcement level** (gates T6): recommend ERROR for minors —
+   the Handbook already requires guardian signature; this is enforcement
+   catching up to policy, not new policy.
+2. **SMS budget and ownership** (gates T1's conclusion): who owns the
+   gateway account and number; appetite for per-message cost vs email-only
+   first season.
+3. **Family model** (gates T7 shape): decided by T4 evidence.
+4. **Verification target** (Q2, gates T2 conclusion): registrant vs athlete
+   vs both — recommend registrant + guardian-for-minors.
+
+*Facts only the maintainer can supply, feeding the spikes: whether VAY SM
+households are populated in ChMeetings (T4 verifies); whether the
+registration form can gain fields; whether the ChMeetings app offers any
+native SMS the tenant already has.*
+
+---
+
+*Companion reading: `docs/CANONICAL_IDENTITY_RFC.md` (the repair layer this
+RFC prevents work for), `docs/EVENT_DAY_RESULTS_WORKFLOW_RFC.md` (the WSMS
+deferral and the RFC→issues pattern this document follows), `docs/PRD.md`
+§4–§7 (forms, workflow, business rules).*

--- a/docs/REGISTRANT_TRUST_RFC.md
+++ b/docs/REGISTRANT_TRUST_RFC.md
@@ -204,44 +204,43 @@ Nothing in this RFC starts from zero:
 
 ## 7. Implementation issues (Track T)
 
-*To be created as sub-issues of the Identity & Registrant Trust epic.
-Spikes are discovery: their deliverable is a written recommendation, not
-production code. Issue numbers backfilled after filing.*
+*Sub-issues of epic #307. Spikes are discovery: their deliverable is a
+written recommendation, not production code.*
 
-### T1 — `spike: SMS/notification gateway evaluation`
+### T1 (#313) — `spike: SMS/notification gateway evaluation`
 Evaluate Twilio and alternatives for cost, nonprofit A2P 10DLC registration
 lead time (weeks — a start-early item), sender identity, and operational
 ownership; define the email fallback that works with zero gateway setup.
 Deliverable: recommendation + cost model. **Dependencies:** none.
 
-### T2 — `spike: contact verification page (token-page pattern)`
+### T2 (#314) — `spike: contact verification page (token-page pattern)`
 Prototype a `[contact_verify]`-style page on the insurance-upload pattern:
 request-code → token → verified; verified contact stored on the participant.
 Answers Q2 with a working prototype; feeds `find-duplicates` a strong
 anchor. **Dependencies:** T1 (channel).
 
-### T3 — `spike: minor registration → parent notification & consent capture`
+### T3 (#315) — `spike: minor registration → parent notification & consent capture`
 Design the trigger (sync-time, `age_at_event < 18`, new registration), the
 guardian notification (T1 channel), and the consent-capture page (token-page
 pattern) as complement or replacement for the ChMeetings consent form.
 Answers Q3, informs Q4. **Dependencies:** T1, T2.
 
-### T4 — `spike: ChMeetings /families API evaluation`
+### T4 (#316) — `spike: ChMeetings /families API evaluation`
 Determine whether households are reliably populated for VAY SM families and
 whether the API supports a guardian link worth trusting; recommend family
 model (ChMeetings households vs WordPress-side guardian link vs flat text).
 **Dependencies:** none.
 
-### T5 — `middleware: flag minor + self-signed consent mismatch`
+### T5 (#317) — `middleware: flag minor + self-signed consent mismatch`
 Buildable now: cross-check signer-type against `age_at_event` during consent
 processing; WARNING-severity validation issue first, severity revisited with
 T6. **Dependencies:** none.
 
-### T6 — `validation: consent enforcement level for minors`
+### T6 (#318) — `validation: consent enforcement level for minors`
 Rules-JSON change raising missing/self-signed consent for minors to ERROR
 (Handbook-aligned), adults stay WARNING. **Dependencies:** §8 decision, T5.
 
-### T7 — `middleware: consent drift — changes that invalidate consent`
+### T7 (#319) — `middleware: consent drift — changes that invalidate consent`
 Extend the drift framework with consent-drift for minors per Q4/Q5
 (registration+sports attachment). **Dependencies:** T3 outcome, T6.
 


### PR DESCRIPTION
## Summary

Design documents for the **Identity & Registrant Trust** initiative (epic #307) — no code, no schema changes, no behavioral changes.

## What's in this PR

- **docs/CANONICAL_IDENTITY_RFC.md** (Approved — maintainer review incorporated) — the *repair* layer: a canonical ChMeetings-ID alias map applied at the sync choke point, retire-don't-delete reconciliation, a duplicate finder that proposes but never merges, and downstream warning tripwires. Includes the five binding guardrails from maintainer review and §11 Implementation Issues (#308–#312, Track A).
- **docs/REGISTRANT_TRUST_RFC.md** (Draft for review) — the *prevention* layer: the 10-step athlete onboarding journey (as-is), the explicit role model (athlete / parent / Church Rep / pastor), the six open design questions with codebase evidence, foundations to reuse (token-page pattern, drift framework, identity scoring), and §7 Implementation Issues (#313–#319, Track T).
- **CLAUDE.md** — docs tree annotated with the owning epic.

## Real-world symptoms addressed

- Duplicate "Justin Nguyen" on scoresheet; twin "Ngoc Le" / "Khoa Le" badges
- 404s on approval sync after ChMeetings profile merges; stale WordPress rows that "reincarnate"
- Minors self-signing consent with no flag; parents never notified of a minor's registration
- Re-registering to change sports as the top duplicate generator

## Tracking

Epic #307 with sub-issues #308–#312 (canonical identity, ready to build) and #313–#319 (registrant trust spikes + minor-consent work). The Canonical Identity RFC's §6 event-day playbook remains usable during the event with existing tools only.

## Not yet implemented

Design only. Post-season work per the sequencing in #307.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GVdKGZ6sjDU4Xpxq6zi8RU