### PR TITLE
Distinguish API read failures from empty results

### DIFF
--- a/middleware/chmeetings/backend_connector.py
+++ b/middleware/chmeetings/backend_connector.py
@@ -16,6 +16,11 @@ class ChMeetingsAPIError(Exception):
     pass
 
 
+class ChMeetingsReadError(ChMeetingsAPIError):
+    """Raised when a ChMeetings read cannot be completed safely."""
+    pass
+
+
 # Fields returned by GET /api/v1/people/{id} that must NOT be sent in
 # PUT /api/v1/people/{id}.  Sending them causes HTTP 400 or 500 errors:
 #   - full_name      : computed by the server from first + last name
@@ -88,6 +93,7 @@ class ChMeetingsConnector:
         self.api_key = Config.CHM_API_KEY
         self.use_api = use_api
         self.last_group_membership_delete_status: Optional[str] = None
+        self.last_get_people_status: Optional[str] = None
         self.last_get_person_status: Optional[str] = None
         self.last_get_groups_status: Optional[str] = None
         self.last_get_group_people_status: Optional[str] = None
@@ -190,6 +196,7 @@ class ChMeetingsConnector:
         """
         if not self.use_api:
             logger.error("API usage is disabled")
+            self.last_get_people_status = "failed"
             return []
 
         all_people = []
@@ -231,9 +238,13 @@ class ChMeetingsConnector:
                         break
                 page += 1
             except requests.RequestException as e:
+                self.last_get_people_status = "failed"
                 logger.error(f"Failed to get people on page {page}: {str(e)}")
-                break
+                raise ChMeetingsReadError(
+                    f"Failed to complete ChMeetings people read on page {page}"
+                ) from e
 
+        self.last_get_people_status = "ok"
         return all_people
 
     def get_person(self, person_id: str) -> Optional[Dict[str, Any]]:

--- a/middleware/group_assignment.py
+++ b/middleware/group_assignment.py
@@ -24,7 +24,7 @@ from config import (
 current_dir = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(current_dir)
 
-from chmeetings.backend_connector import ChMeetingsConnector
+from chmeetings.backend_connector import ChMeetingsConnector, ChMeetingsReadError
 from wordpress.frontend_connector import WordPressConnector
 
 
@@ -693,9 +693,14 @@ def repair_form_people(
             logger.error("Authentication with ChMeetings failed")
             return empty
 
-        live_people: List[Dict[str, Any]] = (
-            people if people is not None else chm_connector.get_people()
-        )
+        try:
+            live_people: List[Dict[str, Any]] = (
+                people if people is not None else chm_connector.get_people()
+            )
+        except ChMeetingsReadError as exc:
+            logger.error(f"Failed to load ChMeetings people for repair-form-people: {exc}")
+            return empty
+
         live_groups: List[Dict[str, Any]] = (
             groups if groups is not None else chm_connector.get_groups()
         )
@@ -867,7 +872,11 @@ def audit_form_people(
             if not chm_connector.authenticate():
                 logger.error("Authentication with ChMeetings failed")
                 return False
-            people = chm_connector.get_people()
+            try:
+                people = chm_connector.get_people()
+            except ChMeetingsReadError as exc:
+                logger.error(f"Failed to load ChMeetings people for audit-form-people: {exc}")
+                return False
 
     people_index = _index_people_for_form_audit(people)
     audit_rows: List[Dict[str, str]] = []
@@ -1299,7 +1308,11 @@ def _assign_people_to_church_team_groups_legacy(
             return False
 
         # --- Identification (unchanged logic) ---
-        all_people = chm_connector.get_people()
+        try:
+            all_people = chm_connector.get_people()
+        except ChMeetingsReadError as exc:
+            logger.error(f"Failed to load ChMeetings people for group assignment: {exc}")
+            return False
         logger.info(f"Retrieved {len(all_people)} people from ChMeetings")
         if source_file:
             audit_form_people(source_file, people=all_people)
@@ -1518,7 +1531,11 @@ def assign_people_to_church_team_groups(
             logger.error("Authentication with ChMeetings failed")
             return False
 
-        all_people = chm_connector.get_people()
+        try:
+            all_people = chm_connector.get_people()
+        except ChMeetingsReadError as exc:
+            logger.error(f"Failed to load ChMeetings people for group assignment: {exc}")
+            return False
         logger.info(f"Retrieved {len(all_people)} people from ChMeetings")
         if target_chm_ids:
             found_target_ids = {str(person.get("id")) for person in all_people} & target_chm_ids

--- a/middleware/sync/participants.py
+++ b/middleware/sync/participants.py
@@ -716,7 +716,17 @@ class ParticipantSyncer:
             all_participants_processed_successfully = True # Assume success unless a participant fails
 
             for group in team_groups:
+                if hasattr(self.chm_connector, "last_get_group_people_status"):
+                    self.chm_connector.last_get_group_people_status = None
                 participants_in_group = self.chm_connector.get_group_people(group["id"])
+                if getattr(self.chm_connector, "last_get_group_people_status", None) == "failed":
+                    logger.error(
+                        f"Failed to load participants in group '{group['name']}' "
+                        f"(ID: {group['id']}). Full participant sync cannot safely continue."
+                    )
+                    all_participants_processed_successfully = False
+                    continue
+
                 if not participants_in_group:
                     logger.info(f"No participants in group '{group['name']}' (ID: {group['id']}). Skipping.")
                     continue
@@ -749,12 +759,7 @@ class ParticipantSyncer:
                 logger.warning("Full participant sync from groups completed, but one or more participants encountered errors or were invalid. Check logs and stats.")
 
             logger.info(f"Participant sync completed. Stats: Participants {self.stats['participants']}, Rosters: {self.stats['rosters']}, Validation Issues: {self.stats['validation_issues']}")
-            # For full sync, the method is considered "successful" if it ran through.
-            # Individual errors are in stats. The original code implies a True return if it reaches the end.
-            # However, all_participants_processed_successfully gives a more nuanced status.
-            # Let's return True if the process completed, consistent with original high-level behavior.
-            # If you want it to return False if ANY participant fails, change the return to `all_participants_processed_successfully`.
-            return True
+            return all_participants_processed_successfully
 # START --- New helper method for ParticipantSyncer in participants.py ---
     def _sync_single_participant(
         self,

--- a/middleware/tests/test_chmeetings_connector.py
+++ b/middleware/tests/test_chmeetings_connector.py
@@ -4,7 +4,7 @@ import pytest
 import sys
 import time
 import requests
-from chmeetings.backend_connector import ChMeetingsConnector
+from chmeetings.backend_connector import ChMeetingsConnector, ChMeetingsReadError
 from conftest import require_live_mutation_test
 from loguru import logger
 
@@ -107,6 +107,37 @@ def test_get_people_pagination(chm_connector, mocker, mock_chm_people_data):
 
     assert len(people) == 3, "All 3 people should be collected across 2 pages"
     assert call_count["n"] == 2, "Should have made exactly 2 page requests"
+
+
+def test_get_people_page_two_failure_raises_instead_of_returning_partial(chm_connector, mocker, mock_chm_people_data):
+    """A mid-pagination ChMeetings failure must not return a truncated people list."""
+    live_test = os.getenv("LIVE_TEST", "false").strip().lower() == "true"
+    if live_test:
+        pytest.skip("Failure semantics are covered by mock mode")
+
+    page1_data = mock_chm_people_data[:2]
+    call_count = {"n": 0}
+
+    def paged_get(*args, **kwargs):
+        call_count["n"] += 1
+        if call_count["n"] == 2:
+            raise requests.ConnectionError("page 2 connection dropped")
+        mock_resp = mocker.Mock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = mocker.Mock()
+        mock_resp.json.return_value = {
+            "paging": {"total_count": 3, "page": 1, "page_size": 2},
+            "data": page1_data,
+        }
+        return mock_resp
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr("requests.Session.get", paged_get)
+        with pytest.raises(ChMeetingsReadError):
+            chm_connector.get_people({"page_size": 2})
+
+    assert chm_connector.last_get_people_status == "failed"
+    assert call_count["n"] == 2
 
 
 def test_get_people_request_params(chm_connector, mocker):

--- a/middleware/tests/test_group_assignment.py
+++ b/middleware/tests/test_group_assignment.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock
 # Ensure the middleware package root is importable (mirrors conftest.py / pytest.ini)
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
+from chmeetings.backend_connector import ChMeetingsReadError
 from group_assignment import (
     assign_people_to_church_team_groups,
     audit_form_people,
@@ -1175,3 +1176,46 @@ def test_repair_form_people_blocks_duplicate_source_submissions(mock_connector, 
     audit_file = tmp_path / "form_people_repair.xlsx"
     df = pd.read_excel(audit_file)
     assert set(df["Outcome"]) == {"blocked_duplicate_source"}
+
+
+# ---------------------------------------------------------------------------
+# ChMeetingsReadError handling — a mid-pagination ChMeetings read failure must
+# not crash these operator commands (daily-run.bat runs assign-groups
+# unattended); it must be logged and reported as a clean failure instead.
+# ---------------------------------------------------------------------------
+
+def test_assign_people_to_church_team_groups_returns_false_on_get_people_read_error(mock_connector):
+    """A mid-pagination ChMeetings read failure must be a clean False, not a crash."""
+    mock_connector.get_people.side_effect = ChMeetingsReadError("page 2 connection dropped")
+
+    result = assign_people_to_church_team_groups(dry_run=False)
+
+    assert result is False
+    mock_connector.get_groups.assert_not_called()
+    mock_connector.add_person_to_group.assert_not_called()
+
+
+def test_audit_form_people_returns_false_on_get_people_read_error(mock_connector, tmp_path):
+    """A mid-pagination ChMeetings read failure must be a clean False, not a crash."""
+    mock_connector.get_people.side_effect = ChMeetingsReadError("page 2 connection dropped")
+
+    source_file = tmp_path / "individual.xlsx"
+    pd.DataFrame([_individual_row()]).to_excel(source_file, index=False)
+
+    result = audit_form_people(str(source_file))
+
+    assert result is False
+
+
+def test_repair_form_people_returns_empty_on_get_people_read_error(mock_connector, tmp_path):
+    """A mid-pagination ChMeetings read failure must be a clean empty result, not a crash."""
+    mock_connector.get_people.side_effect = ChMeetingsReadError("page 2 connection dropped")
+
+    source_file = tmp_path / "individual.xlsx"
+    pd.DataFrame([_individual_row()]).to_excel(source_file, index=False)
+
+    counts = repair_form_people(str(source_file), dry_run=True)
+
+    assert counts["created"] == 0
+    assert counts["linked"] == 0
+    mock_connector.create_person.assert_not_called()

--- a/middleware/tests/test_sync_manager.py
+++ b/middleware/tests/test_sync_manager.py
@@ -1983,6 +1983,38 @@ def test_sync_participants_skips_orphaned_group_membership(sync_manager, mocker)
 # All three tests are pure mock tests (no LIVE_TEST guard needed).
 # ---------------------------------------------------------------------------
 
+def test_sync_participants_fails_when_group_member_read_fails(sync_manager, mocker):
+    """A failed ChMeetings Team group member read must not look like an empty group."""
+    mocker.patch("sync.participants.Config.TEAM_PREFIX", "Team")
+
+    mocker.patch.object(
+        sync_manager.wordpress_connector,
+        "get_churches",
+        return_value=[{"church_code": "RPC", "church_id": 1, "pastor_email": "pastor@rpc.org"}],
+    )
+    mocker.patch.object(
+        sync_manager.chm_connector,
+        "get_groups",
+        return_value=[{"id": "870578", "name": "Team RPC"}],
+    )
+
+    def failed_group_people(_group_id):
+        sync_manager.chm_connector.last_get_group_people_status = "failed"
+        return []
+
+    mocker.patch.object(
+        sync_manager.chm_connector,
+        "get_group_people",
+        side_effect=failed_group_people,
+    )
+    get_person = mocker.patch.object(sync_manager.chm_connector, "get_person")
+
+    result = sync_manager.sync_participants()
+
+    assert result is False
+    get_person.assert_not_called()
+
+
 def test_sync_approvals_api_happy(sync_manager, mocker):
     """Happy path: 2 approved participants → add_person_to_group called twice,
     both marked synced in WordPress."""

--- a/middleware/tests/test_wordpress_connector.py
+++ b/middleware/tests/test_wordpress_connector.py
@@ -384,6 +384,33 @@ def test_get_rosters_raises_retry_error_after_exhausted_attempts(wp_connector, m
         wp_connector.get_rosters({"participant_id": 42})
 
 
+def test_get_roster_raises_retry_error_after_exhausted_connection_errors(wp_connector, mocker):
+    """get_roster() should retry connection errors without referencing an unset response."""
+    mocker.patch("time.sleep")
+    mocker.patch.object(wp_connector.session, "get", side_effect=_connection_error())
+
+    with pytest.raises(RetryError):
+        wp_connector.get_roster(77)
+
+    assert wp_connector.last_get_roster_status == "failed"
+
+
+def test_get_roster_returns_none_on_404_without_retry(wp_connector, mocker):
+    """A missing roster is a true not-found result, not a transient read failure."""
+    mocker.patch("time.sleep")
+
+    missing_response = mocker.Mock()
+    missing_response.status_code = 404
+
+    mock_get = mocker.patch.object(wp_connector.session, "get", return_value=missing_response)
+
+    result = wp_connector.get_roster(77)
+
+    assert result is None
+    assert wp_connector.last_get_roster_status == "not_found"
+    assert mock_get.call_count == 1
+
+
 def test_get_participants_retries_on_transient_disconnect(wp_connector, mocker):
     """get_participants() retries on ConnectionError and returns data on recovery."""
     mocker.patch("time.sleep")

--- a/middleware/wordpress/frontend_connector.py
+++ b/middleware/wordpress/frontend_connector.py
@@ -54,6 +54,7 @@ class WordPressConnector:
         self.total_participants = 0
         self.total_participant_pages = 0
         self.last_get_rosters_status = "unknown"
+        self.last_get_roster_status = "unknown"
         self.last_get_approvals_status = "unknown"
         self.last_get_validation_issues_status = "unknown"
         self.last_update_validation_issue_status = "unknown"
@@ -315,17 +316,23 @@ class WordPressConnector:
                 raise  # Let retry handle transient failures.
             return []
             
+    @retry(**_WP_READ_RETRY)
     def get_roster(self, roster_id: int) -> Optional[Dict[str, Any]]:
         """Get a specific roster by ID from WordPress."""
         try:
             response = self.session.get(f"{self.custom_api_url}/rosters/{roster_id}")
+            if response.status_code == 404:
+                self.last_get_roster_status = "not_found"
+                logger.warning(f"Roster {roster_id} not found")
+                return None
             response.raise_for_status()
+            self.last_get_roster_status = "ok"
             return response.json()
         except requests.RequestException as e:
-            if response.status_code == 404:
-                logger.warning(f"Roster {roster_id} not found")
-            else:
-                logger.error(f"Failed to get roster {roster_id}: {str(e)}")
+            self.last_get_roster_status = "failed"
+            logger.error(f"Failed to get roster {roster_id}: {str(e)}")
+            if _is_retryable_wp_read_exception(e):
+                raise
             return None            
             
 ## Newer code:


### PR DESCRIPTION
## Summary
- raise a ChMeetingsReadError when paginated people reads fail mid-stream instead of returning partial data
- make full participant sync return failure when a Team group member read fails
- make WordPress get_roster retry transient read failures while preserving 404 as not_found
- add regression tests for all three issue paths

## Validation
- .\.venv\Scripts\python.exe -m pytest tests\test_chmeetings_connector.py::test_get_people_page_two_failure_raises_instead_of_returning_partial tests\test_sync_manager.py::test_sync_participants_fails_when_group_member_read_fails tests\test_wordpress_connector.py::test_get_roster_raises_retry_error_after_exhausted_connection_errors tests\test_wordpress_connector.py::test_get_roster_returns_none_on_404_without_retry -q
- .\.venv\Scripts\python.exe -m pytest tests\test_chmeetings_connector.py tests\test_sync_manager.py tests\test_wordpress_connector.py -q
- .\.venv\Scripts\python.exe -m pytest tests -q