### PR TITLE
middleware: remove broken uuid pin and clear §2.4 code smells — closes #374

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 ## Unreleased
 
+- Removed the broken `uuid>=1.30` pin from `middleware/requirements.txt` (#374).
+  That 2006-era PyPI package shadows the standard-library `uuid` module and fails
+  to build on Python 3 (`AttributeError: install_layout` out of setuptools), which
+  aborted `pip install -r requirements.txt` outright on any machine without an
+  already-provisioned environment — so the documented setup path in
+  `docs/INSTALLATION.md` did not work on a fresh or rebuilt box. Existing operator
+  virtualenvs were unaffected, which is why it went unnoticed for a full season.
+  No source change was needed alongside it: the code imports the stdlib `uuid`.
+  Verified both directions — a clean `pip install -r requirements.txt` now
+  succeeds, and installing `uuid>=1.30` on its own still fails as described.
+  (Debt register §2.1.)
+- Micro-fixes from the 2026 architecture review's debt register §2.4 (#377).
+  `middleware/church_teams_export.py`'s column-width sizing no longer swallows
+  every exception with a bare `except: pass`; it now catches
+  `(AttributeError, TypeError, ValueError)` and logs at debug level, so a sizing
+  failure is visible without a wide sheet flooding the run log (the column still
+  falls back to the width computed from its other cells — behavior unchanged).
+  `middleware/config.py`'s directory-creation failure handler uses `logger.error()`
+  instead of `print()`, bringing that failure path into the structured logging
+  conventions; it reaches loguru's default stderr sink rather than the log file,
+  which is correct here since `LOG_DIR` itself may be the directory that failed.
+  The third §2.4 item — the hardcoded `G:\Shared drives\...` default export path
+  at `config.py:39` — is deliberately **not** included; see #377 for why.
 - Hotfix 1.1.14: Fixed the public/admin `Approved Participants` stat
   under-reporting real approved-athlete counts (#181). `VAYSF_Statistics::get_overall_stats()`
   was counting `sf_approvals.approval_status = 'approved'` (a pastor-approval-token/sync

--- a/middleware/church_teams_export.py
+++ b/middleware/church_teams_export.py
@@ -3040,8 +3040,11 @@ class ChurchTeamsExporter: # MODIFIED CLASS NAME
                             try:
                                 if len(str(cell.value)) > max_length:
                                     max_length = len(str(cell.value))/2 # Divide by 2 for better fit
-                            except:
-                                pass
+                            except (AttributeError, TypeError, ValueError) as e:
+                                # Per-cell and non-fatal: the column just keeps the
+                                # width computed from its other cells. Logged at debug
+                                # so a wide sheet cannot flood the run log.
+                                logger.debug(f"Skipped column-width sizing for cell {cell.coordinate!r}: {e}")
                         
                         # Set width with some padding
                         adjusted_width = min(max_length + 2, 50)  # Max width of 50

--- a/middleware/config.py
+++ b/middleware/config.py
@@ -63,7 +63,10 @@ for directory in [LOG_DIR, DATA_DIR, TEMP_DIR, EXPORT_DIR]:
     try:
         directory.mkdir(parents=True, exist_ok=True)
     except OSError as e:
-        print(f"Failed to create directory {directory}: {e}")
+        # Logging is configured below, so this reaches loguru's default stderr
+        # sink rather than the log file — which is correct here, since LOG_DIR
+        # itself may be the directory that failed to create.
+        logger.error(f"Failed to create directory {directory}: {e}")
         raise
 
 # Configure logging (file and console)

--- a/middleware/requirements.txt
+++ b/middleware/requirements.txt
@@ -11,7 +11,6 @@ tqdm>=4.64.1
 schedule>=1.1.0
 tenacity>=8.1.0
 pytz>=2022.5
-uuid>=1.30
 
 # Scheduling / optimization
 ortools>=9.8


### PR DESCRIPTION
Ships the v1.12.x patch proposed in `docs/ARCHITECTURE_REVIEW_2026.md` §4 step 2 — scheduled for the week after the event, never ran.

Closes #374. Advances #377 (two of three items; see below).

## #374 — the broken `uuid` pin

`middleware/requirements.txt:14` pinned `uuid>=1.30`, a 2006-era PyPI package that shadows the standard-library `uuid` module and fails to build on Python 3. Removed. No source change needed alongside it — the code imports the stdlib module.

Verified both directions rather than taking the review's word for it:

- `pip install -r requirements.txt` on a clean environment now **succeeds** (exit 0).
- `pip install "uuid>=1.30"` on its own still **fails**, confirming the diagnosis:
  ```
  AttributeError: install_layout. Did you mean: 'install_platlib'?
  ERROR: Failed building wheel for uuid
  ```

Impact worth naming: this aborted `pip install -r requirements.txt` *entirely*, so the documented setup path in `docs/INSTALLATION.md` did not work on a fresh or rebuilt machine. Already-provisioned operator virtualenvs were unaffected, which is why it survived a full season unnoticed.

## #377 — §2.4 code smells (2 of 3)

**`church_teams_export.py`** — column-width sizing caught everything with a bare `except: pass`. Narrowed to `(AttributeError, TypeError, ValueError)` and logged at **debug**, not warning: this runs per cell, so warning level would flood the log on a wide sheet. The column still falls back to the width computed from its other cells — no behavior change, the failure is just no longer invisible.

**`config.py`** — the directory-creation failure handler used `print()`. Now `logger.error()`. Noted in a comment that this resolves to loguru's default stderr sink rather than the log file, since logging is configured further down and `LOG_DIR` may be the very directory that failed to create. That's the correct outcome here, but it's the kind of thing worth being explicit about rather than leaving a reader to assume it lands in the log.

## What I deliberately left out

The third §2.4 item — the hardcoded `G:\Shared drives\...` default export path at `config.py:39` — is **not** in this PR.

Two reasons. First, `.env.template` already documents `EXPORT_DIR` (lines 23–26), so the review's stated ask ("the default should live in `.env.template`, not code") is already half-satisfied. Second, and the blocking one: `os.getenv("EXPORT_DIR")` returns `""` for a template-default blank value, which is falsy, so the code falls through to the hardcoded path. Deleting that default would **silently relocate report output** on any operator machine whose `.env` leaves `EXPORT_DIR` empty — reports would land somewhere new with no error.

That is an operational decision (fail loud on unset? neutral local default? require it in `Config.validate()`?), not a micro-fix, and it does not belong in a patch whose whole purpose is to be boring. #377 stays open to carry it.

## Verification

- **922 tests pass** in mock mode (`pytest tests/ -q`, 94s).
- Clean `pip install -r requirements.txt` succeeds.
- No PHP touched, so the plugin lint is not implicated.

One note on the test environment: the sandbox had a pre-existing broken system `cryptography` (missing `_cffi_backend`, unrelated to these changes) that blocked collection entirely. Repaired by installing `cffi` before running. Nothing in this diff caused or addresses it, but worth knowing if CI shows the same panic.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LAfWWJZNfgXRPKicrzHQWS

---
_Generated by [Claude Code](https://claude.ai/code/session_01LAfWWJZNfgXRPKicrzHQWS)_