### PR TITLE
docs: 2025 retrospective and retrospectives index

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,12 @@ vaysf/
 │   ├── SEASON_TRANSITION.md
 │   ├── CHMEETINGS_API_MIGRATION.md
 │   ├── TROUBLESHOOTING.md
-│   └── CONTRIBUTING.md
+│   ├── CONTRIBUTING.md
+│   ├── RETROSPECTIVES.md            # index + reading order for the four retrospectives below
+│   ├── RETROSPECTIVE_PODIO_2016_2024.md  # Podio/Globiflow era, pre-repo history
+│   ├── RETROSPECTIVE_2025.md        # season one: the rebuild off Podio
+│   ├── RETROSPECTIVE_2026.md        # canonical 2026 season record
+│   └── RETROSPECTIVE_2026_COMPANION.md   # independent 2026 reflection
 ├── middleware/                      # Python, all middleware code lives here
 │   ├── .env.template                # committed; real .env is gitignored
 │   ├── requirements.txt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,12 @@ vaysf/
 │   ├── SEASON_TRANSITION.md
 │   ├── CHMEETINGS_API_MIGRATION.md
 │   ├── TROUBLESHOOTING.md
-│   └── CONTRIBUTING.md
+│   ├── CONTRIBUTING.md
+│   ├── RETROSPECTIVES.md            # index + reading order for the four retrospectives below
+│   ├── RETROSPECTIVE_PODIO_2016_2024.md  # Podio/Globiflow era, pre-repo history
+│   ├── RETROSPECTIVE_2025.md        # season one: the rebuild off Podio
+│   ├── RETROSPECTIVE_2026.md        # canonical 2026 season record
+│   └── RETROSPECTIVE_2026_COMPANION.md   # independent 2026 reflection
 ├── middleware/                      # Python, all middleware code lives here
 │   ├── .env.template                # committed; real .env is gitignored
 │   ├── requirements.txt

--- a/README.md
+++ b/README.md
@@ -140,6 +140,10 @@ For detailed setup and usage instructions, see the [Installation Guide](docs/INS
 - [Contributing](docs/CONTRIBUTING.md)
 - [2026 Architecture Review](docs/ARCHITECTURE_REVIEW_2026.md)
 
+### Project history
+
+- [Retrospectives index](docs/RETROSPECTIVES.md) — narrative history of the system from 2016 to 2026, covering the Podio/Globiflow era, the 2025 rebuild, and the 2026 season. Start here for *how the system got this way*; see the Architecture Review for *what it is now*.
+
 ## Project Status
 
 The system is actively maintained and in production for Sports Fest 2026. Current release: **v1.12** (2026-07-18), with WordPress plugin **1.0.46** — see [CHANGELOG.md](CHANGELOG.md) for the full history. All core functionality is implemented and tested (889 tests in mock mode):

--- a/docs/RETROSPECTIVES.md
+++ b/docs/RETROSPECTIVES.md
@@ -1,0 +1,73 @@
+# Sports Fest Retrospectives — Index
+
+Narrative records of how this system got built, covering 2016 through 2026.
+These are history, not specification: for the technical state of the system read
+`ARCHITECTURE_REVIEW_2026.md`, and for how to operate it read `USAGE.md` and
+`SCHEDULE-HOW-TO.md`.
+
+## The series
+
+| Document | Era | Drafted by | Reconstructed from |
+|---|---|---|---|
+| [`RETROSPECTIVE_PODIO_2016_2024.md`](RETROSPECTIVE_PODIO_2016_2024.md) | 2016–2024 | Codex | Podio workspace + Globiflow XML archaeology |
+| [`RETROSPECTIVE_2025.md`](RETROSPECTIVE_2025.md) | 2025 | Claude | 61 commits, CHANGELOG 0.1–1.04, the 2025 docs tree |
+| [`RETROSPECTIVE_2026.md`](RETROSPECTIVE_2026.md) | 2026 (canonical) | Claude | 544 commits, 191 issues, release history |
+| [`RETROSPECTIVE_2026_COMPANION.md`](RETROSPECTIVE_2026_COMPANION.md) | 2026 (companion) | Codex | Independent reflection, same season |
+
+All four were reviewed and approved by Bumble.
+
+## Reading order
+
+Chronological is the right order — the arc only makes sense forward.
+
+1. **`RETROSPECTIVE_PODIO_2016_2024.md`** — Access, then Podio and Globiflow.
+   Nine seasons of accumulated operational knowledge, and the specific ways a
+   platform-configured system becomes brittle: meaning hidden in display labels,
+   validation buried in 128-step visual flows, annual behavior copied forward
+   instead of versioned. Read this first; much of what follows is a set of
+   countermeasures to it.
+2. **`RETROSPECTIVE_2025.md`** — year one of the replacement. A good architecture
+   designed largely before the repository existed, carried by manual Excel loops,
+   Selenium, and an operator standing in the middle of it.
+3. **`RETROSPECTIVE_2026.md`** — the season the system grew up. Seven dated acts,
+   the CP-SAT solver that became a validator, and the identity problems that
+   define the 2027 backlog. This is the canonical 2026 record.
+4. **`RETROSPECTIVE_2026_COMPANION.md`** — a second reading of 2026 written the
+   same morning. Preserved as an independent view and as provenance for findings
+   folded into the canonical document, most importantly the Track & Field
+   boundary.
+
+If you only read one, read `RETROSPECTIVE_2026.md`. If you are deciding what to
+build next, read the Podio document's *Open Migration Questions* alongside the
+2026 document's *What 2027 inherits* — together they are the real backlog.
+
+## The through-line
+
+Each era solved the previous era's binding constraint and created the next one.
+
+| Era | What it solved | What it left |
+|---|---|---|
+| Access | A custom database VAY controlled | Local files, desktop-only, no distribution |
+| Podio + Globiflow | Cloud access for many churches and volunteers | Logic in platform config, no source control, no canonical identity |
+| 2025 `vaysf` | Source-controlled rules, tested validation, API-first sync | Manual Excel loops, no CI, no tags, one load-bearing operator |
+| 2026 `vaysf` | Scheduling, live scoring, results, public display | Identity drift, scheduling cockpit, Track & Field intake |
+
+Two themes recur across all four documents and are worth naming directly:
+
+- **Automation is only honest where the source of truth exists.** Track & Field
+  in 2026 is the clean case study; the Podio-era `Ping Pong` / `Table Tennis`
+  label hack is the same lesson wearing different clothes.
+- **Human authority was never the obstacle.** Unstructured capture of that
+  authority was — in Globiflow flow chains, in coordinator spreadsheets, in
+  colored cells. Every era's biggest pain traces back to a decision that was made
+  well and recorded badly.
+
+## Conventions
+
+- Named for the **era** they cover, not the tool that drafted them. Authorship and
+  review status live in each document's header.
+- Reconstructed from evidence — commits, issues, exported XML, changelogs — with
+  inference marked inline as inference.
+- No participant names, contact details, or other personal data.
+- Historical records. When a claim is superseded, correct it in place and note
+  the correction rather than silently rewriting the past.

--- a/docs/RETROSPECTIVE_2025.md
+++ b/docs/RETROSPECTIVE_2025.md
@@ -4,16 +4,23 @@
 2025-07-17, the CHANGELOG's version history back to 2025-03-10, and the shape
 of what 2026 inherited.*
 
-*This is the prequel to `CLAUDE_RETROSPECTIVE_2026.md`. That document opens with
-ChMeetings pulling its API out from under a working system. This one explains
-what that system was, how it got built, and why so much of 2026's spring was
-spent paying its debts.*
+*Drafted by Claude; reviewed and approved by Bumble.*
 
-The central achievement of 2025 was not full automation. It was turning an
-operation carried in screens, spreadsheets, email threads, and one person's
-memory into a shared memory surface: this participant exists; this church owns
-the record; these are the sports and validation issues; this approval is pending.
-That first act of making the work legible is what later automation had to build on.
+*This sits between two other records. `RETROSPECTIVE_PODIO_2016_2024.md` covers
+the nine seasons before this repository existed, when Sports Fest ran on Podio
+and Globiflow. `RETROSPECTIVE_2026.md` opens with ChMeetings pulling its API out
+from under a working system. This one explains what that system was, how it got
+built, and why so much of 2026's spring was spent paying its debts. See
+`RETROSPECTIVES.md` for the full series and reading order.*
+
+The central achievement of 2025 was not full automation. It was moving Sports
+Fest's operational memory onto infrastructure VAY owned end to end — this
+participant exists; this church owns the record; these are the sports and
+validation issues; this approval is pending — and making the *rules* behind that
+memory readable, testable, and versioned for the first time. Podio had held the
+records for nine years; what it could not hold was its own logic in a form anyone
+could review. That act of making the work legible is what later automation had to
+build on.
 
 ---
 
@@ -49,6 +56,19 @@ to whatever the season broke next, and then silence.
 The most important fact about the pre-2026 codebase is that its design does not
 appear in the repository at all.
 
+Two things sit outside git here, and they are different in kind. The first is
+**nine seasons of prior operation**: from roughly 2016 through 2024, Sports Fest
+ran on Podio and Globiflow, and before that on Microsoft Access. That system knew
+what the tournament was — churches, athletes, pastors, church reps, signatures,
+medical releases, badges, rosters, score sheets, gyms, fees, deadlines,
+volunteers, Bible verses — and it is documented separately in
+`RETROSPECTIVE_PODIO_2016_2024.md`. This repository did not invent the domain. It
+inherited it.
+
+The second is the **eighteen days in March 2025** when that inherited knowledge
+was translated into a new architecture, in conversation, before a repository
+existed to record it.
+
 `CHANGELOG.md` documents ten versions — 0.1 through 1.00 — dated March 10
 through March 28, 2025. The repository's first commit is March 28. Every one of
 those versions predates version control:
@@ -77,8 +97,17 @@ This is the sharpest contrast with 2026. The 2026 retrospective could be written
 *because* 191 issues carried their own argument. The 2025 design phase left ten
 bullet lists.
 
-**What this act was really about:** the system was designed somewhere git could
-not see.
+It is worth being precise about what was lost and what was not. The *domain*
+knowledge was not lost — it had been accumulating in Podio since 2016 and was
+still running the 2024 season. What vanished was the **translation layer**: the
+reasoning that turned a decade of no-code operational practice into a three-tier
+architecture with JSON validation and a `church_code` key. Why the schema went
+from 11 tables to 8 in a single day, why email moved tiers, why `church_code`
+displaced `church_id` — those were the decisions that converted inherited
+experience into a new shape, and they are the ones with no record.
+
+**What this act was really about:** a decade of operational knowledge being
+translated into a new architecture, somewhere git could not see.
 
 ---
 
@@ -116,17 +145,27 @@ WordPress owning tokens and email. All five survive intact into 2026 — the 202
 retrospective's "What Held" section is, almost entirely, a list of decisions made
 before this repository existed.
 
-The 1.0 release also gave Sports Fest something it had not previously possessed:
-a shared place to remember operational truth. The bridge could now hold a
-participant, church ownership, sports, validation issues, roster membership, and
-pastoral approval state together. It did not eliminate the clipboard world, but
-it began replacing scattered recollection with a common record.
+The 1.0 release re-established, on a new stack, something Sports Fest had held
+since 2016 and could not afford to lose: a shared place to remember operational
+truth. Podio had provided that for nine seasons — visible records, configurable
+views, comments and files beside the data. The 2025 bridge had to earn it back
+from zero, and at first it held less: a participant, church ownership, sports,
+validation issues, roster membership, and pastoral approval state, together in
+one record. What it added was not the idea of shared memory but a place where
+that memory's *rules* could be read, tested, and versioned.
 
-It arrived fully formed because it had been fully designed elsewhere. That is
-the strength and the weakness in the same sentence.
+That is the honest frame for the whole year. 2025 was not a first system. It was
+a **replacement in its first season**, competing against a decade-matured
+incumbent that still did document generation, badges, and e-signature better than
+the new one would for years.
+
+It arrived fully formed because it had been fully designed elsewhere — and
+because the domain had been understood for nine years before that. That is the
+strength and the weakness in the same sentence.
 
 **What this act was really about:** a good architecture arriving without its
-reasoning attached, and manual operations gaining their first shared memory.
+reasoning attached, and a decade-old operation beginning its move onto rails that
+could be versioned.
 
 ---
 
@@ -290,7 +329,7 @@ Nearly everything structural, which is the striking part.
 - **`church_code` as the human-readable identifier**, with `church_id` kept as the database key.
 - **WordPress owning tokens and email**, moved there in v0.4 for "better process flow" — the decision that later let WordPress absorb the entire event-day arena.
 - **The Excel export as a staff-facing artifact.** As an output and review surface, it met volunteers where they were; in 2026 it grew into a diagnostic instrument.
-- **The first shared memory surface.** Participants, churches, rosters, validation, and approval state became parts of one operational record instead of facts scattered across screens and personal memory.
+- **A shared memory surface, rebuilt on owned infrastructure.** Participants, churches, rosters, validation, and approval state became one operational record again — this time in a place where the rules behind it could be read, tested, and versioned.
 
 ## What bent
 
@@ -314,6 +353,7 @@ Nearly everything structural, which is the striking part.
 8. **Agents need a legible repository more than they need a better model.** Codex was here in June 2025 and fixed README links, because that was all the repository could describe of itself.
 9. **Annual software still needs a heartbeat.** Eight dormant months turned a vendor API change into a 77-commit emergency.
 10. **Tag the thing that ran the event.** Four releases ran a real tournament and none of them are findable in git.
+11. **A first season is not a first system.** 2025 replaced a decade-matured incumbent. Judged as a greenfield build it looks thin; judged as year one of a migration off nine years of Podio and Globiflow, the surprise is how much of the domain it already had right.
 
 ---
 
@@ -353,6 +393,16 @@ before this repository existed, and required no structural change to absorb
 scheduling, badges, scoresheets, live scoring, and public advancement displays a
 year later. That is an unusually good call, made early, by someone thinking
 carefully without a tool watching.
+
+It was also not a guess. Nine years of Podio had already established what the
+tournament needed and, more usefully, where a platform-configured system breaks:
+meaning hidden in display labels, logic parsed out of category text, validation
+buried in long visual flow chains, annual behavior copied forward instead of
+versioned. Read against `RETROSPECTIVE_PODIO_2016_2024.md`, the March 2025
+architecture looks less like inspiration and more like a set of deliberate
+countermeasures — `CHM_FIELDS` against label-encoded meaning, JSON rules against
+flow-buried validation, git against copy-forward configuration. The good call was
+real. It was also informed.
 
 Nor should the manual character of 2025 be mistaken for absence of progress.
 The system learned the real tournament before it tried to optimize it. It

--- a/docs/RETROSPECTIVE_2025.md
+++ b/docs/RETROSPECTIVE_2025.md
@@ -1,0 +1,337 @@
+# Retrospective — Sports Fest 2025 and the Pre-2026 Era
+
+*Written 2026-07-27, reconstructed from the 61 commits between 2025-03-28 and
+2025-07-17, the CHANGELOG's version history back to 2025-03-10, and the shape
+of what 2026 inherited.*
+
+*This is the prequel to `CLAUDE_RETROSPECTIVE_2026.md`. That document opens with
+ChMeetings pulling its API out from under a working system. This one explains
+what that system was, how it got built, and why so much of 2026's spring was
+spent paying its debts.*
+
+---
+
+## By the numbers
+
+| | |
+|---|---|
+| Commits | **61** (2025-03-28 → 2025-07-17) — vs. 544 in 2026 |
+| Churn | **+15,303 / −1,325** across 43 files — vs. 196 files in 2026 |
+| Net tree growth | **+13,782 / −3** — near-pure accretion |
+| Issues referenced | **21**, spanning #1–#50 |
+| Versions | **0.1 → 1.04** |
+| Tests | **23** — vs. 889 in 2026 |
+| Git tags | **0** |
+| CI workflows | **0** |
+| Contributors | **3** |
+| Dormancy | **8 months** (2025-07-17 → 2026-03-13) |
+
+Commits by month:
+
+| Mar | Apr | May | Jun | Jul | Aug–Feb |
+|---:|---:|---:|---:|---:|---:|
+| 15 | 6 | 21 | 6 | 13 | 0 |
+
+Fifteen of those March commits landed on a single day. The curve is not a
+development arc — it is one large deposit followed by four months of reacting
+to whatever the season broke next, and then silence.
+
+---
+
+## Act 0 — The era before git (Mar 10 – Mar 27, 2025)
+
+The most important fact about the pre-2026 codebase is that its design does not
+appear in the repository at all.
+
+`CHANGELOG.md` documents ten versions — 0.1 through 1.00 — dated March 10
+through March 28, 2025. The repository's first commit is March 28. Every one of
+those versions predates version control:
+
+| Version | Date | What it records |
+|---|---|---|
+| 0.1 | Mar 10 | Three-tier architecture, 11 WordPress tables, core workflows |
+| 0.2 | Mar 11 | Schema simplified 11 → 8 tables, field mappings from real CSV |
+| 0.3 | Mar 12 | Windows setup, database schema, implementation phases |
+| 0.4 | Mar 13 | Email moved from Python to WordPress, `sf_email_log` |
+| 0.5 | Mar 14 | `church_code` as human-readable identifier |
+| 0.6 | Mar 15 | PyTest, mocking convention, `LIVE_TEST` toggle |
+| 0.7 | Mar 17 | `sf_rosters` table, team-level validation |
+| 0.8 | Mar 21 | Pydantic, rule-based validation |
+| 0.9 | Mar 26 | JSON validation rules, ERROR/WARNING/INFO severity |
+| 1.00 | Mar 28 | Consolidated into final implementation |
+
+Eighteen days of architecture — including decisions still load-bearing today —
+happened in conversation and landed as prose. The schema going from 11 tables to
+8 in one day, email relocating tiers on another, `church_code` displacing
+`church_id` as the operator-facing identifier on a third: these are real design
+iterations with real reasoning behind them, and none of that reasoning survives.
+Only the conclusions do.
+
+This is the sharpest contrast with 2026. The 2026 retrospective could be written
+*because* 191 issues carried their own argument. The 2025 design phase left ten
+bullet lists.
+
+**What this act was really about:** the system was designed somewhere git could
+not see.
+
+---
+
+## Act I — The landing (Mar 28, 2025, 15 commits in one day)
+
+The repository was not grown. It was transcribed.
+
+Fifteen commits on March 28 deposited roughly 13,000 lines: docs first
+(ARCHITECTURE, CONTRIBUTING, INSTALLATION, TROUBLESHOOTING, USAGE), then config,
+then the connectors, then a single "RC commit for 1.0 release" carrying 8,800+
+lines — the entire WordPress plugin, the validation package, the sync package,
+and all the tests, in one commit.
+
+The transcription shows its seams, and they are worth recording precisely
+because they are the fingerprints of the workflow:
+
+- **`95bc75f "Add unit tests for Sports Fest middleware configuration module"`**
+  contains `middleware/main.py`, 299 lines. No tests. The message describes what
+  was *meant* to go in; the paste buffer held something else.
+- **`dddc01e "No code changes made."`** contains `docs/ARCHITECTURE.md`, 540
+  lines — the single most consequential document of the era, committed under a
+  message asserting that nothing happened.
+- **`middleware/wordpress/frontend_connector.104`** was committed alongside
+  `frontend_connector.py` — 489 lines beside 502. A save-as backup, versioned by
+  filename, that lived in the repository from March 28 until July 14, nearly four
+  months. It was removed silently in a commit about adding spreadsheet columns.
+
+Net tree growth across all of 2025 was **+13,782 / −3**. Three lines removed.
+Whatever went in, stayed in.
+
+The architecture that landed that day was, to its credit, the right one. Three
+tiers with narrow jobs. JSON-driven validation with Pydantic models. Mock-mode
+tests with a `LIVE_TEST` toggle. `church_code` as the human-readable key.
+WordPress owning tokens and email. All five survive intact into 2026 — the 2026
+retrospective's "What Held" section is, almost entirely, a list of decisions made
+before this repository existed.
+
+It arrived fully formed because it had been fully designed elsewhere. That is
+the strength and the weakness in the same sentence.
+
+**What this act was really about:** a good architecture arriving without its
+reasoning attached.
+
+---
+
+## Act II — Season one, under fire (Apr 2 – Jul 17, 2025, 46 commits)
+
+Then real registrations arrived, and the system met its users.
+
+The issue numbers tell the story better than the code does. Issue **#1** —
+*"Click Approve on Pastor Approval Email leads to error screen"* — is the first
+thing that happened after launch, and it took two commits on the same day, both
+with the identical message, to put down. The approval path, the single feature
+the entire system existed to provide, was broken in production on day one.
+
+What followed, in order:
+
+- **#4** — approved athletes not showing correct approval status; fixed by
+  removing pagination on the WordPress ID search, then re-doing participant sync
+  so it would stop overwriting `approval_status`
+- **#12** — a minor's record never reaching pastoral approval because a consent
+  ERROR never got updated
+- **#23** — partner names not recorded on `sf_roster`
+- **#32** — *"Not everyone from NHC church show up on Pastoral Approval emails"* —
+  a pagination bug, the same class of bug that #58 would rebuild around
+  `total_count` a year later
+- **#33** — non-members displaying as `Yes` for church membership on the approval
+  email, fixed twice in one day
+- **#42** — resend approval email reusing expired tokens
+- **#50** — a male athlete registered for Women's Volleyball landing on the wrong
+  roster team
+
+Read as a set, these are all one bug: **the system could not be trusted to tell
+a pastor the truth about who they were approving.** Wrong membership status,
+missing minors, missing churches, wrong gendered team, dead approval links. The
+2026 retrospective describes issue #78 — the membership freeze — as "the first
+place this system stopped assuming everyone using it was acting in good faith."
+2025 is the year it could not yet reliably serve users acting in *perfect* good
+faith.
+
+Two other things stand out about how this work was done.
+
+**Debugging ran on human reports.** Branch names are the evidence:
+`4-check-on-pending-approval-status-with-james`,
+`codex/locate-approval-email-for-matthew-demegillo`. Commit messages name
+participants — *"Check for Jasen Pham and Matthew Demegillo who registered for
+Scripture Memorization."* There was no monitoring, no reconciliation report, no
+audit command. A problem became visible when a person noticed and said something.
+The 2026 Church Team export becoming a "diagnostic instrument" is the direct
+answer to this, and it is why that mattered.
+
+**The operator was the integration layer.** `run-me.bat` is two lines:
+
+```
+python main.py sync --type full
+python main.py export-church-teams
+```
+
+Everything else was hands. `USAGE.md` states it plainly at line 146: *"After
+running this command, you should import the generated file into ChMeetings (or
+manually add the people to groups)."* Group assignment generated a spreadsheet
+for a human to re-upload. Churches entered through
+`sync-churches --file "data/Church Application Form.xlsx"`. Consent verification
+was a manual check. Per ChMeetings ticket #11991, forms that failed to
+auto-link had to be connected by hand. The Photo column shipped with an
+instruction to press Ctrl+H in Excel to repair the formula the exporter wrote.
+
+And underneath it all, `backend_connector.py` opened Chrome — Selenium login,
+`WebDriverWait`, `find_element(By.ID, "password")`, and a `save_screenshot()`
+call for when authentication failed. Screenshots as a debugging channel.
+
+**What this act was really about:** a system that worked, provided a person
+stood in the middle of it.
+
+---
+
+## Act III — The first agent (June 2025)
+
+Your recollection is that this era ran on manual copy-paste with no agentic
+tooling. The first half is right, and the evidence is stronger than memory
+suggests. The second half is not quite.
+
+Four merged branches carry the `codex/` prefix:
+
+| PR | Date | Branch |
+|---|---|---|
+| #37 | Jun 5 | `codex/update-readme-links-to-docs-directory` |
+| #38 | Jun 6 | `codex/find-and-fix-bug-in-codebase` |
+| #39 | Jun 6 | `codex/update-person_id-in-test` |
+| #43 | Jul 14 | `codex/locate-approval-email-for-matthew-demegillo` |
+
+Agentic tooling entered this repository in **June 2025**, not 2026. But look at
+the scope: fix README links, fix a config default for tests, correct a person ID
+in a test, find one participant's approval email. Small, bounded, verifiable in
+seconds. Meanwhile the 2,374-line `rest-api.php` and the 554-line sync manager
+were hand-carried.
+
+That is the honest characterization of the era. Not "no agents" — rather, agents
+were trusted with errands while the load-bearing work stayed manual. There was
+also no context for an agent to work from: no `CLAUDE.md`, no `AGENTS.md`, no
+skill, no convention document beyond `CONTRIBUTING.md`. The repository could not
+tell a tool what it was.
+
+Compare the same repository today: a `CLAUDE.md` establishing tenant scope and
+conventions, an `AGENTS.md` kept in sync with it, a vendored `vay-chmeetings`
+skill shared across three projects, and a documented rule that `CHM_FIELDS` is
+the only way to name a ChMeetings field. The 2026 leverage did not come from
+better models alone. It came from a repository that had been made legible.
+
+**What this act was really about:** the tooling arrived a year before the
+groundwork that would let it matter.
+
+---
+
+## Act IV — The silence (Jul 17, 2025 – Mar 13, 2026)
+
+Eight months. Zero commits.
+
+The last 2025 commit fixes gendered team mapping four days before the event. Then
+the repository stops. `CHANGELOG.md` declares *"Version 1.04 (2025-07-17)"* — but
+the commit that actually finalizes v1.04 is dated **2026-03-13**, eight months
+after the version it closes. The season ended mid-sentence and the note was
+written the following spring.
+
+Nothing was tagged. There is no `v1.04` in `git tag` — the first tag in this
+repository's history is **v1.08, April 2026**. Four releases shipped and ran a
+real tournament without a single one being marked in git. The 2026 retrospective
+records plugin release discipline "bending under hotfix pressure" in July 2026;
+the truthful version is that it had no baseline to bend from.
+
+The dormancy is not a criticism. This is volunteer ministry software with one
+primary author and an annual event. But it explains the shape of 2026: when
+ChMeetings changed its API over the winter, there was nobody watching, and the
+season opened with 77 commits of pure repair.
+
+**What this act was really about:** an annual system discovering that its
+dependencies do not take the year off.
+
+---
+
+## What held
+
+Nearly everything structural, which is the striking part.
+
+- **The three-tier architecture.** Designed in the pre-git phase, unbroken through two seasons.
+- **JSON-driven validation with Pydantic.** `Summer_2025.json` was joined by `summer_2026.json`; the mechanism never changed.
+- **Mock-mode testing with a `LIVE_TEST` toggle.** 23 tests became 889 on the same convention, laid down in v0.6 on March 15, 2025.
+- **`church_code` as the human-readable identifier**, with `church_id` kept as the database key.
+- **WordPress owning tokens and email**, moved there in v0.4 for "better process flow" — the decision that later let WordPress absorb the entire event-day arena.
+- **The Excel export as staff-facing artifact**, which in 2026 grew into a diagnostic instrument.
+
+## What bent
+
+- **Selenium**, present from the first connector commit, removed root and branch in 2026's v1.05.
+- **Excel as a workflow stage** rather than an output — church intake, group assignment, and consent all round-tripped through a human and a spreadsheet.
+- **Pagination**, wrong in #32 in May 2025 and still wrong enough to need rebuilding around `total_count` in #58 a year later.
+- **Commit hygiene** — `"asdf"`, `"Config"`, `"No code changes made."`, `"Simple change to test push permission"`, the same fix committed twice under one message, `"Total Denided"` corrected by a follow-up commit.
+- **Release discipline**, which did not exist: no tags, no CI, no lint, a version declared eight months before it was finalized.
+- **The dependency list**, which shipped `uuid>=1.30` on day one.
+
+## What we learned
+
+1. **Designing outside version control costs the reasoning, not the design.** The architecture was right and survived two seasons. Why the schema went 11 tables to 8 is simply gone.
+2. **A commit message that does not match its diff is a workflow smell.** Files pasted one at a time produce messages describing intent rather than content.
+3. **Manual re-import loops are where seasons are lost.** "Generate a spreadsheet, then upload it yourself" is a step that fails silently and only on the busiest day.
+4. **Without monitoring, your bug tracker is a list of people who complained.** Branches named after participants are a diagnostic gap, not a naming convention.
+5. **Agents need a legible repository more than they need a better model.** Codex was here in June 2025 and fixed README links, because that was all the repository could describe of itself.
+6. **Annual software still needs a heartbeat.** Eight dormant months turned a vendor API change into a 77-commit emergency.
+7. **Tag the thing that ran the event.** Four releases ran a real tournament and none of them are findable in git.
+
+---
+
+## What 2026 inherited
+
+Much of 2026's repair work — most of it in the spring, some as late as the week
+before the event — was paying down debt written in 2025:
+
+| 2026 work | 2025 origin |
+|---|---|
+| Selenium removal (v1.05) | `backend_connector.py`, first connector commit, Mar 28 |
+| `CHM_FIELDS` introduced (v1.05) | Field names inlined throughout the original sync package |
+| Pagination via `total_count` (#58) | The #32 pagination bug, May 2025 |
+| Approval sync moved Excel → API | `sync_churches_from_excel`, Mar 28 |
+| 429 retry centralized (#64) | Retry logic scattered across the pasted connectors |
+| Membership trust boundary (#78) | Membership status editable after the fact since v1.00 |
+| First git tag (v1.08, Apr 2026) | Four untagged 2025 releases |
+| First CI workflow (`php.yml`, Jul 2026) | No automation of any kind in 2025 |
+| `uuid` flagged in the 2026 debt register | `requirements.txt:14`, committed 2025-03-28 |
+
+That last row deserves its own sentence. `ARCHITECTURE_REVIEW_2026.md` flags the
+`uuid` line as a dependency that would break a fresh install. It has been sitting
+at `middleware/requirements.txt:14` since the first requirements file, unchanged,
+through two tournaments — **sixteen months**, still open today as part of #332.
+
+---
+
+## Closing reflection
+
+It is tempting to read 2025 as the rough draft and 2026 as the real thing. The
+commit counts invite it: 61 against 544.
+
+The record does not support that reading. The architecture that carried the 2026
+season — three tiers, JSON validation, mock-mode tests, `church_code`,
+WordPress-owned approval — was designed in eighteen days in March 2025, mostly
+before this repository existed, and required no structural change to absorb
+scheduling, badges, scoresheets, live scoring, and public advancement displays a
+year later. That is an unusually good call, made early, by someone thinking
+carefully without a tool watching.
+
+What 2025 lacked was not judgment. It was **legibility and leverage**. The
+decisions were sound and unrecorded. The operator was load-bearing and
+undocumented. The tests were real but thin. The releases ran a tournament and
+left no marker. Agentic tooling was present and had nothing to grip.
+
+2026's true accomplishment was not the solver, or the plugin, or the 889 tests.
+It was converting a system that lived substantially in one person's head and
+hands into one that could be described — to a collaborator, to a tool, to next
+year. The retrospectives now sitting beside this file are themselves evidence of
+that shift: **2026 can be narrated because 2026 wrote things down.** 2025 has to
+be reconstructed from filename extensions and mismatched commit messages.
+
+That is the real distance traveled between the two seasons.

--- a/docs/RETROSPECTIVE_2025.md
+++ b/docs/RETROSPECTIVE_2025.md
@@ -9,6 +9,12 @@ ChMeetings pulling its API out from under a working system. This one explains
 what that system was, how it got built, and why so much of 2026's spring was
 spent paying its debts.*
 
+The central achievement of 2025 was not full automation. It was turning an
+operation carried in screens, spreadsheets, email threads, and one person's
+memory into a shared memory surface: this participant exists; this church owns
+the record; these are the sports and validation issues; this approval is pending.
+That first act of making the work legible is what later automation had to build on.
+
 ---
 
 ## By the numbers
@@ -110,11 +116,17 @@ WordPress owning tokens and email. All five survive intact into 2026 — the 202
 retrospective's "What Held" section is, almost entirely, a list of decisions made
 before this repository existed.
 
+The 1.0 release also gave Sports Fest something it had not previously possessed:
+a shared place to remember operational truth. The bridge could now hold a
+participant, church ownership, sports, validation issues, roster membership, and
+pastoral approval state together. It did not eliminate the clipboard world, but
+it began replacing scattered recollection with a common record.
+
 It arrived fully formed because it had been fully designed elsewhere. That is
 the strength and the weakness in the same sentence.
 
 **What this act was really about:** a good architecture arriving without its
-reasoning attached.
+reasoning attached, and manual operations gaining their first shared memory.
 
 ---
 
@@ -153,6 +165,12 @@ place this system stopped assuming everyone using it was acting in good faith."
 2025 is the year it could not yet reliably serve users acting in *perfect* good
 faith.
 
+These failures also show that validation and approval were never merely technical
+correctness. They were communication among staff, pastors, church reps, and the
+registration source of truth. A consent error could hide a minor from pastoral
+review. A pagination defect could erase a church from an email. A membership
+flag could misstate the very fact a pastor was being asked to affirm.
+
 Two other things stand out about how this work was done.
 
 **Debugging ran on human reports.** Branch names are the evidence:
@@ -161,8 +179,9 @@ Two other things stand out about how this work was done.
 participants — *"Check for Jasen Pham and Matthew Demegillo who registered for
 Scripture Memorization."* There was no monitoring, no reconciliation report, no
 audit command. A problem became visible when a person noticed and said something.
-The 2026 Church Team export becoming a "diagnostic instrument" is the direct
-answer to this, and it is why that mattered.
+The system learned Sports Fest by following the smoke. The 2026 Church Team
+export becoming a "diagnostic instrument" is the direct answer to this, and it is
+why that mattered.
 
 **The operator was the integration layer.** `run-me.bat` is two lines:
 
@@ -180,12 +199,20 @@ was a manual check. Per ChMeetings ticket #11991, forms that failed to
 auto-link had to be connected by hand. The Photo column shipped with an
 instruction to press Ctrl+H in Excel to repair the formula the exporter wrote.
 
+Excel deserves a precise judgment here. As an **output and review surface**, it
+was humane and effective: Church Reps could inspect, annotate, forward, compare,
+and understand a workbook without learning the system internals. As a **workflow
+stage**, where a generated file had to be repaired, changed, and re-imported, it
+was fragile. Excel was both mercy and debt, depending on which side of that line
+it occupied.
+
 And underneath it all, `backend_connector.py` opened Chrome — Selenium login,
 `WebDriverWait`, `find_element(By.ID, "password")`, and a `save_screenshot()`
 call for when authentication failed. Screenshots as a debugging channel.
 
 **What this act was really about:** a system that worked, provided a person
-stood in the middle of it.
+stood in the middle of it — but one that was already making that person's hidden
+work visible enough to improve.
 
 ---
 
@@ -262,26 +289,31 @@ Nearly everything structural, which is the striking part.
 - **Mock-mode testing with a `LIVE_TEST` toggle.** 23 tests became 889 on the same convention, laid down in v0.6 on March 15, 2025.
 - **`church_code` as the human-readable identifier**, with `church_id` kept as the database key.
 - **WordPress owning tokens and email**, moved there in v0.4 for "better process flow" — the decision that later let WordPress absorb the entire event-day arena.
-- **The Excel export as staff-facing artifact**, which in 2026 grew into a diagnostic instrument.
+- **The Excel export as a staff-facing artifact.** As an output and review surface, it met volunteers where they were; in 2026 it grew into a diagnostic instrument.
+- **The first shared memory surface.** Participants, churches, rosters, validation, and approval state became parts of one operational record instead of facts scattered across screens and personal memory.
 
 ## What bent
 
 - **Selenium**, present from the first connector commit, removed root and branch in 2026's v1.05.
-- **Excel as a workflow stage** rather than an output — church intake, group assignment, and consent all round-tripped through a human and a spreadsheet.
+- **Excel as a workflow stage rather than an output.** Church intake, group assignment, and consent all round-tripped through a human and a spreadsheet. The same format that served people well for review became risky when treated as an intermediate source of truth.
 - **Pagination**, wrong in #32 in May 2025 and still wrong enough to need rebuilding around `total_count` in #58 a year later.
 - **Commit hygiene** — `"asdf"`, `"Config"`, `"No code changes made."`, `"Simple change to test push permission"`, the same fix committed twice under one message, `"Total Denided"` corrected by a follow-up commit.
 - **Release discipline**, which did not exist: no tags, no CI, no lint, a version declared eight months before it was finalized.
 - **The dependency list**, which shipped `uuid>=1.30` on day one.
+- **Operational observability.** Without reconciliation reports or audit commands, human complaints and named-person investigations became the monitoring system.
 
 ## What we learned
 
 1. **Designing outside version control costs the reasoning, not the design.** The architecture was right and survived two seasons. Why the schema went 11 tables to 8 is simply gone.
-2. **A commit message that does not match its diff is a workflow smell.** Files pasted one at a time produce messages describing intent rather than content.
-3. **Manual re-import loops are where seasons are lost.** "Generate a spreadsheet, then upload it yourself" is a step that fails silently and only on the busiest day.
-4. **Without monitoring, your bug tracker is a list of people who complained.** Branches named after participants are a diagnostic gap, not a naming convention.
-5. **Agents need a legible repository more than they need a better model.** Codex was here in June 2025 and fixed README links, because that was all the repository could describe of itself.
-6. **Annual software still needs a heartbeat.** Eight dormant months turned a vendor API change into a 77-commit emergency.
-7. **Tag the thing that ran the event.** Four releases ran a real tournament and none of them are findable in git.
+2. **The first step away from manual work is faithful capture, not complete automation.** Before the system could optimize Sports Fest, it had to name and preserve the workflow people were already carrying.
+3. **A commit message that does not match its diff is a workflow smell.** Files pasted one at a time produce messages describing intent rather than content.
+4. **Excel is a bridge when it is an output and a trap when it becomes a workflow stage.** A workbook can be the right human interface while manual re-import still creates the season's most fragile handoffs.
+5. **Validation is communication, not merely correctness.** Consent, membership, eligibility, approval, and roster state shape what pastors and church reps are being told about real people.
+6. **Without monitoring, your bug tracker is a list of people who complained.** Branches named after participants are a diagnostic gap, not a naming convention.
+7. **Narrow repair tools matter.** A one-participant sync or targeted investigation is operationally safer than rerunning the whole universe to diagnose one record.
+8. **Agents need a legible repository more than they need a better model.** Codex was here in June 2025 and fixed README links, because that was all the repository could describe of itself.
+9. **Annual software still needs a heartbeat.** Eight dormant months turned a vendor API change into a 77-commit emergency.
+10. **Tag the thing that ran the event.** Four releases ran a real tournament and none of them are findable in git.
 
 ---
 
@@ -321,6 +353,14 @@ before this repository existed, and required no structural change to absorb
 scheduling, badges, scoresheets, live scoring, and public advancement displays a
 year later. That is an unusually good call, made early, by someone thinking
 carefully without a tool watching.
+
+Nor should the manual character of 2025 be mistaken for absence of progress.
+The system learned the real tournament before it tried to optimize it. It
+translated hidden labor into fields, rules, states, exports, and repair commands.
+Excel made the operation more visible to volunteers. WordPress gave approval a
+home. Validation turned judgment into a conversation the system could preserve.
+The bridge's first victory was not replacing the operator; it was reducing how
+much of Sports Fest had to exist only in the operator's head.
 
 What 2025 lacked was not judgment. It was **legibility and leverage**. The
 decisions were sound and unrecorded. The operator was load-bearing and


### PR DESCRIPTION
Adds the 2025 season record and the index for the retrospective series. Docs-only, no runtime changes.

| File | |
|---|---|
| `docs/RETROSPECTIVE_2025.md` | new, 427 lines — the 2025 season record |
| `docs/RETROSPECTIVES.md` | new, 73 lines — index and reading order for all four retrospectives |
| `README.md` | adds a Project history link under Documentation |
| `CLAUDE.md` / `AGENTS.md` | adds the retrospectives to the `docs/` tree, kept in sync per repo convention |

`RETROSPECTIVE_2025.md` is reconstructed from the 61 commits between 2025-03-28 and 2025-07-17, the CHANGELOG's pre-git version history back to 2025-03-10, and the 2025 docs tree.

## Why this document is different

#355 could be written because 2026 left 191 issues arguing for themselves. 2025 had to be reconstructed from filename extensions and mismatched commit messages — which turned out to be the finding, not an obstacle.

| | 2025 | 2026 |
|---|---:|---:|
| Commits | 61 | 544 |
| Tests | 23 | 889 |
| Git tags | 0 | 5 |
| CI workflows | 0 | 1 |
| Net tree growth | +13,782 / −3 | +109,329 / −4,914 |

## What the evidence shows

**The design predates the repository.** `CHANGELOG.md` documents ten versions (0.1 → 1.00) dated March 10–28 2025. The first commit is March 28. Eighteen days of architecture — the schema going 11 tables → 8, email moving from Python to WordPress, `church_code` displacing `church_id` — survive only as bullet lists.

**The repo was transcribed, not grown.** Fifteen commits on March 28, ~13,000 lines. `95bc75f "Add unit tests for…configuration module"` contains `main.py` and no tests. `dddc01e "No code changes made."` contains 540 lines of `ARCHITECTURE.md`. `middleware/wordpress/frontend_connector.104` — a save-as backup versioned by filename — lived in the repo from March 28 to July 14.

**Agentic tooling arrived in June 2025, not 2026.** Four merged `codex/` branches (#37, #38, #39, #43), all errands: README links, a test default, a person ID, one participant's email. The 2,374-line `rest-api.php` was hand-carried. No `CLAUDE.md`, no `AGENTS.md`, no skill — the repo couldn't describe itself to a tool.

**The eight-month dormancy** (2025-07-17 → 2026-03-13) explains 2026's spring. `CHANGELOG.md` declares "Version 1.04 (2025-07-17)"; the commit finalizing v1.04 is dated 2026-03-13. No tags exist before v1.08 in April 2026 — four releases ran a real tournament unmarked in git.

The closing section maps 2026 repair work to its 2025 origin, including `uuid>=1.30` at `middleware/requirements.txt:14` — present since the first requirements file, flagged in `ARCHITECTURE_REVIEW_2026.md`, still open in #332 sixteen months and two tournaments later.

## Corrected after the Podio retrospective (#358)

This document was originally written without knowing the Podio era existed, and framed March 2025 as the prehistory. That was wrong. Nine seasons ran on Podio and Globiflow from 2016, and on Microsoft Access before that. `9fd0f37` corrects it:

- Act 0 now separates two things outside git: nine seasons of prior operation, and the eighteen days that translated it into a new architecture. What was lost was the **translation layer**, not the domain knowledge.
- The claim that 1.0 gave Sports Fest its first shared memory surface is corrected — Podio held the records for nine years. What 2025 added was a place where the *rules* behind them could be read, tested, and versioned.
- The year is reframed as a replacement in its first season against a decade-matured incumbent, not a greenfield build.
- The March 2025 architecture is set against Podio's named failure modes: `CHM_FIELDS` against label-encoded meaning, JSON rules against flow-buried validation, git against copy-forward configuration. Countermeasures, not inspiration.

## The index

`docs/RETROSPECTIVES.md` covers all four documents — era, drafting tool, and what each was reconstructed from — plus reading order, an era-by-era table of what each system solved and what it left behind, and the two themes recurring across all of them.

## Related

- #355 — `RETROSPECTIVE_2026.md` and `RETROSPECTIVE_2026_COMPANION.md`
- #358 — `RETROSPECTIVE_PODIO_2016_2024.md`

No conflicts; merge order does not matter. Until #355 and #358 land, the index here links to three files not yet on `main`.

## Reviewer notes

- **Act 0 is inference**, drawn from the gap between changelog dates and commit dates. The conclusion — that the architecture was designed in conversation and landed as prose — fits the evidence but only you can confirm it.
- **Anything outside git is outside what could be checked.** Chat transcripts, email, and the 2025 event itself left no trace in the repository.
- **The central claim is that 2025 lacked legibility and leverage, not judgment.** Worth a check that this is fair rather than flattering.
