### PR TITLE
docs: add discipleship vision post and link it from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 The Sports Fest ChMeetings Integration is a comprehensive system for managing the Vietnamese Alliance Youth (VAY) Sports Festival participant registration, validation, and approval. It bridges ChMeetings (for registration and profile management) with WordPress (for operations) using a Windows-based Python middleware.
 
+> **New here?** Read [**Beyond the Tournament: A Vision for Sports Fest Discipleship**](docs/VISION_DISCIPLESHIP.md) first. It explains why this project exists and what we hope it becomes — the tournament is the front porch, not the destination. If that resonates, we would love your help.
+
 ### Key Features
 
 - Complete registration management through ChMeetings
@@ -129,6 +131,7 @@ For detailed setup and usage instructions, see the [Installation Guide](docs/INS
 
 ## Documentation
 
+- [Vision: Beyond the Tournament](docs/VISION_DISCIPLESHIP.md) — why this project exists, and the discipleship future it is building toward
 - [Chatable DeepWiki](https://deepwiki.com/i12know/vaysf) powerered by [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/i12know/vaysf)
 - [Installation Guide](docs/INSTALLATION.md)
 - [Architecture Overview](docs/ARCHITECTURE.md)

--- a/docs/VISION_DISCIPLESHIP.md
+++ b/docs/VISION_DISCIPLESHIP.md
@@ -1,0 +1,508 @@
+# Beyond the Tournament: A Vision for Sports Fest Discipleship
+
+## Why We Are Building `vaysf`
+
+At first glance, `vaysf` is software for running a sports tournament.
+
+It manages registrations, churches, rosters, approvals, schedules, badges, score sheets, results, and standings. It helps coordinators know where teams should be, helps church representatives find problems before event day, and helps spectators follow what is happening.
+
+All of that matters.
+
+But it is not the deepest reason this project exists.
+
+Sports Fest has never been only about sports. For decades, it has created a place where churches gather, young people reconnect, friendships form, leaders emerge, and people who may be distant from church step back into Christian community.
+
+Some participants arrive because they love basketball, volleyball, badminton, running, or competition. Some come because their friends invited them. Some grew up in church but have slowly drifted away. Some do not yet know Christ. Some will compete for a weekend and disappear unless someone notices them, remembers them, and follows up.
+
+The tournament is not the ministry’s destination.
+
+It is the front porch.
+
+The long-term vision for `vaysf` is therefore larger than building better tournament software. We are building the technological foundation for a district-wide discipleship network—one that happens to express itself through sports.
+
+## The Question That Should Guide Us
+
+We should not measure the success of this system only by asking:
+
+> Can Sports Fest manage more athletes?
+
+We should also ask:
+
+> Can Sports Fest help each participant move one step closer to Christ?
+
+That question changes how we design software.
+
+A registration record is no longer merely a row in a database. It represents a person known by a church.
+
+A roster is not merely a list of eligible players. It is a picture of relationships, pastoral responsibility, and belonging.
+
+A badge is not merely an event credential. It connects a name and face to a church community.
+
+A schedule is not merely the allocation of games. It creates opportunities for people to gather, serve, encourage, compete, reconcile, and worship.
+
+A mobile notification is not merely a reminder that Court 3 begins at 10:15. It may also become an invitation to pray for another team, read a devotional, reconnect with a church leader, or take a next step after the event ends.
+
+Technology cannot make disciples.
+
+But it can help the Church notice people, remember commitments, reduce administrative friction, and create more space for relationships.
+
+## From an Annual Event to a Year-Round Journey
+
+Sports Fest has historically operated around a seasonal rhythm:
+
+```text
+Registration
+    ↓
+Preparation
+    ↓
+Two weekends of competition
+    ↓
+Results
+    ↓
+The system becomes quiet until next year
+```
+
+The future should look different:
+
+```text
+Invitation
+    ↓
+Registration
+    ↓
+Preparation and prayer
+    ↓
+Sports Fest
+    ↓
+Pastoral follow-up
+    ↓
+Church connection
+    ↓
+Discipleship and service
+    ↓
+Leadership development
+    ↓
+The next Sports Fest
+```
+
+In this vision, Sports Fest is not an isolated annual transaction. It becomes one chapter in a person’s longer spiritual journey.
+
+A participant may first appear as someone invited by a friend. Later, that person may return as an athlete, join a church community, volunteer, coach, coordinate a sport, mentor younger participants, or become a ministry leader.
+
+Not everyone will follow the same path, and software should never reduce spiritual growth to a simplistic progression chart. Yet the system can help local churches recognize meaningful transitions:
+
+```text
+Guest
+  ↓
+Participant
+  ↓
+Returning participant
+  ↓
+Connected to a local church
+  ↓
+Volunteer
+  ↓
+Coach or team leader
+  ↓
+Church representative or coordinator
+  ↓
+Mentor and ministry leader
+```
+
+The purpose is not to manufacture advancement.
+
+The purpose is to help churches see people clearly enough to shepherd them faithfully.
+
+## The Role of Each Platform
+
+The future architecture should not become one enormous application that tries to do everything. Each platform should serve a distinct ministry purpose.
+
+### ChMeetings: The Person and Church Record
+
+ChMeetings should remain the canonical system for people and their relationships to local churches.
+
+It answers questions such as:
+
+* Who is this person?
+* Which church is responsible for following up with them?
+* Are they a member, attendee, guest, parent, minor, volunteer, or leader?
+* Who is connected to their household?
+* Has the appropriate pastor or church representative approved their participation?
+* What ministry groups or follow-up processes are they part of?
+
+ChMeetings should not merely store a Sports Fest registration. It should help the church retain a relational connection after the tournament is over.
+
+At the same time, Sports Fest must use this information carefully. Pastoral data is not tournament data by default. Access must be limited by role, purpose, and genuine ministry responsibility.
+
+### WordPress: The Public Ministry and Event Platform
+
+WordPress should continue developing into the shared ministry surface for Sports Fest.
+
+It can provide:
+
+* public schedules and results
+* registration guidance
+* Sports Fest policies and philosophy
+* devotionals and Scripture
+* testimonies
+* Bible Challenge materials
+* coach and volunteer training
+* church resources
+* gospel presentations
+* post-event next steps
+
+WordPress answers:
+
+> What is happening, what does it mean, and how can someone participate?
+
+During Sports Fest, it becomes the live operations board.
+
+Throughout the year, it can become the public discipleship and resource platform.
+
+### Middleware: The Trusted Orchestrator
+
+The `vaysf` middleware exists because no single vendor understands Sports Fest.
+
+It translates ministry policies into explicit, testable rules. It synchronizes ChMeetings, WordPress, spreadsheets, schedules, results, badges, and operational workflows.
+
+Its job is not merely to move data.
+
+Its job is to preserve meaning.
+
+The middleware should understand the difference between:
+
+* a person and a registration
+* a church relationship and a team assignment
+* a pastor’s approval and an editable status field
+* consent and evidence of consent
+* a duplicate record and a duplicate person
+* a generated schedule and a human-approved schedule
+* a reported score and a reviewed result
+
+This layer must remain source-controlled, testable, observable, and documented. Future contributors should be able to understand why a rule exists, not merely discover that a script behaves a certain way.
+
+### A Mobile App: The Participant’s Field Companion
+
+A future mobile app should not be imagined as merely a smaller version of the website.
+
+Its purpose should be more personal:
+
+> What is true for me, and what should I do next?
+
+During Sports Fest, the app might show:
+
+* the participant’s teams and events
+* upcoming games
+* venue directions
+* check-in status
+* consent or approval issues
+* digital badge
+* results
+* important announcements
+* church-specific information
+
+But the app’s deeper potential begins after those logistical needs are met.
+
+It could also offer:
+
+* a short morning devotional
+* prayer prompts for teammates and other churches
+* stories from Sports Fest
+* invitations to worship gatherings or small groups
+* opportunities to serve
+* follow-up steps from the participant’s church
+* reminders tied to commitments the participant has chosen
+
+The schedule may be what causes someone to install the app.
+
+Discipleship is what may give the app a reason to remain useful afterward.
+
+## A Possible Participant Experience
+
+Imagine a participant opening the app on the morning of Sports Fest.
+
+Instead of seeing only:
+
+> Volleyball at 9:00 AM, Court 2
+
+the participant might also see:
+
+> Three people from your church are competing this morning. Take a moment to pray for them.
+
+After a difficult loss:
+
+> Competition reveals what is happening in our hearts. Read today’s short reflection on winning, losing, identity, and grace.
+
+After Sunday worship:
+
+> You heard the message at Sports Fest. Would you like to continue the conversation with someone from your church?
+
+A week after the event:
+
+> Sports Fest was never meant to be the finish line. Here are the next gatherings at your church.
+
+Months later:
+
+> Your church is preparing for next year. Would you consider serving as a volunteer or helping a younger athlete?
+
+None of this requires an artificial intelligence system to act as a pastor.
+
+It requires the system to connect the right person with the right church, leader, resource, invitation, and moment.
+
+## The Proper Role of AI
+
+AI-assisted development changes what a volunteer ministry can realistically build.
+
+In earlier eras, creating a custom system required either a large budget or a highly specialized developer working alone. Today, contributors can use AI-assisted coding to turn ministry knowledge into small, focused improvements:
+
+* a new validation rule
+* an operator dashboard
+* a registration follow-up report
+* a mobile screen
+* a notification workflow
+* a schedule importer
+* an identity-reconciliation tool
+* a church packet generator
+* a discipleship-content recommendation
+
+This restores one of the great strengths of the Microsoft Access era: the system can evolve quickly in response to actual ministry needs.
+
+But now those improvements can also be:
+
+* stored in Git
+* reviewed by others
+* tested automatically
+* documented
+* discussed through issues
+* refined across multiple seasons
+
+AI should increase the ministry’s ability to build responsibly. It should not become an excuse to produce unreviewed complexity.
+
+The guiding question should remain:
+
+> What ministry friction did we experience, and what is the smallest trustworthy improvement that would help?
+
+AI may also assist with operational tasks such as summarizing issues, matching resources, detecting anomalies, or drafting communications.
+
+It should not independently determine someone’s spiritual condition, provide pastoral judgment without human oversight, or manipulate people into religious engagement.
+
+Discipleship remains relational, ecclesial, prayerful, and led by human beings under the authority of Christ.
+
+## Local Churches Must Remain Central
+
+Sports Fest should never become a centralized ministry that competes with the participating churches.
+
+Its purpose is to strengthen the churches’ ability to know, welcome, shepherd, and disciple people.
+
+Therefore, a successful follow-up system should not merely send a generic message from VAY. It should help the appropriate local church act.
+
+For example, after Sports Fest, the system could help a church representative see:
+
+* first-time participants
+* participants without an established church connection
+* returning participants who have become disconnected
+* people who requested prayer
+* people interested in serving
+* people who expressed interest in learning more about faith
+* incomplete follow-up assignments
+* participants who should receive a personal invitation
+
+The system can surface the opportunity.
+
+A pastor, church representative, coach, mentor, or trusted believer must carry the relationship.
+
+## The Identity Challenge Is a Discipleship Challenge
+
+Duplicate people, merged ChMeetings profiles, children registered by parents, changing churches, alternate spellings, and stale IDs may appear to be technical problems.
+
+They are also ministry problems.
+
+If we cannot reliably know who someone is, we may:
+
+* ask the wrong church to follow up
+* lose a participant’s history
+* treat a returning person as a stranger
+* overlook incomplete consent
+* duplicate communication
+* expose information to the wrong person
+* fail to recognize a developing leader
+* misunderstand someone’s relationship to the church
+
+This is why identity and registrant trust are not merely infrastructure concerns.
+
+They protect relationships.
+
+The future system should gradually distinguish among:
+
+* the human person
+* the ChMeetings profile
+* the seasonal registration
+* the form submission
+* the household or guardian relationship
+* the church relationship
+* the team assignment
+* the consent record
+* the pastoral approval
+* the volunteer or leadership role
+
+A person is not a row.
+
+The software should eventually reflect that truth.
+
+## Ministry Guardrails
+
+A discipleship vision can easily become intrusive if technology is allowed to overreach. Future contributors should preserve clear boundaries.
+
+### Consent
+
+Participants should understand what information is being collected, why it is being used, and which church or ministry leaders may access it.
+
+Two commitments follow from that, and they are worth stating plainly rather than leaving implied.
+
+**We will ask before we follow up, and "no thank you" is a complete answer.** Registering for a tournament is consent to play in a tournament. It is not consent to be contacted afterward about faith, church, or anything else. Those are separate decisions, and a participant who declines the second should keep receiving everything they need for the first—schedules, results, check-in, their badge—without friction and without being asked again. Someone choosing not to hear from us is not a gap in the data to be closed. It is an answer we asked for, and honoring it is part of the ministry, not an obstacle to it.
+
+**For minors, the guardian decides.** A parent signing a medical release so their child can compete has not agreed to devotional messages, prayer prompts, or an invitation to meet a church leader arriving on that child's phone. Consent to participate and consent to be discipled are different questions, and for anyone under eighteen the second belongs to the parent or guardian—asked separately, in plain language, and revocable at any time. Where a young person's own wishes and a guardian's differ, the guardian's decision governs what the software does, and the pastoral relationship is where the rest is worked out.
+
+Both of these will occasionally mean the system knows about someone it cannot reach. That is the correct outcome. A ministry that quietly treats reluctance as a problem to be routed around has stopped being trustworthy, and trust is the only thing that makes the rest of this vision possible.
+
+### Data minimization
+
+We should collect only what is genuinely useful for the tournament, safety, pastoral responsibility, or an explicitly chosen discipleship process.
+
+### Role-based access
+
+A sport coordinator does not need access to pastoral notes. A church representative should not automatically see every participant. A developer should not casually inspect personal ministry data.
+
+### Human accountability
+
+AI-generated recommendations, identity matches, or follow-up suggestions should remain reviewable by responsible human leaders.
+
+### Observe Fruit, Not Formula
+
+The system should faithfully record the outward story of a person's journey—participation, belonging, service, leadership, and other observable milestones that help local churches shepherd people well. These are not measurements of saving faith or spiritual maturity, nor should they be reduced to a numerical score. They are simply the relational memories of the visible history of God's work in a person's life and ministry, entrusted to the discernment of pastors and church leaders.
+
+### Church authority
+
+The local church—not the software and not the tournament organization—should remain the primary context for ongoing pastoral care and discipleship.
+
+### Grace
+
+People are more complicated than workflows. The system must leave room for exceptions, changed circumstances, reconciliation, and human judgment.
+
+## What Future Contributors Are Really Building
+
+A contributor may come to this repository to fix a bug in schedule publishing.
+
+Another may improve badge generation.
+
+Another may work on duplicate-person resolution.
+
+Another may design a volunteer dashboard or mobile screen.
+
+These tasks may appear disconnected, but they belong to the same larger purpose.
+
+We are building a system that helps Sports Fest:
+
+* know people without reducing them to data
+* enforce rules without losing grace
+* distribute responsibility without losing accountability
+* automate repetitive work without replacing human judgment
+* preserve operational knowledge across generations
+* turn event participation into opportunities for relationship
+* strengthen local churches rather than centralize ministry
+* continue serving participants after the final score is recorded
+
+The codebase should therefore be evaluated by more than technical elegance.
+
+A technically impressive feature that complicates church ministry may not be a good feature.
+
+A small improvement that helps one church notice five people who need follow-up may be deeply valuable.
+
+## A Picture of the Future
+
+Imagine the Monday after Sports Fest.
+
+The public website displays the final results and celebrates the churches, athletes, volunteers, coordinators, and leaders who served.
+
+The Results Desk archive is complete.
+
+Score sheets and schedules are preserved.
+
+Badges and registrations are reconciled.
+
+Church representatives receive a clear, privacy-conscious follow-up list—not merely a mass email blast.
+
+Participants open the app and do not see:
+
+> Sports Fest is over.
+
+Instead, they see:
+
+> Welcome back. Sports Fest was never the finish line.
+
+Some are invited to a youth gathering.
+
+Some receive a devotional connected to the weekend’s message.
+
+Some are introduced to a local church leader.
+
+Some are asked whether they would like prayer.
+
+Some are invited to serve next year.
+
+Some simply receive a reminder that the church remembers their name.
+
+Months later, a person who first arrived as an outsider returns as a volunteer.
+
+A volunteer becomes a coach.
+
+A coach begins mentoring younger participants.
+
+A church representative becomes a ministry coordinator.
+
+A drifting believer reconnects with Christian community.
+
+A person who came for sports begins asking questions about Jesus.
+
+The software did not accomplish those things.
+
+God worked through His people.
+
+But the system helped those people notice, remember, communicate, organize, and follow through.
+
+That is the dream.
+
+## Our North Star
+
+`vaysf` began as tournament middleware.
+
+It is becoming an operational platform.
+
+It may eventually become part of a much larger discipleship ecosystem.
+
+As the codebase grows, we should keep one question in front of every issue, pull request, feature, and architectural decision:
+
+> Does this help Sports Fest—and the participating local churches—know people, serve them faithfully, and invite them one step closer to Christ?
+
+That is the future worth building.
+
+## Would You Help Us Build It?
+
+Most of this document describes a horizon. What the repository actually contains today is narrower and more concrete: registration sync, validation rules, a pastor approval workflow, a schedule solver, badges, score sheets, and a results desk that ran a live tournament. Much of the wider vision—year-round discipleship content, follow-up journeys, the district-level picture—will live in sibling projects rather than in `vaysf` itself. See [`CONTRIBUTING.md`](CONTRIBUTING.md) and the repository's `CLAUDE.md` for what this codebase builds now, and open an issue if you think something belongs here that does not yet.
+
+That narrowness is an invitation, not a disclaimer. Nearly every improvement worth making is small.
+
+**If you write software**, the stack is Python for the middleware and PHP for the WordPress plugin, talking to the ChMeetings API. Start with [`CONTRIBUTING.md`](CONTRIBUTING.md), then [`ARCHITECTURE.md`](ARCHITECTURE.md) to see how the pieces fit. The [open issues](https://github.com/i12know/vaysf/issues) are the real backlog, and the small ones are genuinely small.
+
+**If you do not write software but you know Sports Fest**, you may be more useful than you think. The hardest problems in this repository have never been technical ones. They are questions like: what should happen when a fourteen-year-old registers without a parent, which sports can a person enter in the same weekend, what does a coordinator actually need to see at 7:00 AM on a Saturday, and what did we do last year that nobody wrote down. Filing an issue that describes a real ministry friction clearly is a genuine contribution, and it is frequently the step that unblocks everything after it.
+
+**If you have ministry experience and some patience with technology**, the section above on AI-assisted development is meant for you specifically. The barrier to turning ministry knowledge into working software is lower now than it has ever been. You do not need to already be an engineer to make a real improvement—you need to understand the problem well and be willing to have your work reviewed.
+
+**If you would rather pray than code**, say so and we will tell you what is genuinely hard right now. That is not a consolation role.
+
+We are a volunteer effort. Nobody is paid, the pace follows the season, and contributions are reviewed rather than merged on faith. If you would like to start a conversation before writing anything, reach the VAY Sports Ministry Team at [vaysm.org](https://vaysm.org).
+
+One last thing worth repeating, because it is the whole argument in a sentence:
+
+> A technically impressive feature that complicates church ministry may not be a good feature. A small improvement that helps one church notice five people who need follow-up may be deeply valuable.
+
+If that sounds like work you would want to be part of, we would be glad to have you.


### PR DESCRIPTION
## What this is

A vision-casting piece for the repo — why `vaysf` exists beyond tournament operations, and an invitation to future contributors. Written as a blog post rather than an internal design doc.

Linked from the README in two places: a callout under the Overview, and the first entry in the Documentation list.

## Contents

- **Why we are building this** — the tournament is the front porch, not the destination.
- **From an annual event to a year-round journey** — Sports Fest as one chapter rather than an isolated transaction.
- **The role of each platform** — ChMeetings as the person/church record, WordPress as the public ministry surface, the middleware as the trusted orchestrator, and a possible future mobile app.
- **The proper role of AI** — what AI-assisted development makes newly possible for a volunteer ministry, and the line it should not cross.
- **Ministry guardrails** — consent, data minimization, role-based access, human accountability, church authority, grace.
- **What future contributors are really building** — and a closing call to action.

## Two things worth reviewing closely

**Participant-facing consent commitments** (in the Consent guardrail). These are promises made in public, so they should say what you actually intend:

- Registering to compete is not consent to be contacted afterward about faith or church. Declining follow-up costs a participant nothing operational and is not re-asked.
- For anyone under eighteen, consent to be discipled belongs to the parent or guardian, asked separately from the medical release and revocable at any time.

Both mean the system will sometimes know about someone it cannot reach. The document states that this is the correct outcome. Worth a second read to confirm that is the commitment you want in writing.

**Scope expectations.** The closing section tells readers that much of the wider vision lives in sibling projects rather than in `vaysf`, and points at `CONTRIBUTING.md` and `CLAUDE.md` for what this repo builds today. That is there so someone recruited by the vision does not arrive and immediately collide with "do not add discipleship features."

## Notes

- Docs only — no code, no tests affected.
- Branched from current `main`, so it does not carry the retrospective revisions from `codex/access-era-retrospective`.
- Internal links verified: `docs/CONTRIBUTING.md`, `docs/ARCHITECTURE.md`, and the issues URL all resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
