### PR TITLE
docs: propose ministry architecture principles

### DIFF
--- a/docs/MINISTRY_ARCHITECTURE_PRINCIPLES.md
+++ b/docs/MINISTRY_ARCHITECTURE_PRINCIPLES.md
@@ -1,0 +1,51 @@
+# Ministry Architecture Principles
+
+> **Status: Proposed for review**
+
+Sports Fest software exists to support a ministry, not merely to operate a tournament. These principles are intended to guide architecture, product decisions, data modeling, automation, and contributor review across the VAY Sports Fest ecosystem.
+
+They are deliberately more durable than any current framework, API, database, or vendor.
+
+## 1. People are not rows
+
+Every registration represents a person created in the image of God. Software exists to serve people, never to reduce them to records, identifiers, validation results, or workflow states.
+
+A technically correct feature can still be wrong for the ministry if it makes people easier to process but harder to know, care for, or restore.
+
+## 2. Identity is canonical
+
+Each person has one enduring identity even when registrations, names, churches, contact information, or ChMeetings records change.
+
+The system should preserve continuity rather than create parallel versions of the same person. Duplicate resolution, alias mapping, and identity verification are therefore not merely data-cleaning tasks; they protect the continuity of a person's history across seasons.
+
+## 3. Relationships have stewardship
+
+People participate within relationships: families, churches, pastors, Church Representatives, coaches, teammates, volunteers, mentors, and ministry leaders.
+
+The system should represent those relationships clearly and preserve who is responsible for each form of care, consent, communication, approval, and follow-up. We do not own people; we steward the relationships entrusted to us.
+
+## 4. Technology serves shepherding
+
+Automation, AI, middleware, WordPress, ChMeetings, reporting tools, and future mobile applications should reduce administrative friction so pastors, Church Representatives, coaches, and volunteers can spend more time caring for people.
+
+Technology may surface information, preserve context, suggest next actions, and prevent people from falling through operational cracks. It must not replace pastoral discernment, relational judgment, or human responsibility.
+
+## 5. Relational Memory outlives every season
+
+Sports Fest lasts for a season. Discipleship and ministry relationships continue beyond it.
+
+The system should faithfully preserve the outward story of participation, belonging, service, leadership, invitation, mentoring, and ministry involvement so future leaders can continue the work rather than repeatedly starting over.
+
+Relational Memory is not a spiritual score. It does not claim to measure saving faith, inward grace, or spiritual maturity. It preserves observable history that can help churches recognize people, remember relationships, discern fruit, and shepherd faithfully.
+
+## Applying the principles
+
+When proposing or reviewing a feature, contributors should ask:
+
+1. Does this treat people as people rather than merely as records?
+2. Does this preserve one continuous identity?
+3. Does this clarify and strengthen relational stewardship?
+4. Does this help churches and ministry leaders shepherd better?
+5. Does this enrich Relational Memory rather than fragment or erase it?
+
+A feature that advances these principles is likely aligned with the purpose of the project. A feature that conflicts with them deserves reconsideration even when it is technically elegant or operationally convenient.


### PR DESCRIPTION
## What changed

Adds a proposed `docs/MINISTRY_ARCHITECTURE_PRINCIPLES.md` for contributor review, built around five durable principles:

1. People are not rows.
2. Identity is canonical.
3. Relationships have stewardship.
4. Technology serves shepherding.
5. Relational Memory outlives every season.

The document also translates the principles into five questions contributors can use when proposing or reviewing features.

## Why

The repository has increasingly sophisticated identity, consent, relationship, and discipleship-support capabilities. Before those capabilities are coded further, contributors need a shared ministry-centered standard for judging architecture and product decisions.

This proposal frames identity verification as protection of relational continuity—not distrust of registrants—and defines Relational Memory as observable ministry history rather than a spiritual score.

## Impact

Documentation only. No production code or behavior changes.

## Validation

- Compared the branch against `main`.
- Diff contains one new Markdown document: 51 additions, no deletions.

## Review questions

- Are these the right five principles?
- Is “Relationships have stewardship” the clearest wording?
- Is the distinction between Relational Memory and spiritual scoring sufficiently clear?
- After approval, where should this be linked from the README and contributor documentation?

Related context: #307 and #350.