### PR TITLE
docs: add Podio era retrospective

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -238,6 +238,7 @@ middleware/logs/
 # Pytest temp and run artifacts
 middleware/temp/
 middleware/.pytest_tmp*/
+middleware/scratch/podio-globiflow-archive-2024/
 middleware/data/*_audit.xlsx
 middleware/data/team_group_*.xlsx
 middleware/data/form_people_repair*.xlsx

--- a/docs/CODEX_RETROSPECTIVE_PODIO_2015_2024.md
+++ b/docs/CODEX_RETROSPECTIVE_PODIO_2015_2024.md
@@ -1,0 +1,374 @@
+# VAYSF Podio Era Retrospective, 2016-2024
+
+## From Access To Podio To `vaysf`
+
+The 2024 Sports Fest season appears to have been the last year when the tournament operated primarily through Podio and Globiflow. That matters historically because Podio was not merely an old database that happened to be replaced. For VAY, it was the cloud bridge between the Microsoft Access era and the current ChMeetings + middleware + WordPress system.
+
+The Access system represented the first era: a locally controlled custom database where one technically capable operator could model churches, athletes, teams, forms, reports, and annual rules. That was powerful, but it was centered on local files, desktop workflows, and manual distribution. It could support a ministry event, but it was not naturally built for many churches, remote representatives, web intake, mobile access, or simultaneous volunteer collaboration.
+
+Podio represented the second era. Around the 2016 Sports Fest cycle, VAY moved the operation into a cloud workspace where church representatives and volunteers could interact with shared records instead of passing spreadsheets and database exports around. In its time, that was a very strong architectural choice. Podio gave a volunteer-run ministry a shared cloud database, public forms, relational-ish records, app views, comments, file attachments, and distributed access before modern no-code platforms became normal. Globiflow then supplied the missing programming layer: triggers, filters, calculations, item updates, PDF generation, emails, SMS messages, webhooks, and e-signature handoffs.
+
+The current `vaysf` system is the third era. It began in 2025 and matured sharply in 2026, but it should be understood as a rebuild-in-progress rather than a completed one-for-one replacement. The 2026 system surpassed Podio in important areas: API sync, source control, validation, scheduling artifacts, event-day score entry, Results Desk review, public results, and issue-tracked release discipline. But it has not yet rebuilt every mature Podio-era capability. Some Podio workflows, especially around registration packets, e-signature document generation, badge production, volunteer SMS/voting, and operator-facing dashboard views, were deeply developed by 2024.
+
+The 2024 artifacts show a system that had accumulated almost ten years of operational intelligence. They also show why the next system had to be built differently. Podio could hold records and make them approachable. Globiflow could automate workflows quickly. But by 2024, Sports Fest needed canonical identity, source-controlled rules, testable validation, explicit schedule/result models, and an event-day UI that was shaped around the tournament itself.
+
+This is not a failure story. It is the story of a good bridge carrying more and more traffic until the organization finally needed a road.
+
+## Why Podio Was The Right Move
+
+The move from Access to Podio was not simply a tooling swap. It was a generational architecture change.
+
+Access gave VAY control. Podio gave VAY distribution.
+
+Access was excellent when the problem was "build a custom local database for a ministry event." Podio was excellent when the problem became "let many churches and volunteers participate in a shared cloud operation." It translated many Access-era ideas into a browser-native form:
+
+- Database became organization/workspace.
+- Table became app.
+- Record became item.
+- Column became field.
+- Data-entry form became Podio form or webform.
+- Relationship became Podio relationship field.
+- Query/report became filtered view.
+- Macro/VBA event became Globiflow workflow.
+- Report output became PDF generation, email, exports, and shared views.
+
+For a volunteer ministry, that was not a small improvement. It meant VAY could operate Sports Fest as a distributed system without first building a custom web application, hosting a database server, managing user authentication, and maintaining a mobile-capable UI.
+
+Podio also matched the way Sports Fest evolved. A sport could be added. A field could be changed. A saved view could be created for a coordinator. A workflow could be copied from last year and adjusted. That flexibility was one of the reasons the system lasted as long as it did.
+
+The tradeoff was that Podio never became a fully governed application platform. It looked relational, but it did not enforce relational integrity like a database. It could calculate and automate, but the logic lived in platform configuration rather than source control. It could collect registrations, but it did not solve canonical person identity. It could generate documents, but document logic became scattered across app fields, flow steps, and annual copies.
+
+That tradeoff was reasonable in 2016. By 2024, the cost had grown.
+
+## Evidence Captured
+
+This retrospective is based on a read-only archaeology pass through the VAY Sports Fest Podio workspace and its Globiflow automation screens on July 27, 2026.
+
+Local archive artifacts were saved under:
+
+```text
+middleware/scratch/podio-globiflow-archive-2024/
+```
+
+That archive includes:
+
+- Exported Globiflow XML files for the major Sports Fest apps.
+- A generated `flow_manifest.csv` summarizing flow names, apps, trigger types, step counts, and step-function counts.
+- Screenshots of the Globiflow flow lists.
+- Screenshots of the current Globiflow flow screen and the Podio Bible Verses app screen.
+
+The archive should be treated as historical evidence, not as source code. It may contain operational details that should not be committed casually.
+
+No participant names, emails, phone numbers, addresses, or other personal row data are included in this document.
+
+## The 2024 Podio Data Model
+
+The VAY Sports Fest workspace was organized as a set of Podio apps. In practice, each app acted like a table, each item acted like a record, each field acted like a column, and each saved view acted like an operations dashboard.
+
+### `ChurchReg`
+
+`ChurchReg` represented each participating church's season registration. The 2024 workspace showed 16 church records. Its views grouped churches by participating team sports, other events, fee states, PDF-generation state, and pastor-signature status.
+
+Operationally, this app carried the church-level commitments:
+
+- Which sports and events the church intended to enter.
+- Whether the church had late fees or flag fees.
+- Whether the church registration packet had been generated.
+- Whether pastor signature was complete.
+- Whether church files should be emailed.
+- Whether athlete badges should be generated.
+
+The Globiflow exports show `ChurchReg` was also one of the automation centers. It generated church registration PDFs, sent pastor-signature packets, reacted when a pastor signed, emailed church files, and generated athlete badges for church teams.
+
+### `PlayerReg`
+
+`PlayerReg` was the athlete registration table. The 2024 Podio view showed 496 records. Its field structure mixed person identity, church/team assignment, sport selection, consent/signature state, photo processing, validation notes, and output-generation controls.
+
+Visible fields included:
+
+- Athlete name, first name, last name, birthdate, computed age on game date, gender.
+- Church team and church membership status.
+- Athlete contact fields and emergency/guardian contact fields.
+- Primary sport, secondary sport, other events, derived sport list, and team code.
+- Photo and cropped photo URL fields.
+- Medical release and electronic-signature state.
+- Issue-detected and notes fields.
+- Athlete ID and PDF/email generation controls.
+- Signature-line and legal-guardian print fields.
+
+The saved views show how Podio doubled as the operating dashboard. Player records were grouped by sport, church, gender, membership status, PDF generation state, medical-release state, other events, and signing status.
+
+The 2024 counts also reveal the operational shape of the event: Volleyball, Basketball, Bible Challenge, Track & Field, Tug-of-war, Pickleball, Badminton, Table Tennis, Tennis, and Scripture Memorization were all represented in the athlete intake.
+
+### `VolunteerReg`
+
+`VolunteerReg` represented volunteers and staff roles. The 2024 workspace showed 41 records. Its views grouped records by church-rep/staff categories, serving year, gender, and sport assignments.
+
+This app was not only a registry. Its Globiflow automation handled SMS-based voting and response capture, then updated a voting score back onto the annual configuration app.
+
+### `Approval Records`
+
+`Approval Records` appears to have been a lightweight workflow table for yes/no approval actions. Its flows generated approval links in comments, sent emails on update, and processed external approve/deny link hits.
+
+This is an important historical bridge to the current WordPress pastor-approval system. In Podio, the approval action was mediated through app items, comments, and Globiflow external links. In `vaysf`, that idea became a more explicit WordPress approval surface with middleware sync back to ChMeetings.
+
+### `Events`
+
+`Events` was a small planning and meeting app. The visible fields were:
+
+- Event
+- Date
+- Meeting Participants
+- Location
+- Agenda
+- Resources Link
+
+This was the least automated part of the captured structure, but it shows how Podio served as both operations database and team collaboration space.
+
+### `Annual Parameters`
+
+`Annual Parameters` was the global season-configuration app. In 2024 it had one record and fields for:
+
+- Sports Fest start date.
+- First and second weekend dates.
+- Church fees, participant fees, late fees, and super-late fees.
+- Registration deadlines and no-more-registration cutoff.
+- PDF/email generation toggles.
+- Badge template parameters, including background images and HTML/table fragments.
+- Texting targets, voting title, voting options, and voting transcript.
+
+This app is especially revealing. It shows that season constants, fee policy, deadlines, badge-template configuration, PDF-generation state, and volunteer-voting settings were all stored as editable Podio fields.
+
+In the current `vaysf` architecture, these concerns are split more deliberately between JSON rules, middleware configuration, WordPress plugin state, checked-in templates, and issue-tracked policy decisions.
+
+### `ScoreSheets`
+
+`ScoreSheets` represented scheduled games and generated score-sheet artifacts. The 2024 app showed 92 records. Visible fields included:
+
+- Game
+- Bible Verse ID
+- Sport
+- Team A and Team B
+- Date, time, and gym
+- Generating-sheet state
+- Format
+- Church A and Church B
+- Sheet-issue detection
+- Both team rosters
+
+The views grouped score sheets by generation state and sport format. The flows show sport-specific PDF generation for general games, volleyball, badminton, and ping pong/table tennis.
+
+This was the ancestor of the 2026 schedule-driven score-sheet and Results Desk work. In Podio, score sheets were generated from app records. In `vaysf`, schedule rows, score entry, protected uploads, result review, public display, and playoff advancement became typed WordPress/Python workflows.
+
+### `Bible Verses`
+
+`Bible Verses` was a verse bank used by Bible Challenge. The captured app showed 126 records, with records last edited before the 2024-to-2026 migration period.
+
+This is a direct ancestor of the later WordPress Bible Challenge verse-management work. Podio had the data; the new system needed the event-day editing, seed/import behavior, and schedule/results integration.
+
+## The Globiflow Programming Layer
+
+The exported Globiflow XML confirms that the 2024 system's real behavior lived in automation flows. The workspace had active flow groups for:
+
+- `ChurchReg`: 14 flows.
+- `PlayerReg`: 20 flows.
+- `VolunteerReg`: 3 flows.
+- `Approval Records`: 4 flows.
+- `Annual Parameters`: 2 flows.
+- `ScoreSheets`: 5 flows.
+- Global date/day flows: 2 flows.
+- Global webhook flows: 1 flow.
+
+The major step functions were:
+
+- `customPrep`: expression/calculation blocks.
+- `prepFilter` and `endIf`: conditional gates.
+- `updateItem` and `updateCollected`: Podio record mutation.
+- `searchApp`, `getReferenced`, `sortCollected`, `clearCollected`, `forEach`: relationship and query behavior.
+- `makePdf`: document generation.
+- `rightSignatureSend`: e-signature packet generation.
+- `sendEmail` and `sendSms`: communications.
+- `remotePost`: external service calls.
+- `triggerSelf` and `triggerCollected`: flow chaining.
+- `displayPage`: external approval-link response page.
+
+This is the key technical insight: Globiflow was not an accessory. It was the procedural runtime of the Podio-era Sports Fest system.
+
+## How The 2024 System Operated
+
+### 1. Church Registration
+
+A church registration item entered `ChurchReg`. Creation and update flows generated church-registration PDF packets, shared or emailed files, and sent the registration form for pastor signature through RightSignature.
+
+When a pastor signed, an external-signature flow updated the church record and sent follow-up email. Additional update-triggered flows handled "Update Now" style commands for regenerating registration files and emailing them back to the church representative.
+
+Badge generation also hung from `ChurchReg`. The 2024 badge flow was large: over 120 steps, mostly custom expression blocks and filters. It pulled related athlete data, prepared badge-specific output, generated PDFs, emailed results, and called remote services for image or badge handling.
+
+### 2. Athlete Registration
+
+An athlete registration item entered `PlayerReg`. Creation flows initialized derived fields, generated or protected key identity values, shared the item, posted remote data where needed, and triggered additional self-processing.
+
+Update flows responded to key changes:
+
+- Recalculate athlete sports.
+- Process photo and cropped-photo URL fields.
+- Prevent unauthorized updates of ID-critical fields.
+- Generate adult/minor registration PDFs.
+- Send e-signature packets.
+- Mark an athlete as electronically signed.
+- Send registration forms for pastor signature.
+- Re-run generation when an operator pressed an update field.
+
+The athlete workflow was sophisticated, but it was also tightly coupled to field labels and option text. Sport validation and category derivation lived as procedural string logic across many Globiflow steps.
+
+### 3. Sport Derivation And Validation
+
+The clearest single artifact is the 2024 flow:
+
+```text
+CHECK and RECALC SPORTS LIST (2024 edited sports names)
+```
+
+It had 128 steps and ran as a manual/flow-triggered routine on `PlayerReg`.
+
+Its job was to transform a participant's primary sport, secondary sport, gender, church team, and other events into the derived `Sport` and `Team` fields. It:
+
+- Removed an old `3 Point Contest` option.
+- Removed duplicate primary/secondary selections.
+- Split Volleyball into men's and women's categories.
+- Enforced male-only Basketball.
+- Derived Bible Challenge, Badminton, Tennis, Table Tennis/Ping Pong, Pickleball, Scripture Memorization, Track & Field, and Tug-of-war participation.
+- Wrote issue comments when invalid combinations were detected.
+- Cleared sport fields when no valid sports remained.
+- Derived a short team code from the church field.
+
+The most memorable line in the XML is an explicit hack note: the athlete's sports-list field needed to be labeled internally as `Ping Pong` even when the display text said `Table Tennis`, otherwise the flow could not reliably separate Tennis from Table Tennis while generating rosters and badges.
+
+That one detail explains a lot about why the current codebase cares so much about canonical sport IDs, field mappings, and testable rules. The Podio system encoded meaning inside display strings. `vaysf` tries to make those meanings explicit.
+
+### 4. Pastor Approval
+
+The `Approval Records` app generated yes/no links and processed external link hits. A yes link updated an approval record as approved. A no link updated it as denied. Email update flows then notified the relevant people.
+
+This was a clever low-code approval surface, but it depended on link-generated workflow state rather than a purpose-built approval UI. The 2026 WordPress pastor approval workflow is the same ministry need expressed in a more explicit application layer.
+
+### 5. Score Sheet Generation
+
+`ScoreSheets` items carried game, teams, church codes, date/time/gym, format, and roster references. Update-triggered flows generated PDFs for general games, volleyball, badminton, and ping pong/table tennis.
+
+The large score-sheet flows searched Podio records, sorted and collected related athletes, prepared roster tables, and generated PDFs. This explains the historical continuity between Podio-era generated score sheets and the 2026 `vaysf` score-sheet pipeline.
+
+The difference is that 2026 made schedule rows, coordinator score entry, result manifests, protected uploads, and public results first-class operational surfaces. Podio could generate the paper. The new system needed to run the live event.
+
+### 6. Volunteer SMS And Voting
+
+`VolunteerReg` and `Annual Parameters` included SMS and voting flows. One flow sent voting prompts. Another captured SMS replies. A third updated voting totals on the annual-parameter record.
+
+This is a good example of what Podio and Globiflow did well: a custom operational workflow could be assembled without building a full application from scratch.
+
+## What Worked Well
+
+Podio worked because it gave VAY a cloud database that ordinary operators could understand. Records were visible. Views were configurable. Apps could be modified without a release. Forms could accept external input. Comments and files lived near the records. Volunteers did not need a VPN, Access runtime, or custom desktop app.
+
+Globiflow worked because it let a technically capable operator program the process where Podio stopped. It could send signatures, generate PDFs, update related items, send email and SMS, and chain workflows together. For a volunteer ministry, that was genuinely powerful.
+
+The 2024 system also had a strong operational vocabulary. It knew about churches, athletes, pastors, church reps, signatures, medical releases, badges, sports, rosters, score sheets, gyms, fees, deadlines, volunteers, and Bible verses. The current `vaysf` system did not invent those concepts from nothing. It inherited them from a decade of Podio practice.
+
+The mature 2024 Podio system also had breadth. It could accept registrations, organize church and player records, prepare registration packets, send e-signature requests, process photos, generate badges, generate score sheets, send email, send SMS, track volunteer voting, and preserve app views that operators knew how to use. Even where the implementation was brittle, the operational coverage was impressive.
+
+## What Became Brittle
+
+The system became brittle where operational meaning was hidden in editable platform configuration:
+
+- Display labels carried business meaning.
+- Category text was parsed as logic.
+- "Button" fields such as `Update Now`, `Generate`, and `Idle` acted as commands.
+- Flow behavior was copied forward by year rather than versioned as code.
+- Validation lived inside long visual flow chains.
+- PDF templates and badge templates were embedded in app fields and flow expressions.
+- Relationship integrity depended on Podio behavior and operator discipline rather than database constraints.
+- Identity lived across athlete records, church records, signatures, photos, and generated IDs without a canonical person layer.
+
+The flow names tell the story. There were creation flows for 2021, 2022, and 2023; sports-list flows for 2020, 2021, 2023, and 2024; badge flows for 2019, 2022, 2023, and 2024; and test PDF flows still present beside production flows.
+
+That was not negligence. It was how the system survived year after year. Copy the working flow, adjust the season's sports and templates, preserve the old one in case the new one breaks, and keep the tournament moving.
+
+But that style reaches a limit. Once Sports Fest needed repeatable sync, source-controlled changes, tested validation, audit trails, canonical identity, and event-day score/result handling, the no-code runtime stopped being enough.
+
+## How This Led To `vaysf`
+
+The current `vaysf` architecture can be read as a direct answer to the Podio-era pressure points, but not as a complete recreation of every Podio feature.
+
+- ChMeetings became the source of truth for registration and people.
+- Python middleware became the explicit orchestration layer.
+- WordPress became the staff, pastor, coordinator, schedule, score-entry, and results surface.
+- JSON/Pydantic validation replaced hidden workflow rules.
+- `CHM_FIELDS` replaced scattered literal field names.
+- Git history replaced copied annual flow variants.
+- Tests replaced manual confidence in long flow chains.
+- Schedule and result records replaced score-sheet-only generation.
+- Issues and RFCs replaced undocumented operational memory.
+
+The 2025-2026 rebuild prioritized the places where Podio had become riskiest:
+
+- API-first synchronization instead of browser/manual export dependency.
+- Structured field mapping instead of scattered field-label assumptions.
+- Rule validation that can be tested.
+- Git history for changes that used to live inside copied workflows.
+- WordPress admin surfaces for pastor approvals, coordinator score entry, results review, public schedules, and public results.
+- Schedule and result models that can drive event-day workflows, not only printed artifacts.
+
+That priority order made sense. It let Sports Fest 2026 run on the new system where live operations most needed structure and accountability.
+
+But the migration is not finished. The 2024 Podio system still represents a fuller document-generation and no-code-operations surface in several areas:
+
+- Church registration packet generation and email workflows.
+- Mature e-signature document handling around athlete and church forms.
+- Badge generation flows that had been copied and refined over multiple seasons.
+- Volunteer SMS/voting workflows.
+- Operator-friendly Podio views that functioned as quick dashboards.
+- Annual configuration fields that bundled deadlines, fees, templates, texting, and generation toggles in one visible place.
+
+The Podio system already knew what Sports Fest was. `vaysf` is the attempt to make that knowledge explicit, testable, and operable during a live tournament. In 2026 it became stronger than Podio in some domains, especially schedule/results operations, but it still needs to rebuild or intentionally retire other Podio-era capabilities.
+
+## The Historical Arc
+
+The full system arc looks like this:
+
+1. Microsoft Access gave VAY a locally controlled custom database.
+2. Around the 2016 season, Podio moved that database model into a collaborative cloud workspace.
+3. Globiflow turned that workspace into an automated event operations platform.
+4. From 2016 through 2024, year-by-year copying and adjustment let the system survive changing sports, forms, templates, and policies.
+5. By 2024, the operation had outgrown platform-configured automation in areas where identity, validation, scheduling, results, and auditability needed stronger guarantees.
+6. In 2025 and 2026, `vaysf` became the migration and buildout path for a source-controlled system.
+7. After Sports Fest 2026, the remaining question is not "did `vaysf` replace Podio?" The better question is "which Podio-era capabilities should be rebuilt, which should move to ChMeetings or Dropbox, and which should be retired because the process itself changed?"
+
+The emotional truth is worth preserving too. Podio was highly innovative for its time. It let VAY build a cloud Sports Fest operating system years before a small volunteer organization could reasonably have afforded a custom one.
+
+The current system stands on that work. It should not treat the Podio era as something embarrassing to escape. It should treat it as the field notebook from which the modern system learned what the tournament actually is, and as a reminder that operational usefulness matters as much as architectural cleanliness.
+
+## What To Remember For Future Design
+
+1. Keep VAY-specific language. The old system worked because it modeled the real event, not a generic sports product.
+2. Preserve operator-visible workflows. Podio views were useful because staff could see work state directly.
+3. Do not hide policy in display strings. Canonical IDs and tested rules are worth the ceremony.
+4. Keep annual changes source-controlled. Copy-forward configuration is understandable, but it needs history and review.
+5. Treat generated artifacts as outputs, not truth. PDFs, badges, exports, and score sheets matter, but the data behind them must remain structured.
+6. Do not assume every Podio feature must be rebuilt. Some may belong in ChMeetings, Dropbox, GitHub issues, or a simpler manual process.
+7. Do not assume every Podio feature can be discarded. Some workflows existed because the event genuinely needed them.
+8. Build around the human operator. The best parts of Podio were approachable. `vaysf` should keep that spirit even as it becomes more rigorous.
+
+## Open Migration Questions
+
+The 2024 Podio system should now be used as a comparison map for `vaysf`, not as a template to copy blindly.
+
+Open questions for future planning:
+
+- Should church registration packet generation be rebuilt in WordPress/middleware, moved fully into ChMeetings, or preserved as a Dropbox/document workflow?
+- Should athlete medical-release and pastor-signature packet workflows remain external document workflows, or should consent/approval become more native to ChMeetings and WordPress?
+- Which badge-generation features from Podio are still needed after the 2026 badge-image and hosted-badge work?
+- Should volunteer SMS/voting be rebuilt, or was that a season-specific Podio convenience?
+- Should Annual Parameters become a structured WordPress season-settings screen, a JSON config, or a hybrid?
+- Which Podio views are worth recreating as WordPress dashboards because operators still need that at-a-glance view?
+
+The practical lesson is that `vaysf` should not chase parity for its own sake. It should pursue continuity where the old system embodied real operational wisdom, and replacement where the old system encoded that wisdom in fragile platform configuration.

--- a/docs/RETROSPECTIVE_PODIO_2016_2024.md
+++ b/docs/RETROSPECTIVE_PODIO_2016_2024.md
@@ -1,5 +1,16 @@
 # VAYSF Podio Era Retrospective, 2016-2024
 
+*Drafted by Codex on 2026-07-28 from a read-only archaeology pass through the
+VAY Sports Fest Podio workspace and its Globiflow automation screens. Reviewed
+and approved by Bumble.*
+
+*This is the earliest document in the retrospective set — see
+`RETROSPECTIVES.md` for the full series and reading order. It covers the nine
+seasons before this repository existed; `RETROSPECTIVE_2025.md` picks up where
+it ends.*
+
+---
+
 ## From Access To Podio To `vaysf`
 
 The 2024 Sports Fest season appears to have been the last year when the tournament operated primarily through Podio and Globiflow. That matters historically because Podio was not merely an old database that happened to be replaced. For VAY, it was the cloud bridge between the Microsoft Access era and the current ChMeetings + middleware + WordPress system.


### PR DESCRIPTION
## Summary

- add a Codex retrospective for the 2016-2024 Podio/Globiflow Sports Fest era
- explain the Access -> Podio -> vaysf migration arc
- document that 2026 vaysf has not yet fully rebuilt every mature 2024 Podio capability
- ignore the local Podio/Globiflow archaeology archive so exported XML and screenshots are preserved locally but not committed accidentally

## Validation

- documentation-only change; no tests run
- staged diff checked to include only the new doc and .gitignore guard